### PR TITLE
Default to the previous version of L2 dist calculation

### DIFF
--- a/src/curobo/content/configs/task/base_cfg.yml
+++ b/src/curobo/content/configs/task/base_cfg.yml
@@ -62,10 +62,10 @@ convergence:
     weight: 1.0
     terminal: True
     run_weight: 0.0
-    use_l2_kernel: True
+    use_l2_kernel: False
   null_space_cfg:
     weight: 0.001
     terminal: True
     run_weight: 1.0
-    use_l2_kernel: True
+    use_l2_kernel: False
 

--- a/src/curobo/content/configs/task/gradient_ik.yml
+++ b/src/curobo/content/configs/task/gradient_ik.yml
@@ -48,7 +48,7 @@ cost:
     weight: 5000.0
     activation_distance: [0.001]
     null_space_weight: [0.001]
-    use_l2_kernel: True
+    use_l2_kernel: False
 
   primitive_collision_cfg:
     weight: 5000.0

--- a/src/curobo/rollout/cost/dist_cost.py
+++ b/src/curobo/rollout/cost/dist_cost.py
@@ -38,7 +38,7 @@ class DistType(Enum):
 class DistCostConfig(CostConfig):
     dist_type: DistType = DistType.L2
     use_null_space: bool = False
-    use_l2_kernel: bool = True
+    use_l2_kernel: bool = False
 
     def __post_init__(self):
         return super().__post_init__()


### PR DESCRIPTION
Fixes #295 

The issue popped up for me on a bare metal Ubuntu22 install when I ran `omni_python examples/isaac_sim/motion_gen_reacher.py`.