### PR TITLE
fix: correct iterator variable shadowing in multi_arm_reacher causing TypeError on pause/stop

### DIFF
--- a/examples/isaac_sim/multi_arm_reacher.py
+++ b/examples/isaac_sim/multi_arm_reacher.py
@@ -308,9 +308,9 @@ def main():
             )
             # add link poses:
             link_poses = {}
-            for i in target_links.keys():
-                c_p, c_rot = target_links[i].get_world_pose()
-                link_poses[i] = Pose(
+            for k in target_links.keys():
+                c_p, c_rot = target_links[k].get_world_pose()
+                link_poses[k] = Pose(
                     position=tensor_args.to_device(c_p),
                     quaternion=tensor_args.to_device(c_rot),
                 )


### PR DESCRIPTION
### Summary
This PR fixes a crash in the multi_arm_reacher example when pressing "Pause" or "Stop" after the robot begins moving.

Fixes #372

### Environment
- cuRobo installation mode: isaac sim
- Python: native 3.10 (bundled with Isaac Sim 4.1.0)
- Isaac Sim: 4.1.0

### Steps to Reproduce
1. Launch multi_arm_reacher example
2. Press Play
3. Move the red cube so the arms start moving
4. Press Pause or Stop
5. Crash occurs with:

    TypeError: not all arguments converted during string formatting

### Cause
The example uses an out-of-scope iterator variable `i`, which leads to incorrect formatting behavior inside a conditional.

### Fix
Replaced the incorrect iterator name with a scoped variable (`k`) inside the loop:

```python
for k in target_links.keys():
    c_p, c_rot = target_links[k].get_world_pose()
    link_poses[k] = Pose(
        position=tensor_args.to_device(c_p),
        quaternion=tensor_args.to_device(c_rot),
    )
