### PR TITLE
Defer torch import in setup.py for PEP 517 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,72 +22,97 @@ import sys
 
 # Third Party
 import setuptools
-from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
-extra_cuda_args = {
-    "nvcc": [
-        "--threads=8",
-        "-O3",
-        "--ftz=true",
-        "--fmad=true",
-        "--prec-div=false",
-        "--prec-sqrt=false",
+
+def _ext_modules():
+    """Lazily construct extension modules only when actually building.
+
+    Returns empty list during metadata-only builds (e.g., uv lock)
+    to avoid requiring torch at metadata generation time.
+    """
+    try:
+        from torch.utils.cpp_extension import CUDAExtension  # lazy import
+    except Exception:
+        # During metadata-only builds (uv lock / pip prepare_metadata), Torch isn't available.
+        # Return no extensions so metadata can be generated without compiling.
+        return []
+
+    extra_cuda_args = {
+        "nvcc": [
+            "--threads=8",
+            "-O3",
+            "--ftz=true",
+            "--fmad=true",
+            "--prec-div=false",
+            "--prec-sqrt=false",
+        ]
+    }
+
+    if sys.platform == "win32":
+        extra_cuda_args["nvcc"].append("--allow-unsupported-compiler")
+
+    return [
+        CUDAExtension(
+            "curobo.curobolib.lbfgs_step_cu",
+            [
+                "src/curobo/curobolib/cpp/lbfgs_step_cuda.cpp",
+                "src/curobo/curobolib/cpp/lbfgs_step_kernel.cu",
+            ],
+            extra_compile_args=extra_cuda_args,
+        ),
+        CUDAExtension(
+            "curobo.curobolib.kinematics_fused_cu",
+            [
+                "src/curobo/curobolib/cpp/kinematics_fused_cuda.cpp",
+                "src/curobo/curobolib/cpp/kinematics_fused_kernel.cu",
+            ],
+            extra_compile_args=extra_cuda_args,
+        ),
+        CUDAExtension(
+            "curobo.curobolib.line_search_cu",
+            [
+                "src/curobo/curobolib/cpp/line_search_cuda.cpp",
+                "src/curobo/curobolib/cpp/line_search_kernel.cu",
+                "src/curobo/curobolib/cpp/update_best_kernel.cu",
+            ],
+            extra_compile_args=extra_cuda_args,
+        ),
+        CUDAExtension(
+            "curobo.curobolib.tensor_step_cu",
+            [
+                "src/curobo/curobolib/cpp/tensor_step_cuda.cpp",
+                "src/curobo/curobolib/cpp/tensor_step_kernel.cu",
+            ],
+            extra_compile_args=extra_cuda_args,
+        ),
+        CUDAExtension(
+            "curobo.curobolib.geom_cu",
+            [
+                "src/curobo/curobolib/cpp/geom_cuda.cpp",
+                "src/curobo/curobolib/cpp/sphere_obb_kernel.cu",
+                "src/curobo/curobolib/cpp/pose_distance_kernel.cu",
+                "src/curobo/curobolib/cpp/self_collision_kernel.cu",
+            ],
+            extra_compile_args=extra_cuda_args,
+        ),
     ]
-}
 
-if sys.platform == "win32":
-    extra_cuda_args["nvcc"].append("--allow-unsupported-compiler")
 
-# create a list of modules to be compiled:
-ext_modules = [
-    CUDAExtension(
-        "curobo.curobolib.lbfgs_step_cu",
-        [
-            "src/curobo/curobolib/cpp/lbfgs_step_cuda.cpp",
-            "src/curobo/curobolib/cpp/lbfgs_step_kernel.cu",
-        ],
-        extra_compile_args=extra_cuda_args,
-    ),
-    CUDAExtension(
-        "curobo.curobolib.kinematics_fused_cu",
-        [
-            "src/curobo/curobolib/cpp/kinematics_fused_cuda.cpp",
-            "src/curobo/curobolib/cpp/kinematics_fused_kernel.cu",
-        ],
-        extra_compile_args=extra_cuda_args,
-    ),
-    CUDAExtension(
-        "curobo.curobolib.line_search_cu",
-        [
-            "src/curobo/curobolib/cpp/line_search_cuda.cpp",
-            "src/curobo/curobolib/cpp/line_search_kernel.cu",
-            "src/curobo/curobolib/cpp/update_best_kernel.cu",
-        ],
-        extra_compile_args=extra_cuda_args,
-    ),
-    CUDAExtension(
-        "curobo.curobolib.tensor_step_cu",
-        [
-            "src/curobo/curobolib/cpp/tensor_step_cuda.cpp",
-            "src/curobo/curobolib/cpp/tensor_step_kernel.cu",
-        ],
-        extra_compile_args=extra_cuda_args,
-    ),
-    CUDAExtension(
-        "curobo.curobolib.geom_cu",
-        [
-            "src/curobo/curobolib/cpp/geom_cuda.cpp",
-            "src/curobo/curobolib/cpp/sphere_obb_kernel.cu",
-            "src/curobo/curobolib/cpp/pose_distance_kernel.cu",
-            "src/curobo/curobolib/cpp/self_collision_kernel.cu",
-        ],
-        extra_compile_args=extra_cuda_args,
-    ),
-]
+def _cmdclass():
+    """Lazily construct cmdclass only when torch is available.
+
+    Returns empty dict during metadata-only builds to avoid requiring torch.
+    """
+    try:
+        from torch.utils.cpp_extension import BuildExtension  # lazy import
+    except Exception:
+        # No torch during metadata build: don't register a cmdclass
+        return {}
+    return {"build_ext": BuildExtension}
 
 setuptools.setup(
-    ext_modules=ext_modules,
-    cmdclass={"build_ext": BuildExtension},
+    ext_modules=_ext_modules(),
+    cmdclass=_cmdclass(),
     package_data={"": ["*.so"]},
     include_package_data=True,
 )


### PR DESCRIPTION
## Problem

The current setup.py imports torch.utils.cpp_extension at the top level, which causes ModuleNotFoundError during metadata-only builds. This breaks compatibility with modern packaging tools like uv, pip-tools, poetry, etc that need to resolve dependencies without actually building the package.

This means you can't use cuRobo in projects with locked dependencies or run things like `uv lock` without torch already installed.

## Solution

Moved the torch imports into lazy helper functions that only import when actually building extensions. During metadata generation these return empty lists/dicts so the import never happens.

## What this enables

- Can now run `uv lock` to generate lock files without torch installed
- Faster dependency resolution (no need to download torch just to check what deps are needed)
- Can integrate cuRobo into pyproject.toml-based projects with proper dependency locking
- Still fully backward compatible with existing install workflows

## Example usage with uv

You can now add cuRobo to your pyproject.toml like this:

```toml
[project]
dependencies = [
    "nvidia-curobo",
]

[tool.uv.sources]
nvidia-curobo = { git = "https://github.com/NVlabs/curobo", rev = "ebb71702f3f70e767f40fd8e050674af0288abe8" }

[tool.uv]
no-build-isolation-package = ["nvidia-curobo"]
```

Then `uv lock` will work without needing torch installed during the lock process.

## Technical details

The change wraps the extension module and cmdclass definitions in functions:

```python
def _ext_modules():
    try:
        from torch.utils.cpp_extension import CUDAExtension
    except Exception:
        return []  # metadata-only build
    # ... return actual extensions
```

When torch is available (normal installs), everything works exactly as before. When it's not (metadata builds), empty values are returned and no compilation is attempted.

All existing functionality preserved - same CUDA flags, same Windows support, same extension modules.