### PR TITLE
Update example code comment on the timestep dt used in get_interpolated_plan()

### DIFF
--- a/examples/motion_gen_example.py
+++ b/examples/motion_gen_example.py
@@ -134,7 +134,7 @@ def demo_motion_gen_simple():
     )
 
     result = motion_gen.plan_single(start_state, goal_pose, MotionGenPlanConfig(max_attempts=1))
-    traj = result.get_interpolated_plan()  # result.optimized_dt has the dt between timesteps
+    traj = result.get_interpolated_plan()  # result.interpolation_dt has the dt between timesteps
     print("Trajectory Generated: ", result.success)
 
 


### PR DESCRIPTION
Update the comment in the example code in:
https://curobo.org/get_started/2a_python_examples.html#motion-generation

And clarified in this discussion:
https://github.com/NVlabs/curobo/discussions/210