### PR TITLE
Resolve time optimization issues

### DIFF
--- a/src/curobo/util/trajectory.py
+++ b/src/curobo/util/trajectory.py
@@ -448,7 +448,7 @@ def calculate_dt_fixed(
     max_acc: torch.Tensor,
     max_jerk: torch.Tensor,
     raw_dt: torch.Tensor,
-    interpolation_dt: float,
+    min_dt: float,
 ):
     # compute scaled dt:
     max_v_arr = torch.max(torch.abs(vel), dim=-2)[0]  # output is batch, dof
@@ -465,7 +465,7 @@ def calculate_dt_fixed(
     dt_score_jerk = raw_dt * torch.pow((torch.max(jerk_scale_dt, dim=-1)[0]), 1 / 3)
     dt_score = torch.maximum(dt_score_vel, dt_score_acc)
     dt_score = torch.maximum(dt_score, dt_score_jerk)
-    dt_score = torch.clamp(dt_score, interpolation_dt, raw_dt)
+    dt_score = torch.clamp(dt_score, min_dt, raw_dt)
     # NOTE: this dt score is not dt, rather a scaling to convert velocity, acc, jerk that was
     # computed with raw_dt to a new dt
     return dt_score
@@ -480,7 +480,7 @@ def calculate_dt(
     max_acc: torch.Tensor,
     max_jerk: torch.Tensor,
     raw_dt: float,
-    interpolation_dt: float,
+    min_dt: float,
 ):
     # compute scaled dt:
     max_v_arr = torch.max(torch.abs(vel), dim=-2)[0]  # output is batch, dof
@@ -497,7 +497,7 @@ def calculate_dt(
     dt_score_jerk = raw_dt * torch.pow((torch.max(jerk_scale_dt, dim=-1)[0]), 1 / 3)
     dt_score = torch.maximum(dt_score_vel, dt_score_acc)
     dt_score = torch.maximum(dt_score, dt_score_jerk)
-    dt_score = torch.clamp(dt_score, interpolation_dt, raw_dt)
+    dt_score = torch.clamp(dt_score, min_dt, raw_dt)
     # NOTE: this dt score is not dt, rather a scaling to convert velocity, acc, jerk that was
     # computed with raw_dt to a new dt
     return dt_score
@@ -546,7 +546,7 @@ def calculate_tsteps(
 ):
     # compute scaled dt:
     opt_dt = calculate_dt_fixed(
-        vel, acc, jerk, max_vel, max_acc, max_jerk, raw_dt, interpolation_dt
+        vel, acc, jerk, max_vel, max_acc, max_jerk, raw_dt, min_dt
     )
     if not optimize_dt:
         opt_dt[:] = raw_dt

--- a/src/curobo/wrap/reacher/evaluator.py
+++ b/src/curobo/wrap/reacher/evaluator.py
@@ -169,6 +169,7 @@ def compute_smoothness(
     traj_dt: torch.Tensor,
     min_dt: float,
     max_dt: float,
+    epsilon: float = 1e-6,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """JIT compatible function to compute smoothness.
 
@@ -185,6 +186,7 @@ def compute_smoothness(
         traj_dt: dt of trajectory tensor of shape (batch, horizon) or (1, horizon)
         min_dt: minimum delta time allowed between steps/waypoints in a trajectory.
         max_dt: maximum delta time allowed between steps/waypoints in a trajectory.
+        epsilon: relaxes evaluation of velocity, acceleration and jerk limits to allow for numerical errors.
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: success label tensor of shape (batch) and
@@ -211,7 +213,7 @@ def compute_smoothness(
 
     # clamp dt score:
 
-    dt_score = torch.clamp(dt_score, min_dt, max_dt)
+    dt_score = torch.clamp(dt_score * (1 + epsilon), min_dt, max_dt)
     scale_dt = (1 / dt_score).view(-1, 1, 1)
     abs_acc = torch.abs(acc) * (scale_dt**2)
     # mean_acc_val = torch.max(torch.mean(abs_acc, dim=-1), dim=-1)[0]


### PR DESCRIPTION
- Decouples interpolation dt from the minimum dt in retiming operation which are independent
- Resolves issue where trajectory evaluation will fail after retiming operation
- Resolves issues where the solver dt will not be restored to its original value
- Resolves minor bug where the multiplication with finetune_dt_scale was missing

Possibly resolves issues mentioned in #210 