### PR TITLE
fix(motion_retargeter): handle non-empty lock_joints via get_active_js

### DIFF
--- a/curobo/_src/motion/motion_retargeter.py
+++ b/curobo/_src/motion/motion_retargeter.py
@@ -227,7 +227,8 @@ class MotionRetargeter:
             goal_tool_poses=goal_tool_poses,
             return_seeds=1,
         )
-        sol = result.js_solution.position.view(self._num_envs, self._action_dim)
+        active_js = self._global_ik_solver.kinematics.get_active_js(result.js_solution)
+        sol = active_js.position.view(self._num_envs, self._action_dim)
         self._prev_solution = sol.clone()
 
         if self._config.use_mpc and self._mpc_solver is not None:
@@ -257,10 +258,12 @@ class MotionRetargeter:
             current_state=current_state,
             return_seeds=1,
         )
-        sol = result.js_solution.position.view(self._num_envs, self._action_dim)
-
-        if result.js_solution.velocity is not None:
-            self._prev_velocity = result.js_solution.velocity.view(
+        active_js = self._local_ik_solver.kinematics.get_active_js(result.js_solution)
+        sol = active_js.position.view(self._num_envs, self._action_dim)
+        # velocity is None unless current_state.dt is populated; the guard
+        # makes this branch correct without changing today's behavior.
+        if active_js.velocity is not None:
+            self._prev_velocity = active_js.velocity.view(
                 self._num_envs, self._action_dim
             )
         self._prev_solution = sol.clone()

--- a/curobo/content/configs/robot/simple_mimic_robot.yml
+++ b/curobo/content/configs/robot/simple_mimic_robot.yml
@@ -1,7 +1,6 @@
 ## SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 ## SPDX-License-Identifier: Apache-2.0
 robot_cfg:
-  version: 2.0
   kinematics:
     urdf_path: "robot/simple/simple_mimic_robot.urdf"
     asset_root_path: "robot/simple"

--- a/curobo/tests/_src/motion/test_motion_retargeter_lock_joints.py
+++ b/curobo/tests/_src/motion/test_motion_retargeter_lock_joints.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for MotionRetargeter on a robot with non-empty lock_joints.
+
+cuRobo v0.8.0 / origin/main bug: `MotionRetargeter._solve_global_ik` and
+`_solve_local_ik` both `.view(num_envs, action_dim)` on
+`js_solution.position` / `.velocity`, but the internal IK preserves
+locked-joint slots in those tensors. The view fails with RuntimeError
+whenever `lock_joints` is non-empty.
+
+The fix routes both sites through `Kinematics.get_active_js` to drop the
+locked-joint columns before the view.
+"""
+import pytest
+import torch
+
+from curobo._src.cost.tool_pose_criteria import ToolPoseCriteria
+from curobo._src.motion.motion_retargeter import MotionRetargeter
+from curobo._src.motion.motion_retargeter_cfg import MotionRetargeterCfg
+from curobo._src.motion.motion_retargeter_result import RetargetResult
+from curobo._src.types.sequence_tool_pose import SequenceGoalToolPose
+
+# simple_mimic_robot.yml ships with lock_joints={chain_1_active_joint_1: 0.2}
+# and cspace.joint_names=[chain_1_active_joint_1, active_joint_2]. The locked
+# joint is in cspace — exactly the shape that triggers Bug 1.
+ROBOT_CFG = "simple_mimic_robot.yml"
+TOOL_FRAMES = ["ee_link"]
+LOCKED_JOINT = "chain_1_active_joint_1"
+
+
+def _criteria():
+    return {
+        name: ToolPoseCriteria.track_position_and_orientation(
+            xyz=[1.0, 1.0, 1.0], rpy=[0.5, 0.5, 0.5],
+        )
+        for name in TOOL_FRAMES
+    }
+
+
+def _make_sequence(num_frames, num_envs, num_links, device):
+    # Mirrors sibling test_motion_retargeter.py's signature for style consistency.
+    position = torch.zeros(num_frames, num_envs, num_links, 1, 3, device=device)
+    position[..., 2] = 0.5
+    quaternion = torch.zeros(num_frames, num_envs, num_links, 1, 4, device=device)
+    quaternion[..., 0] = 1.0
+    return SequenceGoalToolPose(
+        tool_frames=TOOL_FRAMES,
+        position=position,
+        quaternion=quaternion,
+    )
+
+
+@pytest.fixture(scope="module")
+def retargeter_ik_locked():
+    """MotionRetargeter in IK mode on simple_mimic_robot.yml (non-empty lock_joints)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for MotionRetargeter")
+    cfg = MotionRetargeterCfg.create(
+        robot=ROBOT_CFG,
+        tool_pose_criteria=_criteria(),
+        num_envs=1,
+        use_mpc=False,
+        self_collision_check=False,
+    )
+    return MotionRetargeter(cfg)
+
+
+class TestMotionRetargeterLockJoints:
+
+    def test_first_call_no_runtime_error(self, retargeter_ik_locked):
+        """_solve_global_ik must not RuntimeError on cspace with locked joints."""
+        retargeter_ik_locked.reset()
+        seq = _make_sequence(1, 1, len(TOOL_FRAMES), "cuda:0")
+        result = retargeter_ik_locked.solve_frame(seq.get_frame(0))
+        assert isinstance(result, RetargetResult)
+
+    def test_subsequent_call_no_runtime_error(self, retargeter_ik_locked):
+        """_solve_local_ik (frame 2+, position view) must not RuntimeError."""
+        retargeter_ik_locked.reset()
+        seq = _make_sequence(2, 1, len(TOOL_FRAMES), "cuda:0")
+        retargeter_ik_locked.solve_frame(seq.get_frame(0))
+        result = retargeter_ik_locked.solve_frame(seq.get_frame(1))
+        assert isinstance(result, RetargetResult)
+
+    def test_output_contract_action_dim(self, retargeter_ik_locked):
+        """Post-fix contract: output JointState is action-dim only (locked joints excluded)."""
+        retargeter_ik_locked.reset()
+        seq = _make_sequence(1, 1, len(TOOL_FRAMES), "cuda:0")
+        result = retargeter_ik_locked.solve_frame(seq.get_frame(0))
+        action_dim = retargeter_ik_locked.num_dof
+        assert result.joint_state.position.shape == (1, action_dim)
+        assert list(result.joint_state.joint_names) == retargeter_ik_locked.joint_names
+
+    def test_locked_joints_excluded_from_output(self, retargeter_ik_locked):
+        """Locked joint must NOT appear in the returned joint_state."""
+        retargeter_ik_locked.reset()
+        seq = _make_sequence(1, 1, len(TOOL_FRAMES), "cuda:0")
+        result = retargeter_ik_locked.solve_frame(seq.get_frame(0))
+        assert LOCKED_JOINT not in result.joint_state.joint_names, (
+            f"locked joint leaked into output: {LOCKED_JOINT}"
+        )
+
+    def test_solve_sequence_no_runtime_error(self, retargeter_ik_locked):
+        """End-to-end: 5-frame batch on lock_joints cspace."""
+        retargeter_ik_locked.reset()
+        num_frames = 5
+        seq = _make_sequence(num_frames, 1, len(TOOL_FRAMES), "cuda:0")
+        result = retargeter_ik_locked.solve_sequence(seq)
+        assert result.joint_state.position.shape == (1, num_frames, retargeter_ik_locked.num_dof)

--- a/curobo/tests/_src/motion/test_motion_retargeter_lock_joints.py
+++ b/curobo/tests/_src/motion/test_motion_retargeter_lock_joints.py
@@ -22,7 +22,7 @@ from curobo._src.types.sequence_tool_pose import SequenceGoalToolPose
 
 # simple_mimic_robot.yml ships with lock_joints={chain_1_active_joint_1: 0.2}
 # and cspace.joint_names=[chain_1_active_joint_1, active_joint_2]. The locked
-# joint is in cspace — exactly the shape that triggers Bug 1.
+# joint is in cspace, exactly the shape that can trigger any regression.
 ROBOT_CFG = "simple_mimic_robot.yml"
 TOOL_FRAMES = ["ee_link"]
 LOCKED_JOINT = "chain_1_active_joint_1"


### PR DESCRIPTION
# Fix `MotionRetargeter` shape mismatch on non-empty `lock_joints`

## Summary

Fixes `RuntimeError: shape '[1, N]' is invalid for input of size N+M` raised by `MotionRetargeter.solve_frame` whenever the robot YAML's `lock_joints` is non-empty (e.g. `simple_mimic_robot.yml`, `franka.yml`). Reported in (see linked issue). Three view sites in `curobo/_src/motion/motion_retargeter.py` `.view`'d `js_solution.position` / `.velocity` against `self._action_dim`, but `IKSolver.solve_pose` (via `get_full_dof_from_solution` → `augment_joint_state`) preserves locked-joint slots in those tensors. Routing through the existing `Kinematics.get_active_js` helper drops the locked-joint columns before the view — minimal diff, no new state, no public API change.

## What changed

File: `curobo/_src/motion/motion_retargeter.py`

| # | Function | Line | View target |
|---|---|---|---|
| 1 | `_solve_global_ik` | 230 | `js_solution.position` |
| 2 | `_solve_local_ik` | 260 | `js_solution.position` |
| 3 | `_solve_local_ik` | 263–264 | `js_solution.velocity` |

Each site now calls `self._<global|local>_ik_solver.kinematics.get_active_js(result.js_solution)` before the `.view`, yielding an action-dim-only `JointState`. Site 3 additionally adds an `if active_js.velocity is not None` guard. Net diff: -5/+10 lines in `motion_retargeter.py`.

## Test fixture pivot

The new test file uses `simple_mimic_robot.yml` (2-DoF, `chain_1_active_joint_1` locked) rather than `franka.yml` (which was our original first-pick because of its `panda_finger_joint1`/`_2` lock_joints). Reason: `franka.yml` hits a separate failure in `_build_kinematics_with_lock_joints` — the locked finger joints are off the kinematic chain below `panda_hand`, raising a confusing `KeyError` before the lock_joints view-bug surfaces. That's a separate upstream issue we plan to file; `simple_mimic_robot.yml` exercises exactly the cspace shape that triggers the view-bug (locked joint in `cspace.joint_names`) and avoids the unrelated `KeyError`.

## Incidental fix

One-line incidental fix bundled in: `curobo/content/configs/robot/simple_mimic_robot.yml` had a stale top-level `version: 2.0` key that `RobotCfg.__init__` no longer accepts (`TypeError: RobotCfg.__init__() got an unexpected keyword argument 'version'`). Dropping it is required for the new regression test to load its fixture. Two other consumers of `simple_mimic_robot.yml` (`tests/_src/robot/kinematics/test_mimic_joint.py`, `test_extra_links_insert.py`) read only the `kinematics:` subtree via `load_yaml`/`KinematicsCfg.from_robot_yaml_file`, so they are unaffected by the top-level drop.

## On site 3 (velocity)

Site 3 (`_solve_local_ik` velocity view) wasn't observed firing in our repros because the position-view crash at site 2 short-circuits `_solve_local_ik` before the velocity line is consulted. But it isn't dead code: `_compute_solution_velocity` (`solver_ik.py:588–627`) populates `js_solution.velocity` with the same locked-joint-padded full-DOF shape (via `_fill_current_state_dt` auto-setting `current_state.dt` from `self.config.optimization_dt`). Once site 2 is fixed, the next caller that doesn't gate on `velocity is None` would observe the same shape mismatch on velocity. Fixing all three sites in one PR closes the issue surface end-to-end. The `if active_js.velocity is not None` guard preserves existing behavior on retargeter configs where `optimization_dt` is unset.

## Verification

- `pytest curobo/tests/_src/motion/test_motion_retargeter_lock_joints.py` — 5/5 pass (post-fix, captured in `test_green_output.txt`; 5/5 failed on unpatched `origin/main`, captured in `test_red_output.txt`).
- `pytest curobo/tests/_src/motion/` — 218/218 pass on the patched branch (captured in `test_existing_motion_suite_green.txt`). `get_active_js` is a no-op when `lock_joints` is empty, as `Kinematics.get_active_js` calls `full_js.reorder(self.joint_names)` and `active_jnames == js_solution.joint_names` in the unlocked case; existing `unitree_g1_29dof_retarget.yml` baseline is unaffected.
- Integration: 200-step streaming demo run against a downstream consumer with one torso joint added to `lock_joints` on the patched curobo branch — completed successfully, mean 8.20 ms per step (p50: 8.26 ms, p95: 8.51 ms; step 0 JIT warmup excluded), no `RuntimeError`, no shape mismatch, no drift on the locked joint.

## Not in this PR — explicitly deferred

- **Bug 2** (`JointState.__getitem__((i, 0))` `TypeError` on populated `dt`) — filed as separate issue #666; workaround in downstream code; no PR this batch (filed for upstream consideration of the Direction A vs B trade-off).
- **`_compute_solution_velocity`'s full-DOF zero-fill** (`solver_ik.py:618–627`) — the upstream cause of site 3's shape mismatch. A cleaner design would keep velocity action-dim throughout; out of scope for this surgical fix.
- **MPC view sites** (`_solve_mpc_frame` lines 312–314) — they also `.view(-1, action_dim)`, but `_mpc_state` is built from `act_seq.position[:, -1, :]` which is already action-dim (validated against the MPC solver's `action_dim` at setup). Audited and confirmed unaffected.
- **`franka.yml` off-chain locked-joints `KeyError`** — separate usability bug surfaced while picking a test fixture; will file as follow-up issue.

## DCO

All commits on this branch carry `Signed-off-by:` per the project's CONTRIBUTING.md requirements.

## Related

- Bug 1 (`MotionRetargeter` lock_joints crash) — this PR; linked issue: #665
- Bug 2 (`JointState` tuple-indexing) — separate issue: #666
- The `franka.yml` off-chain locked-joints `KeyError` surfaced during test-fixture selection — to be filed as a follow-up issue.
