### PR TITLE
Fix backward in SelfCollisionDistance

### DIFF
--- a/src/curobo/curobolib/geom.py
+++ b/src/curobo/curobolib/geom.py
@@ -123,7 +123,7 @@ class SelfCollisionDistance(torch.autograd.Function):
         if ctx.needs_input_grad[3]:
             (g_vec,) = ctx.saved_tensors
             if ctx.return_loss:
-                g_vec = g_vec * grad_out_distance.unsqueeze(1)
+                g_vec = g_vec * grad_out_distance.view(*g_vec.shape[:2], 1, 1)
             sphere_grad = g_vec
         return None, None, None, sphere_grad, None, None, None, None, None, None, None, None
 


### PR DESCRIPTION
Currently, the unsqueeze is missing an additional dimension in the backward pass.

```
  File "/home/willshen/workspace/curobo/src/curobo/curobolib/geom.py", line 134, in backward
    g_vec = g_vec * grad_out_distance.unsqueeze(1)
RuntimeError: The size of tensor a (4) must match the size of tensor b (512) at non-singleton dimension 1
```

For example:

- `grad_out_distance` has shape `(n, 4)`
- `g_vec` has shape `(n, 4, num_spheres, 4)`

All the unit tests still pass with this change:

```
❯ pwd
/home/willshen/workspace/curobo
❯ python3 -m pytest .
...
================== 259 passed, 11 skipped, 3 warnings in 217.06s (0:03:37) ===================
```