### PR TITLE
fix SceneData cross-type obstacle lookup by catching ValueError

### DIFF
--- a/curobo/_src/geom/data/data_cuboid.py
+++ b/curobo/_src/geom/data/data_cuboid.py
@@ -340,7 +340,7 @@ class CuboidData:
             env_idx: Environment index.
 
         Raises:
-            RuntimeError: If cuboid with given name not found.
+            ValueError: If cuboid with given name not found.
         """
         if w_obj_pose is None and obj_w_pose is None:
             log_and_raise("Either w_obj_pose or obj_w_pose must be provided")
@@ -361,7 +361,7 @@ class CuboidData:
             env_idx: Environment index.
 
         Raises:
-            RuntimeError: If cuboid with given name not found.
+            ValueError: If cuboid with given name not found.
         """
         idx = self.get_idx(name, env_idx)
         self.dims[env_idx, idx, :3] = dims
@@ -375,7 +375,7 @@ class CuboidData:
             env_idx: Environment index.
 
         Raises:
-            RuntimeError: If cuboid with given name not found.
+            ValueError: If cuboid with given name not found.
         """
         idx = self.get_idx(name, env_idx)
         self.enable[env_idx, idx] = int(enabled)

--- a/curobo/_src/geom/data/data_mesh.py
+++ b/curobo/_src/geom/data/data_mesh.py
@@ -387,7 +387,7 @@ class MeshData:
             env_idx: Environment index.
 
         Raises:
-            RuntimeError: If mesh with given name not found.
+            ValueError: If mesh with given name not found.
         """
         if w_obj_pose is None and obj_w_pose is None:
             log_and_raise("Either w_obj_pose or obj_w_pose must be provided")
@@ -441,7 +441,16 @@ class MeshData:
         self.names[env_idx][mesh_idx] = name
 
     def set_enabled(self, name: str, enabled: bool, env_idx: int = 0) -> None:
-        """Enable or disable a mesh for collision checking."""
+        """Enable or disable a mesh for collision checking.
+
+        Args:
+            name: Name of the mesh.
+            enabled: True to enable, False to disable.
+            env_idx: Environment index.
+
+        Raises:
+            ValueError: If mesh with given name not found.
+        """
         idx = self.get_idx(name, env_idx)
         self.enable[env_idx, idx] = int(enabled)
 

--- a/curobo/_src/geom/data/data_scene.py
+++ b/curobo/_src/geom/data/data_scene.py
@@ -323,21 +323,21 @@ class SceneData:
             try:
                 self.cuboids.update_pose(name, w_obj_pose=pose, env_idx=env_idx)
                 return
-            except RuntimeError:
+            except (RuntimeError, ValueError):
                 pass
 
         if self.meshes is not None:
             try:
                 self.meshes.update_pose(name, w_obj_pose=pose, env_idx=env_idx)
                 return
-            except RuntimeError:
+            except (RuntimeError, ValueError):
                 pass
 
         if self.voxels is not None:
             try:
                 self.voxels.update_pose(name, w_obj_pose=pose, env_idx=env_idx)
                 return
-            except RuntimeError:
+            except (RuntimeError, ValueError):
                 pass
 
         log_and_raise(f"Obstacle '{name}' not found in environment {env_idx}")
@@ -362,21 +362,21 @@ class SceneData:
             try:
                 self.cuboids.set_enabled(name, enabled, env_idx)
                 return
-            except RuntimeError:
+            except (RuntimeError, ValueError):
                 pass
 
         if self.meshes is not None:
             try:
                 self.meshes.set_enabled(name, enabled, env_idx)
                 return
-            except RuntimeError:
+            except (RuntimeError, ValueError):
                 pass
 
         if self.voxels is not None:
             try:
                 self.voxels.set_enabled(name, enabled, env_idx)
                 return
-            except RuntimeError:
+            except (RuntimeError, ValueError):
                 pass
 
         log_and_raise(f"Obstacle '{name}' not found in environment {env_idx}")

--- a/curobo/_src/geom/data/data_voxel.py
+++ b/curobo/_src/geom/data/data_voxel.py
@@ -546,6 +546,9 @@ class VoxelData:
             w_obj_pose: New pose in world frame.
             obj_w_pose: New inverse pose. Used if w_obj_pose is None.
             env_idx: Environment index.
+
+        Raises:
+            ValueError: If voxel grid with given name not found.
         """
         if w_obj_pose is None and obj_w_pose is None:
             log_and_raise("Either w_obj_pose or obj_w_pose must be provided")
@@ -558,7 +561,16 @@ class VoxelData:
         self.inv_pose[env_idx, idx, :7] = obj_w_pose.get_pose_vector()
 
     def set_enabled(self, name: str, enabled: bool, env_idx: int = 0) -> None:
-        """Enable or disable a voxel grid for collision checking."""
+        """Enable or disable a voxel grid for collision checking.
+
+        Args:
+            name: Name of the voxel grid.
+            enabled: True to enable, False to disable.
+            env_idx: Environment index.
+
+        Raises:
+            ValueError: If voxel grid with given name not found.
+        """
         idx = self.get_idx(name, env_idx)
         self.enable[env_idx, idx] = int(enabled)
 


### PR DESCRIPTION
## Summary

Fixes a bug in `SceneData.update_obstacle_pose()` and `SceneData.enable_obstacle()` where obstacles stored in mesh or voxel storage could not be updated or toggled when cuboid storage was also initialized.

When resolving an obstacle by name, `SceneData` iterates over cuboid, mesh, and voxel stores in order. If the name is not found in the current store, it should continue to the next type. However, the handlers only caught `RuntimeError`, while the underlying lookup paths raise `ValueError` (via `list.index()` ). As a result, a missing name in the cuboid store would raise immediately and prevent lookup in subsequent stores.

This change catches both `RuntimeError` and `ValueError` during the cross-type search. Docstrings for `update_pose()` and `set_enabled()` in `CuboidData`, `MeshData`, and `VoxelData` are updated to document the actual `ValueError` behavior.

## Changes

- `SceneData`: catch `(RuntimeError, ValueError)` in `update_obstacle_pose()` and `enable_obstacle()`
- `CuboidData`, `MeshData`, `VoxelData`: align `Raises` docstrings with actual exception types