### PR TITLE
fix missing curobo/content in non-git sdist/wheel builds

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Ship runtime configs and robot assets in builds without VCS file discovery.
+recursive-include curobo/content *


### PR DESCRIPTION
## Summary

  - Added a `MANIFEST.in` (`recursive-include curobo/content *`) so `curobo/content/**` ships in the sdist and wheel when the build can't discover files through the VCS (no `.git` tree).
  - Fixes the runtime `FileNotFoundError` on bundled configs (e.g. `content/configs/task/ik/particle_ik.yml`) for installs built from an unpacked sdist, a repackaged source tree, or any non-VCS wheel build.

## Implementation Notes

  - Content shipping relied on `include-package-data` + the setuptools_scm VCS file-finder, which enumerates nothing without a `.git` tree, so any build without VCS file discovery silently dropped the whole content tree. `MANIFEST.in` makes inclusion independent of the file-finder; `include-package-data` (already enabled) then carries it from the sdist into the wheel.
  - This is only the file-discovery half of setuptools_scm. The version half is unaffected — a non-VCS build still needs the version supplied out-of-band (sdist `PKG-INFO`, or `SETUPTOOLS_SCM_PRETEND_VERSION`), otherwise it fails earlier at version detection.
  - Used `MANIFEST.in` rather than a `[tool.setuptools.package-data] "curobo.content" = ["**/*"]` entry: recursive `**` globs in package-data need setuptools >= 62.3, while `build-system.requires` pins `setuptools>=45`, so on an older builder that entry matches only the top-level `__init__.py` and drops the deep files. `MANIFEST.in` has no such version dependency. Checked on setuptools 62.1 and current; sdist and wheel both carry the full tree (150 content files) after the change, vs. only `content/__init__.py` before.
  - Editable installs from a git clone (`pip install -e .`) are unaffected — `.git` is present.
  - Not part of this PR: the wheel also ships all of `curobo/tests/` (204 files) because `[tool.setuptools.packages.find] exclude = ["tests"]` doesn't match the nested `curobo.tests` package. Happy to send a separate fix.
