### PR TITLE
Change from link_pose to link_poses

### DIFF
--- a/examples/isaac_sim/multi_arm_reacher.py
+++ b/examples/isaac_sim/multi_arm_reacher.py
@@ -175,7 +175,7 @@ def main():
 
     kin_state = motion_gen.kinematics.get_state(motion_gen.get_retract_config().view(1, -1))
 
-    link_retract_pose = kin_state.link_pose
+    link_retract_pose = kin_state.link_poses
     t_pos = np.ravel(kin_state.ee_pose.to_list())
     target = cuboid.VisualCuboid(
         "/World/target",

--- a/examples/usd_example.py
+++ b/examples/usd_example.py
@@ -205,7 +205,7 @@ def save_log_motion_gen(robot_file: str = "franka.yml"):
     ]
 
     # exit()
-    link_poses = state.link_pose
+    link_poses = state.link_poses
     # print(link_poses)
     # del link_poses["tool0"]
     # del link_poses["tool1"]

--- a/src/curobo/cuda_robot_model/cuda_robot_model.py
+++ b/src/curobo/cuda_robot_model/cuda_robot_model.py
@@ -186,7 +186,7 @@ class CudaRobotModelState:
         return self.link_spheres_tensor
 
     @property
-    def link_pose(self) -> Dict[str, Pose]:
+    def link_poses(self) -> Dict[str, Pose]:
         """Get link poses as a dictionary of link name to Pose object."""
         link_poses = None
         if self.link_names is not None:

--- a/src/curobo/rollout/arm_reacher.py
+++ b/src/curobo/rollout/arm_reacher.py
@@ -267,7 +267,7 @@ class ArmReacher(ArmBase, ArmReacherConfig):
                 cost_list.append(goal_cost)
         with profiler.record_function("cost/link_poses"):
             if self._goal_buffer.links_goal_pose is not None and self.cost_cfg.pose_cfg is not None:
-                link_poses = state.link_pose
+                link_poses = state.link_poses
 
                 for k in self._goal_buffer.links_goal_pose.keys():
                     if k != self.kinematics.ee_link:
@@ -359,7 +359,7 @@ class ArmReacher(ArmBase, ArmReacherConfig):
             pose_error = [out_metrics.pose_error]
             position_error = [out_metrics.position_error]
             quat_error = [out_metrics.rotation_error]
-            link_poses = state.link_pose
+            link_poses = state.link_poses
 
             for k in self._goal_buffer.links_goal_pose.keys():
                 if k != self.kinematics.ee_link:

--- a/src/curobo/rollout/dynamics_model/kinematic_model.py
+++ b/src/curobo/rollout/dynamics_model/kinematic_model.py
@@ -108,7 +108,7 @@ class KinematicModelState(Sequence):
         return Pose(self.ee_pos_seq, self.ee_quat_seq, normalize_rotation=False)
 
     @property
-    def link_pose(self):
+    def link_poses(self):
         if self.link_names is not None:
             link_pos_seq = self.link_pos_seq.contiguous()
             link_quat_seq = self.link_quat_seq.contiguous()

--- a/src/curobo/wrap/reacher/motion_gen.py
+++ b/src/curobo/wrap/reacher/motion_gen.py
@@ -1803,7 +1803,7 @@ class MotionGen(MotionGenConfig):
                 joint_names=self.rollout_fn.joint_names,
             )
             state = self.rollout_fn.compute_kinematics(start_state)
-            link_poses = state.link_pose
+            link_poses = state.link_poses
 
             if n_goalset == -1:
                 retract_pose = Pose(state.ee_pos_seq, quaternion=state.ee_quat_seq)
@@ -1867,7 +1867,7 @@ class MotionGen(MotionGenConfig):
                 joint_names=self.rollout_fn.joint_names,
             ).repeat_seeds(batch)
             state = self.rollout_fn.compute_kinematics(start_state)
-            link_poses = state.link_pose
+            link_poses = state.link_poses
 
             if n_goalset == -1:
                 retract_pose = Pose(state.ee_pos_seq, quaternion=state.ee_quat_seq)

--- a/tests/multi_pose_test.py
+++ b/tests/multi_pose_test.py
@@ -53,7 +53,7 @@ def test_multi_pose_franka(b_size: int):
 
     q_sample = ik_solver.sample_configs(b_size)
     kin_state = ik_solver.fk(q_sample)
-    link_poses = kin_state.link_pose
+    link_poses = kin_state.link_poses
     goal = Pose(kin_state.ee_position, kin_state.ee_quaternion)
     result = ik_solver.solve_batch(goal, link_poses=link_poses)
 
@@ -91,7 +91,7 @@ def test_multi_pose_hand(b_size: int):
 
     q_sample = ik_solver.sample_configs(b_size)
     kin_state = ik_solver.fk(q_sample)
-    link_poses = kin_state.link_pose
+    link_poses = kin_state.link_poses
     goal = Pose(kin_state.ee_position, kin_state.ee_quaternion).clone()
     result = ik_solver.solve_batch(goal, link_poses=link_poses)
 

--- a/tests/usd_export_test.py
+++ b/tests/usd_export_test.py
@@ -56,7 +56,7 @@ def test_write_motion_gen_log(robot_file: str = "franka.yml"):
         JointState.from_position(retract_cfg.view(1, -1))
     )
 
-    link_poses = state.link_pose
+    link_poses = state.link_poses
 
     retract_pose = Pose(state.ee_pos_seq.squeeze(), quaternion=state.ee_quat_seq.squeeze())
     start_state = JointState.from_position(retract_cfg.view(1, -1).clone() + 0.5)


### PR DESCRIPTION
I believe `link_poses` is always a `Optional[Dict[str, Pose]]`. Although Pose could technically be 1 or N poses, a dict of these should probably always be plural. This name change reduces confusion about `link_pose` and `link_poses` appearing to be different

This happens often, but isn't super clear to new users.
```
    link_poses = state.link_pose
```

However, this is a breaking change, so might not be worth the switch