### PR TITLE
Fix/robot config loading

### DIFF
--- a/curobo/_src/types/robot.py
+++ b/curobo/_src/types/robot.py
@@ -81,13 +81,12 @@ class RobotCfg:
             data_dict_in = data_dict_in["robot_cfg"]
         data_dict = deepcopy(data_dict_in)
         if isinstance(data_dict["kinematics"], dict):
+            kinematics_dict = data_dict["kinematics"]
+            kinematics_dict["device_cfg"] = device_cfg
+            kinematics_dict["load_collision_spheres"] = load_collision_spheres
+            kinematics_dict["num_envs"] = num_envs
             data_dict["kinematics"] = KinematicsCfg.from_config(
-                KinematicsLoaderCfg(
-                    **data_dict_in["kinematics"],
-                    device_cfg=device_cfg,
-                    load_collision_spheres=load_collision_spheres,
-                    num_envs=num_envs,
-                )
+                KinematicsLoaderCfg(**kinematics_dict)
             )
 
         load_dynamics = data_dict.pop("load_dynamics", False)

--- a/curobo/tests/_src/types/test_robot_config.py
+++ b/curobo/tests/_src/types/test_robot_config.py
@@ -5,6 +5,7 @@
 """Unit tests for robot configuration types."""
 
 # Standard Library
+from copy import deepcopy
 
 # Third Party
 import pytest
@@ -127,6 +128,25 @@ class TestRobotCfg:
 
         assert robot_cfg is not None
         assert robot_cfg.kinematics is not None
+
+    def test_robot_cfg_create_allows_loader_keys_in_yaml(self, robot_yaml_data):
+        """Robot YAML may include fields that RobotCfg.create also forwards."""
+        device_cfg = DeviceCfg()
+        data = deepcopy(robot_yaml_data)
+        data["robot_cfg"]["kinematics"]["device_cfg"] = DeviceCfg()
+        data["robot_cfg"]["kinematics"]["load_collision_spheres"] = False
+        data["robot_cfg"]["kinematics"]["num_envs"] = 8
+
+        robot_cfg = RobotCfg.create(
+            data,
+            device_cfg=device_cfg,
+            load_collision_spheres=True,
+            num_envs=2,
+        )
+
+        assert robot_cfg is not None
+        assert robot_cfg.kinematics.kinematics_config.num_envs == 2
+        assert robot_cfg.kinematics.kinematics_config.link_spheres.shape[0] == 2
 
     def test_robot_cfg_create_with_dynamics(self, robot_yaml_data):
         """Test RobotCfg.create with load_dynamics flag."""


### PR DESCRIPTION
## Summary

Fix duplicate keyword argument failures when `RobotCfg.create()` receives a robot config whose `kinematics` dict already contains loader-level fields.

`RobotCfg.create()` was expanding the robot YAML kinematics dict and also passing `device_cfg`, `load_collision_spheres`, and `num_envs` explicitly into `KinematicsLoaderCfg`. If those keys were already present in the YAML or an in-memory robot dict, Python raised a duplicate keyword argument `TypeError`.

This changes the factory to merge the factory-controlled values into the copied kinematics dict first, then construct `KinematicsLoaderCfg` once from that dict. The explicit `RobotCfg.create()` arguments still take precedence.

## Testing

- Ran targeted pytest for the new regression test.
- Validated in an application using a robot YAML that includes the affected kinematics fields.