### PR TITLE
Fix particle IK V2 cost config

### DIFF
--- a/curobo/content/configs/task/ik/particle_ik.yml
+++ b/curobo/content/configs/task/ik/particle_ik.yml
@@ -2,7 +2,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 rollout:
   cost_cfg:
-    bound_cfg:
+    cspace_cfg:
       activation_distance:
       - 0.001
       - 0.001
@@ -10,9 +10,9 @@ rollout:
       weight:
       - 50.0
       - 1.0
-      cost_type: TELEPORT
+      cost_type: POSITION
 
-    multi_link_pose_cfg:
+    tool_pose_cfg:
       _project_distance_to_goal: false
       weight:
         - 1000.0


### PR DESCRIPTION
## Summary

Fix `particle_ik.yml` so its IK objective terms use the V2 `RobotCostManagerCfg` cost key names:

- `bound_cfg` -> `cspace_cfg`
- `multi_link_pose_cfg` -> `tool_pose_cfg`
- `cost_type: TELEPORT` -> `cost_type: POSITION`

## Root Cause

The V2 `RobotCostManagerCfg.create()` factory only registers these cost config keys:

- `self_collision_cfg`
- `cspace_cfg`
- `scene_collision_cfg`
- `start_cspace_dist_cfg`
- `target_cspace_dist_cfg`
- `tool_pose_cfg`

Because `particle_ik.yml` still used the older `bound_cfg` and `multi_link_pose_cfg` names, those entries were ignored when constructing the robot cost manager. That means the intended IK objective terms were not registered as V2 cost components, while the constraint block still loaded separately.

The old `cost_type: TELEPORT` value also does not exist in the V2 `CSpaceCostType`, which currently defines `POSITION` and `STATE`.

## Validation

- Checked that no remaining `bound_cfg`, `multi_link_pose_cfg`, or `cost_type: TELEPORT` entries exist under `curobo/`.
- Parsed `curobo/content/configs/task/ik/particle_ik.yml` and asserted the V2 keys are present and the old keys are absent.
- Validated in internal IK use cases with the patched `particle_ik.yml` config loaded through `InverseKinematicsCfg.create()`:

```python
ik_config = InverseKinematicsCfg.create(
    robot=self._robot_cfg_dict,
    optimizer_configs=[self._PARTICLE_IK_CFG, "ik/lbfgs_ik.yml"],
    scene_model=None,
    num_seeds=200,
    position_tolerance=0.005,
    orientation_tolerance=0.05,
    self_collision_check=False,
    use_cuda_graph=False,
    max_batch_size=32,
)
```
