### PR TITLE
Fix CUDA 13 and pybind backend source build

### DIFF
--- a/curobo/_src/curobolib/backends/__init__.py
+++ b/curobo/_src/curobolib/backends/__init__.py
@@ -45,9 +45,10 @@ def _try_load_cuda_core_backend() -> Optional[dict]:
             "dynamics": cc_dyn,
             "pba": cc_pba,
         }
-    except ImportError as e:
-        # cuda.core not available
-        log_and_raise(f"Error loading cuda.core backend: {e}")
+    except ImportError:
+        # cuda.core not available — return None (soft) so _auto_select_backend can fall back
+        # to the compiled pybind backend. (Was log_and_raise, which raised and broke the
+        # documented cuda.core->pybind fallback whenever cuda.core isn't installed.)
         return None
 
 

--- a/curobo/_src/curobolib/kernels/third_party/helper_math.h
+++ b/curobo/_src/curobolib/kernels/third_party/helper_math.h
@@ -1119,10 +1119,15 @@ inline __host__ __device__ uint4 max(uint4 a, uint4 b)
 // - linear interpolation between a and b, based on value t in [0, 1] range
 ////////////////////////////////////////////////////////////////////////////////
 
+#if !defined(CUDART_VERSION) || (CUDART_VERSION < 13000)
+// CUDA 13.0+ provides a built-in scalar lerp(float,float,float); our own then
+// conflicts. Skip the scalar overload on CUDA>=13 (semantics are identical: a+t*(b-a));
+// the float2/3/4 overloads below are cuRobo-specific and never conflict.
 inline __device__ __host__ float lerp(float a, float b, float t)
 {
     return a + t*(b-a);
 }
+#endif
 inline __device__ __host__ float2 lerp(float2 a, float2 b, float t)
 {
     return a + t*(b-a);

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,13 @@ if USE_PYBIND:
         if sys.platform == "win32":
             extra_cuda_args["nvcc"].append("--allow-unsupported-compiler")
 
+        # Kernel headers live in nested subdirs (e.g. optimization/lbfgs/) but the .cu
+        # files #include them by bare filename, so every subdir must be on the include path.
+        _kernels_root = source_dir / "curobo/_src/curobolib/kernels"
+        kernel_include_dirs = [str(_kernels_root)] + [
+            str(p) for p in _kernels_root.rglob("*") if p.is_dir()
+        ]
+
         # Create a list of modules to be compiled
         ext_modules = [
             CUDAExtension(
@@ -54,7 +61,7 @@ if USE_PYBIND:
                     "curobo/_src/curobolib/backends/pybind/kinematics_forward_kernel_launch.cu",
                     "curobo/_src/curobolib/backends/pybind/kinematics_backward_kernel_launch.cu",
                 ],
-                include_dirs=[str(source_dir / "curobo/_src/curobolib/kernels")],
+                include_dirs=kernel_include_dirs,
                 extra_compile_args=extra_cuda_args,
             ),
             CUDAExtension(
@@ -64,7 +71,7 @@ if USE_PYBIND:
                     "curobo/_src/curobolib/backends/pybind/line_search_kernel_launch.cu",
                     "curobo/_src/curobolib/backends/pybind/lbfgs_step_kernel_launch.cu",
                 ],
-                include_dirs=[str(source_dir / "curobo/_src/curobolib/kernels")],
+                include_dirs=kernel_include_dirs,
                 extra_compile_args=extra_cuda_args,
             ),
             CUDAExtension(
@@ -73,18 +80,16 @@ if USE_PYBIND:
                     "curobo/_src/curobolib/backends/pybind/trajectory_bindings.cpp",
                     "curobo/_src/curobolib/backends/pybind/trajectory_kernel_launch.cu",
                 ],
-                include_dirs=[str(source_dir / "curobo/_src/curobolib/kernels")],
+                include_dirs=kernel_include_dirs,
                 extra_compile_args=extra_cuda_args,
             ),
             CUDAExtension(
                 "curobo._src.curobolib.backends.pybind.geometry",
                 [
                     "curobo/_src/curobolib/backends/pybind/geometry_bindings.cpp",
-                    "curobo/_src/curobolib/backends/pybind/sphere_obb_kernel_launch.cu",
                     "curobo/_src/curobolib/backends/pybind/self_collision_kernel_launch.cu",
-                    "curobo/_src/curobolib/backends/pybind/sphere_voxel_kernel_launch.cu",
                 ],
-                include_dirs=[str(source_dir / "curobo/_src/curobolib/kernels")],
+                include_dirs=kernel_include_dirs,
                 extra_compile_args=extra_cuda_args,
             ),
         ]


### PR DESCRIPTION
## Summary

Building the compiled pybind backend (`CUROBO_USE_PYBIND=1`) currently fails on CUDA 13, and even after compiling, the runtime can't use the extensions. This PR fixes four issues so the source build works end-to-end. All are in the opt-in pybind path (the default `cuda.core` backend masks them in CI); fix #1 also helps `cuda.core` since it shares the kernel sources.

Each commit corresponds to one symptom encountered, in build order:

1. **CUDA 13 `lerp` conflict** (`helper_math.h`) — CUDA 13.0 ships a built-in scalar `lerp(float,float,float)`; the third-party `helper_math.h` redefinition then fails with *"conflicts with a previous declaration"*. Guarded the scalar overload out on `CUDART_VERSION >= 13000` (identical semantics); the `float2/3/4` overloads are cuRobo-specific and don't conflict.

2. **Kernel include dirs** (`setup.py`) — kernel headers live in nested subdirs (`optimization/lbfgs/`, `optimization/line_search/`, ...) but the `.cu` launchers `#include` them by bare filename, while only the `kernels` root was on `include_dirs` → *"fatal error: line_search_kernel.cuh: No such file or directory"*. Added all kernel subdirs recursively.

3. **Phantom geometry sources** (`setup.py`) — the `geometry` extension listed `sphere_obb_kernel_launch.cu` and `sphere_voxel_kernel_launch.cu`, which aren't in the tree (`geometry_bindings.cpp` only binds `self_collision_distance`) → *"ninja: error: ... missing and no known rule to make it"*. Compile only the sources that exist.

4. **cuda.core → pybind fallback** (`backends/__init__.py`) — `_try_load_cuda_core_backend()` is the soft loader (`Optional[dict]`, *"Try to load"*) but called `log_and_raise()` on `ImportError`, so it raised instead of returning `None`. This broke the documented auto-select fallback: with `cuda.core` not installed, `_auto_select_backend()` couldn't fall back to a compiled pybind backend and raised *"No module named 'cuda.core'"* even with extensions built. Returns `None` now, matching `_try_load_pybind_backend()`.

## Environment

- CUDA toolkit 13.3, PyTorch 2.12 (cu130), `TORCH_CUDA_ARCH_LIST=8.9` (RTX 6000 Ada), Python 3.12, Linux.

## Verification

After these fixes, `CUROBO_USE_PYBIND=1 ... pip install -e . --no-build-isolation` compiles all four extensions, and an IK solve succeeds via the compiled backend:

```
backend = pybind | solve_pose success = 100% | position_error = 8.3e-09
```