### PR TITLE
Fix reachability example IK batch size

### DIFF
--- a/curobo/examples/getting_started/inverse_kinematics.py
+++ b/curobo/examples/getting_started/inverse_kinematics.py
@@ -575,6 +575,7 @@ def reachability_example(robot_file="franka.yml", port=8080):
     BATCH_TARGET = 500
     n_per_axis = int(BATCH_TARGET ** 0.5)
     actual_batch = n_per_axis * n_per_axis
+    total_batch = actual_batch + 1
 
     viser_viz = ViserVisualizer(
         content_path=ContentPath(robot_config_file=robot_file),
@@ -591,6 +592,7 @@ def reachability_example(robot_file="franka.yml", port=8080):
         #num_seeds=12,
         self_collision_check=True,
         scene_model="collision_test.yml",
+        max_batch_size=total_batch,
         #seed_solver_num_seeds=12,
     )
     scene_cfg = config.scene_collision_cfg.scene_model
@@ -721,8 +723,6 @@ def reachability_example(robot_file="franka.yml", port=8080):
             dim=-1,
         )
         grid_world_pts = (pose_t @ local_pts.T).T[:, :3]
-
-        total_batch = actual_batch + 1
 
         primary_pos_np, primary_quat_np = cur_tool_poses[primary_link]
         primary_quat = torch.tensor(


### PR DESCRIPTION
## Summary

- configure the reachability IK example with `max_batch_size` equal to the submitted pose batch
- keep the batch size calculation next to the fixed grid dimensions so the solver config matches the generated query count

## Root cause

The reachability viewer submits all grid poses plus the gizmo pose in one `solve_pose` call. With the default IK config, `max_batch_size` stayed at `1`, so launching:

```bash
/isaac-sim/kit/python/bin/python3 -m curobo.examples.getting_started.inverse_kinematics --reachability --port 8081
```

failed with:

```text
ValueError: solve_pose: goal_tool_poses.batch_size=485 exceeds config.max_batch_size=1.
```

## Testing

Validated by launching the reachability viewer with:

```bash
/isaac-sim/kit/python/bin/python3 -m curobo.examples.getting_started.inverse_kinematics --reachability --port 8081
```

The viewer starts successfully and evaluates the 22x22 grid plus gizmo pose without the previous `max_batch_size=1` error.
