### PR TITLE
Fix feature_mapping example crash by passing feature grid dimensions to MapperCfg

### DIFF
--- a/curobo/examples/getting_started/feature_mapping.py
+++ b/curobo/examples/getting_started/feature_mapping.py
@@ -764,6 +764,8 @@ def main():
     # sync with the model regardless of which C-RADIO variant is loaded.
     probe_feats = feature_model.extract_patch_features(dataset[0].rgb_image)
     feature_dim = probe_feats.shape[-1]
+    feature_grid_height = int(probe_feats.shape[0])
+    feature_grid_width = int(probe_feats.shape[1])
     print(f"Feature dim: {feature_dim}")
     print(f"Feature shape: {probe_feats.shape}")
 
@@ -780,6 +782,8 @@ def main():
         image_height=SUN3D_IMAGE_SHAPE[0],
         image_width=SUN3D_IMAGE_SHAPE[1],
         feature_dim=feature_dim,
+        feature_grid_height=feature_grid_height,
+        feature_grid_width=feature_grid_width,
         block_size=8,
     )
     mapper = Mapper(config)


### PR DESCRIPTION
### ❌ Issue
Running `feature_mapping.py` fails at startup with: `ValueError: feature_dim > 0 requires feature_grid_height and feature_grid_width.`

The example derives feature_dim from C-RADIO probe features but does not provide the corresponding feature_grid_height and feature_grid_width required by MapperCfg.

<img width="983" height="558" alt="before" src="https://github.com/user-attachments/assets/784b4e7b-6154-45f0-affb-bc27d66aa869" />


### ✅ Solution
Derive feature_grid_height and feature_grid_width from the extracted probe features and pass them to MapperCfg during initialization.

<img width="981" height="269" alt="after" src="https://github.com/user-attachments/assets/3e10daf7-3247-42eb-ad29-99c824b37c1b" />


### 🧪 Test plan

1.  Ran python -m curobo.examples.getting_started.feature_mapping --root ./datasets/sun3d/... --num-frames 50 --stride 10 --save-pca
2.  Mapper initializes successfully (no ValueError)
3. Feature mapping proceeds past MapperCfg initialization.