### PR TITLE
Update link_poses type hint to Optional[Dict[str, Pose]]

### DIFF
--- a/src/curobo/cuda_robot_model/cuda_robot_model.py
+++ b/src/curobo/cuda_robot_model/cuda_robot_model.py
@@ -186,7 +186,7 @@ class CudaRobotModelState:
         return self.link_spheres_tensor
 
     @property
-    def link_pose(self) -> Dict[str, Pose]:
+    def link_pose(self) -> Optional[Dict[str, Pose]]:
         """Get link poses as a dictionary of link name to Pose object."""
         link_poses = None
         if self.link_names is not None:

--- a/src/curobo/wrap/reacher/motion_gen.py
+++ b/src/curobo/wrap/reacher/motion_gen.py
@@ -1430,7 +1430,7 @@ class MotionGen(MotionGenConfig):
         start_state: JointState,
         goal_pose: Pose,
         plan_config: MotionGenPlanConfig = MotionGenPlanConfig(),
-        link_poses: List[Pose] = None,
+        link_poses: Optional[Dict[str, Pose]] = None,
     ) -> MotionGenResult:
         """Plan a single motion to reach a goal pose from a start joint state.
 
@@ -1471,7 +1471,7 @@ class MotionGen(MotionGenConfig):
         start_state: JointState,
         goal_pose: Pose,
         plan_config: MotionGenPlanConfig = MotionGenPlanConfig(),
-        link_poses: List[Pose] = None,
+        link_poses: Optional[Dict[str, Pose]] = None,
     ) -> MotionGenResult:
         """Plan a single motion to reach a goal from set of poses, from a start joint state.
 
@@ -1510,7 +1510,7 @@ class MotionGen(MotionGenConfig):
         start_state: JointState,
         goal_pose: Pose,
         plan_config: MotionGenPlanConfig = MotionGenPlanConfig(),
-        link_poses: Dict[str, List[Pose]] = None,
+        link_poses: Optional[Dict[str, Pose]] = None,
     ) -> MotionGenResult:
         """Plan motions to reach a batch of goal poses from a batch of start joint states.
 
@@ -1544,7 +1544,7 @@ class MotionGen(MotionGenConfig):
         start_state: JointState,
         goal_pose: Pose,
         plan_config: MotionGenPlanConfig = MotionGenPlanConfig(),
-        link_poses: Dict[str, List[Pose]] = None,
+        link_poses: Optional[Dict[str, Pose]] = None,
     ) -> MotionGenResult:
         """Plan motions to reach a batch of poses (goalset) from a batch of start joint states.
 
@@ -1579,7 +1579,7 @@ class MotionGen(MotionGenConfig):
         start_state: JointState,
         goal_pose: Pose,
         plan_config: MotionGenPlanConfig = MotionGenPlanConfig(),
-        link_poses: Dict[str, List[Pose]] = None,
+        link_poses: Optional[Dict[str, Pose]] = None,
     ) -> MotionGenResult:
         """Plan motions to reach (batch) poses in different collision environments.
 
@@ -1625,7 +1625,7 @@ class MotionGen(MotionGenConfig):
         start_state: JointState,
         goal_pose: Pose,
         plan_config: MotionGenPlanConfig = MotionGenPlanConfig(),
-        link_poses: Dict[str, List[Pose]] = None,
+        link_poses: Optional[Dict[str, Pose]] = None,
     ) -> MotionGenResult:
         """Plan motions to reach (batch) goalset poses in different collision environments.
 
@@ -2738,7 +2738,7 @@ class MotionGen(MotionGenConfig):
         start_state: JointState,
         goal_pose: Pose,
         plan_config: MotionGenPlanConfig = MotionGenPlanConfig(),
-        link_poses: List[Pose] = None,
+        link_poses: Optional[Dict[str, Pose]] = None,
     ):
         """Call many planning attempts for a given reacher solve state.
 

--- a/src/curobo/wrap/reacher/types.py
+++ b/src/curobo/wrap/reacher/types.py
@@ -166,7 +166,7 @@ class ReacherSolveState:
         goal_pose: Pose,
         goal_state: Optional[JointState] = None,
         retract_config: Optional[T_BDOF] = None,
-        link_poses: Optional[List[Pose]] = None,
+        link_poses: Optional[Dict[str, Pose]] = None,
         current_solve_state: Optional[ReacherSolveState] = None,
         current_goal_buffer: Optional[Goal] = None,
         tensor_args: TensorDeviceType = TensorDeviceType(),


### PR DESCRIPTION
* Updates `link_poses` type hint to be more correct. Before there was inconsistency (eg. List[pose], Dict[str, Pose], Dict[str, List[Pose]]), which can be confusing to new users because it wasn't 100% clear that this was the same thing as `CudaRobotModelState.link_pose`. From looking at the code, it is quite clear that these should all be Optional[Dict[str, Pose]]