### PR TITLE
bugfix: typo positoin -> position in state.py

### DIFF
--- a/src/curobo/types/state.py
+++ b/src/curobo/types/state.py
@@ -182,7 +182,7 @@ class JointState(State):
         if velocity is None:
             velocity = self.position * 0.0
         if acceleration is None:
-            acceleration = self.positoin * 0.0
+            acceleration = self.position * 0.0
         if jerk is None:
             jerk = self.position * 0.0
         state_tensor = torch.cat((self.position, velocity, acceleration, jerk), dim=-1)


### PR DESCRIPTION
Fix a typo in state.py

This fixes the error:
```
 File "/pkgs/curobo/src/curobo/types/state.py", line 185, in get_state_tensor
    acceleration = self.positoin * 0.0
AttributeError: 'JointState' object has no attribute 'positoin'. Did you mean: 'position'?
```