### PR TITLE
Fix export_to_urdf dropping the sign of negative joint axes (#676)

### DIFF
--- a/curobo/_src/robot/types/kinematics_params.py
+++ b/curobo/_src/robot/types/kinematics_params.py
@@ -886,6 +886,16 @@ class KinematicsParams:
             # Convert to URDF joint type and axis
             urdf_joint_type, axis = _joint_type_to_urdf_type(joint_type_value)
 
+            # A joint authored with a negative URDF axis (e.g. <axis xyz="-1 0 0"/>) is
+            # stored by UrdfRobotParser as the POSITIVE joint type plus a -1 joint-offset
+            # scale (parser_urdf.py), so _joint_type_to_urdf_type returns the positive axis.
+            # Re-apply that stored sign here, otherwise the exported axis loses it and FK on
+            # the exported URDF rotates the opposite way for the same joint value.
+            if axis is not None and joint_idx >= 0:
+                offset_scale = float(self.joint_offset_map[2 * link_idx].cpu().numpy())
+                if offset_scale < 0:
+                    axis = -axis
+
             # Get fixed transform (origin)
             fixed_transform = self.fixed_transforms[link_idx].cpu().numpy()
             origin = np.eye(4)

--- a/curobo/tests/_src/robot/types/test_kinematics_params.py
+++ b/curobo/tests/_src/robot/types/test_kinematics_params.py
@@ -5,8 +5,10 @@
 """Integration tests for KinematicsParams using KinematicsLoader."""
 
 # Third Party
+import numpy as np
 import pytest
 import torch
+import yourdfpy
 
 from curobo._src.robot.kinematics.kinematics_cfg import KinematicsCfg
 
@@ -496,8 +498,6 @@ class TestExportToUrdfAxisSign:
 
     @pytest.mark.parametrize("axis", ["-1 0 0", "1 0 0", "0 -1 0", "0 0 -1"])
     def test_export_preserves_axis_sign_and_fk(self, axis, tmp_path, cuda_device_cfg):
-        import numpy as np
-        import yourdfpy
 
         src_path = tmp_path / "src.urdf"
         self._write_single_joint_urdf(src_path, axis)

--- a/curobo/tests/_src/robot/types/test_kinematics_params.py
+++ b/curobo/tests/_src/robot/types/test_kinematics_params.py
@@ -467,3 +467,67 @@ class TestKinematicsParamsEdgeCases:
             franka_kinematics_cfg.reference_link_spheres,
         )
 
+
+
+class TestExportToUrdfAxisSign:
+    """Regression for NVlabs/curobo#676: ``export_to_urdf`` must preserve the sign of a
+    joint axis. A joint authored with a negative URDF axis (e.g. ``<axis xyz="-1 0 0"/>``)
+    is stored by the parser as the positive joint type plus a ``-1`` joint-offset scale;
+    the export must re-apply that sign, else FK on the exported URDF rotates the wrong way.
+    """
+
+    @staticmethod
+    def _write_single_joint_urdf(path, axis: str) -> None:
+        path.write_text(
+            '<?xml version="1.0"?>\n'
+            '<robot name="axis_sign_demo">\n'
+            '  <link name="base_link"><inertial><mass value="1.0"/>'
+            '<inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/></inertial></link>\n'
+            '  <link name="link1"><inertial><mass value="1.0"/>'
+            '<inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/></inertial></link>\n'
+            '  <joint name="j1" type="revolute">\n'
+            '    <parent link="base_link"/><child link="link1"/>\n'
+            '    <origin xyz="0.1 0 0" rpy="0 0 0"/>\n'
+            f'    <axis xyz="{axis}"/>\n'
+            '    <limit lower="-1.57" upper="1.57" effort="1" velocity="1"/>\n'
+            '  </joint>\n'
+            '</robot>\n'
+        )
+
+    @pytest.mark.parametrize("axis", ["-1 0 0", "1 0 0", "0 -1 0", "0 0 -1"])
+    def test_export_preserves_axis_sign_and_fk(self, axis, tmp_path, cuda_device_cfg):
+        import numpy as np
+        import yourdfpy
+
+        src_path = tmp_path / "src.urdf"
+        self._write_single_joint_urdf(src_path, axis)
+
+        kin_dict = {
+            "urdf_path": str(src_path), "base_link": "base_link", "tool_frames": ["link1"],
+            "cspace": {
+                "joint_names": ["j1"], "default_joint_position": [0.0],
+                "null_space_weight": [1.0], "cspace_distance_weight": [1.0],
+                "max_acceleration": 1.0, "max_jerk": 10.0,
+            },
+        }
+        cfg = KinematicsCfg.from_data_dict(kin_dict, device_cfg=cuda_device_cfg)
+
+        out_path = tmp_path / "exported.urdf"
+        cfg.kinematics_config.export_to_urdf(
+            output_path=str(out_path), kinematics_parser=cfg.kinematics_parser
+        )
+
+        src_urdf = yourdfpy.URDF.load(str(src_path), load_meshes=False, build_scene_graph=True)
+        exp_urdf = yourdfpy.URDF.load(str(out_path), load_meshes=False, build_scene_graph=True)
+
+        # 1. The exported axis must match the source axis (up to sign-equal float parse).
+        want = np.array([float(x) for x in axis.split()])
+        got = np.array([float(x) for x in exp_urdf.joint_map["j1"].axis])
+        np.testing.assert_allclose(got, want, atol=1e-9)
+
+        # 2. FK round-trip: child link pose must match the source for a non-trivial angle.
+        q = 0.7
+        src_urdf.update_cfg(np.array([q])); exp_urdf.update_cfg(np.array([q]))
+        np.testing.assert_allclose(
+            exp_urdf.get_transform("link1"), src_urdf.get_transform("link1"), atol=1e-6
+        )


### PR DESCRIPTION
## Summary

`KinematicsParams.export_to_urdf` drops the **sign** of negative joint axes, producing a URDF that is kinematically inconsistent with the source.

`UrdfRobotParser` stores a joint authored with a negative URDF axis (e.g. `<axis xyz="-1 0 0"/>`) as the **positive** joint type plus a `-1` joint-offset scale (`parser_urdf.py:289-300`), so `_joint_type_to_urdf_type` correctly returns the positive axis. But `export_to_urdf` never re-applies that stored sign, so the exported joint keeps the positive axis with the original origin — and FK on the affected joints rotates the **opposite** direction for the same joint value.

This surfaces via `ViserVisualizer` (which renders robots with `extra_links` by exporting the internal model to a temp URDF): a dexterous hand with negative-axis finger joints rendered with the wrong articulation, fingertips diverging ~27.5 mm from the source URDF.

Fixes #676.

## Fix

Re-apply the `joint_offset_map` sign to the exported axis in `export_to_urdf` (one guarded block at the joint-emission site). No change to the public API or to FK.

## Test

Added `TestExportToUrdfAxisSign` — a parametrized round-trip regression test over negative **and** positive X/Y/Z axes that asserts (1) the exported axis sign is preserved and (2) FK on the exported URDF matches the source URDF at a non-trivial joint angle. The 4 cases pass; the full `tests/_src/robot/types/test_kinematics_params.py` (37 tests) passes.

## Notes

- DCO signed-off; commit SSH-signed.
- Minimal self-contained repro is in #676.
