### PR TITLE
Fix reflected USD mesh transforms in scene parser

### DIFF
--- a/curobo/_src/util/usd_scene_parser.py
+++ b/curobo/_src/util/usd_scene_parser.py
@@ -29,7 +29,7 @@ from curobo._src.util.usd_util import get_prim_world_pose
 
 try:
     # Third Party
-    from pxr import Usd, UsdGeom
+    from pxr import Gf, Usd, UsdGeom
 except ImportError:
     raise ImportError(
         "usd-core failed to import, install with pip install usd-core"
@@ -167,43 +167,40 @@ def get_mesh_attrs(prim, cache=None, transform=None) -> Optional[Mesh]:
     Args:
         prim: The USD prim to extract from.
         cache: UsdGeom.XformCache for transform computation.
-        transform: Optional additional transformation matrix to apply.
+        transform: Optional additional transformation matrix to bake into mesh vertices.
 
     Returns:
         Mesh obstacle instance, or None if mesh data is invalid.
     """
     points = list(prim.GetAttribute("points").Get())
-    points = [np.ravel(x) for x in points]
 
     faces = list(prim.GetAttribute("faceVertexIndices").Get())
 
-    face_count = list(prim.GetAttribute("faceVertexCounts").Get())
-    if prim.GetAttribute("xformOp:scale").IsValid():
-        scale = list(prim.GetAttribute("xformOp:scale").Get())
-    else:
-        scale = [1.0, 1.0, 1.0]
-    size = prim.GetAttribute("size").Get()
-    if size is None:
-        size = 1
-    scale = [s * size for s in scale]
-
-    mat, t_scale = get_prim_world_pose(cache, prim)
-    # also get any world scale:
-    scale = t_scale
-
+    face_counts = list(prim.GetAttribute("faceVertexCounts").Get())
+    world_transform = cache.GetLocalToWorldTransform(prim)
+    vertices = np.asarray(
+        [world_transform.Transform(Gf.Vec3d(*point)) for point in points], dtype=np.float32
+    )
+    linear_transform = np.asarray(world_transform.ExtractRotationMatrix(), dtype=np.float32)
     if transform is not None:
-        mat = transform @ mat
-    # compute position and orientation on cuda:
-    tensor_mat = torch.as_tensor(mat, device=torch.device("cuda", 0))
-    pose = Pose.from_matrix(tensor_mat).tolist()
+        vertices = vertices @ transform[:3, :3].T + transform[:3, 3]
+        linear_transform = transform[:3, :3] @ linear_transform
+
+    if np.linalg.det(linear_transform) < 0.0:
+        flipped_faces = []
+        face_start = 0
+        for face_count in face_counts:
+            face_end = face_start + face_count
+            flipped_faces.extend(reversed(faces[face_start:face_end]))
+            face_start = face_end
+        faces = flipped_faces
 
     m = Mesh.from_polygon_faces(
         name=str(prim.GetPath()),
-        pose=pose,
-        vertices=points,
+        pose=[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        vertices=vertices.tolist(),
         faces=faces,
-        face_counts=face_count,
-        scale=scale,
+        face_counts=face_counts,
     )
 
     return m

--- a/curobo/_src/util/usd_scene_parser.py
+++ b/curobo/_src/util/usd_scene_parser.py
@@ -167,7 +167,7 @@ def get_mesh_attrs(prim, cache=None, transform=None) -> Optional[Mesh]:
     Args:
         prim: The USD prim to extract from.
         cache: UsdGeom.XformCache for transform computation.
-        transform: Optional additional transformation matrix to bake into mesh vertices.
+        transform: Optional additional transformation matrix to apply.
 
     Returns:
         Mesh obstacle instance, or None if mesh data is invalid.
@@ -181,12 +181,21 @@ def get_mesh_attrs(prim, cache=None, transform=None) -> Optional[Mesh]:
     vertices = np.asarray(
         [world_transform.Transform(Gf.Vec3d(*point)) for point in points], dtype=np.float32
     )
+    mat, _ = get_prim_world_pose(cache, prim)
     linear_transform = np.asarray(world_transform.ExtractRotationMatrix(), dtype=np.float32)
     if transform is not None:
         vertices = vertices @ transform[:3, :3].T + transform[:3, 3]
+        mat = transform @ mat
         linear_transform = transform[:3, :3] @ linear_transform
 
-    if np.linalg.det(linear_transform) < 0.0:
+    reflected_transform = np.linalg.det(linear_transform) < 0.0
+    if reflected_transform:
+        mat[:3, :3] = np.eye(3, dtype=mat.dtype)
+
+    inverse_pose = np.linalg.inv(mat)
+    vertices = vertices @ inverse_pose[:3, :3].T + inverse_pose[:3, 3]
+
+    if reflected_transform:
         flipped_faces = []
         face_start = 0
         for face_count in face_counts:
@@ -195,9 +204,11 @@ def get_mesh_attrs(prim, cache=None, transform=None) -> Optional[Mesh]:
             face_start = face_end
         faces = flipped_faces
 
+    tensor_mat = torch.as_tensor(mat, device=torch.device("cuda", 0))
+    pose = Pose.from_matrix(tensor_mat).tolist()
     m = Mesh.from_polygon_faces(
         name=str(prim.GetPath()),
-        pose=[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        pose=pose,
         vertices=vertices.tolist(),
         faces=faces,
         face_counts=face_counts,

--- a/curobo/_src/util/usd_writer.py
+++ b/curobo/_src/util/usd_writer.py
@@ -419,30 +419,42 @@ def get_mesh_attrs(prim, cache=None, transform=None) -> Mesh:
     # read cube information
     # scale = prim.GetAttribute("size").Get()
     points = list(prim.GetAttribute("points").Get())
-    points = [np.ravel(x) for x in points]
     # points = np.ndarray(points)
 
     faces = list(prim.GetAttribute("faceVertexIndices").Get())
 
     face_count = list(prim.GetAttribute("faceVertexCounts").Get())
-    if prim.GetAttribute("xformOp:scale").IsValid():
-        scale = list(prim.GetAttribute("xformOp:scale").Get())
-    else:
-        scale = [1.0, 1.0, 1.0]
-    size = prim.GetAttribute("size").Get()
-    if size is None:
-        size = 1
-    scale = [s * size for s in scale]
-
-    mat, t_scale = get_prim_world_pose(cache, prim)
-    # also get any world scale:
-    scale = t_scale
+    world_transform = cache.GetLocalToWorldTransform(prim)
+    vertices = np.asarray(
+        [world_transform.Transform(Gf.Vec3d(*point)) for point in points], dtype=np.float32
+    )
+    mat, _ = get_prim_world_pose(cache, prim)
+    linear_transform = np.asarray(world_transform.ExtractRotationMatrix(), dtype=np.float32)
     # position = list(prim.GetAttribute("xformOp:translate").Get())
     # q = prim.GetAttribute("xformOp:orient").Get()
     # orientation = [q.GetReal()] + list(q.GetImaginary())
 
     if transform is not None:
+        vertices = vertices @ transform[:3, :3].T + transform[:3, 3]
         mat = transform @ mat
+        linear_transform = transform[:3, :3] @ linear_transform
+
+    reflected_transform = np.linalg.det(linear_transform) < 0.0
+    if reflected_transform:
+        mat[:3, :3] = np.eye(3, dtype=mat.dtype)
+
+    inverse_pose = np.linalg.inv(mat)
+    vertices = vertices @ inverse_pose[:3, :3].T + inverse_pose[:3, 3]
+
+    if reflected_transform:
+        flipped_faces = []
+        face_start = 0
+        for count in face_count:
+            face_end = face_start + count
+            flipped_faces.extend(reversed(faces[face_start:face_end]))
+            face_start = face_end
+        faces = flipped_faces
+
     # compute position and orientation on cuda:
     tensor_mat = torch.as_tensor(mat, device=torch.device("cuda", 0))
     pose = Pose.from_matrix(tensor_mat).tolist()
@@ -452,10 +464,9 @@ def get_mesh_attrs(prim, cache=None, transform=None) -> Mesh:
     m = Mesh.from_polygon_faces(
         name=str(prim.GetPath()),
         pose=pose,
-        vertices=points,
+        vertices=vertices.tolist(),
         faces=faces,
         face_counts=face_count,
-        scale=scale,
     )
     # print(len(m.vertices), max(m.faces))
 

--- a/curobo/tests/_src/util/test_usd_scene_parser.py
+++ b/curobo/tests/_src/util/test_usd_scene_parser.py
@@ -7,6 +7,7 @@
 # Standard Library
 
 # Third Party
+import numpy as np
 import pytest
 
 # CuRobo
@@ -14,7 +15,7 @@ from curobo._src.geom.types import Cuboid, Cylinder, SceneCfg, Sphere
 
 try:
     # Third Party
-    from pxr import Usd, UsdGeom
+    from pxr import Gf, Usd, UsdGeom
 
     from curobo._src.util.usd_scene_parser import (
         UsdSceneParser,
@@ -268,6 +269,51 @@ class TestGeometryExtractors:
         assert extracted is not None
         assert len(extracted.faces) == 2
         assert extracted.faces == [[1, 3, 0], [1, 2, 3]]
+
+    def test_get_mesh_attrs_bakes_reflected_transform_and_reference_frame(self, tmp_path):
+        """Test mesh extraction preserves reflected world transforms."""
+        stage = create_stage(str(tmp_path / "reflected_mesh.usd"))
+        reference_path = "/world/reference"
+        reference_prim = UsdGeom.Xform.Define(stage, reference_path).GetPrim()
+        set_prim_transform(reference_prim, [0.5, -0.25, 0.75, 1, 0, 0, 0])
+
+        mesh_path = "/world/reflected_mesh"
+        mesh_geom = UsdGeom.Mesh.Define(stage, mesh_path)
+        mesh_geom.CreatePointsAttr([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+        mesh_geom.CreateFaceVertexCountsAttr([3])
+        mesh_geom.CreateFaceVertexIndicesAttr([0, 1, 2])
+        mesh_prim = stage.GetPrimAtPath(mesh_path)
+        set_prim_transform(
+            mesh_prim,
+            [1.25, 0.5, 0.25, 1, 0, 0, 0],
+            scale=[-1.0, 2.0, 1.0],
+        )
+
+        parser = UsdSceneParser()
+        parser.load_stage(stage)
+        scene = parser.get_obstacles_from_stage(
+            only_paths=[mesh_path], reference_prim_path=reference_path
+        )
+
+        extracted = scene.mesh[0]
+        cache = UsdGeom.XformCache()
+        world_transform = cache.GetLocalToWorldTransform(mesh_prim)
+        expected_world_points = np.asarray(
+            [
+                world_transform.Transform(Gf.Vec3d(*point))
+                for point in mesh_geom.GetPointsAttr().Get()
+            ],
+            dtype=np.float32,
+        )
+        expected_reference_points = expected_world_points - np.asarray(
+            [0.5, -0.25, 0.75], dtype=np.float32
+        )
+
+        np.testing.assert_allclose(extracted.vertices, expected_reference_points)
+        assert extracted.pose == [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+
+        triangle = np.asarray(extracted.vertices)[np.asarray(extracted.faces[0])]
+        assert np.cross(triangle[1] - triangle[0], triangle[2] - triangle[0])[2] > 0.0
 
     def test_get_cube_attrs_with_zero_dimension_raises(self, tmp_path):
         """Test that zero cube dimension raises ValueError."""

--- a/curobo/tests/_src/util/test_usd_scene_parser.py
+++ b/curobo/tests/_src/util/test_usd_scene_parser.py
@@ -270,7 +270,10 @@ class TestGeometryExtractors:
         assert len(extracted.faces) == 2
         assert extracted.faces == [[1, 3, 0], [1, 2, 3]]
 
-    def test_get_mesh_attrs_bakes_reflected_transform_and_reference_frame(self, tmp_path):
+    @pytest.mark.parametrize("reader_type", [UsdSceneParser, UsdWriter])
+    def test_get_mesh_attrs_bakes_reflected_transform_and_reference_frame(
+        self, tmp_path, reader_type
+    ):
         """Test mesh extraction preserves reflected world transforms."""
         stage = create_stage(str(tmp_path / "reflected_mesh.usd"))
         reference_path = "/world/reference"
@@ -289,9 +292,9 @@ class TestGeometryExtractors:
             scale=[-1.0, 2.0, 1.0],
         )
 
-        parser = UsdSceneParser()
-        parser.load_stage(stage)
-        scene = parser.get_obstacles_from_stage(
+        reader = reader_type()
+        reader.load_stage(stage)
+        scene = reader.get_obstacles_from_stage(
             only_paths=[mesh_path], reference_prim_path=reference_path
         )
 
@@ -309,8 +312,18 @@ class TestGeometryExtractors:
             [0.5, -0.25, 0.75], dtype=np.float32
         )
 
-        np.testing.assert_allclose(extracted.vertices, expected_reference_points)
-        assert extracted.pose == [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+        np.testing.assert_allclose(extracted.pose[:3], [0.75, 0.75, -0.5], atol=1e-6)
+        np.testing.assert_allclose(extracted.pose[3:], [1.0, 0.0, 0.0, 0.0], atol=1e-6)
+        np.testing.assert_allclose(
+            extracted.vertices,
+            [[0.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 2.0, 0.0]],
+            atol=1e-6,
+        )
+
+        transformed_vertices = np.asarray(extracted.vertices) + np.asarray(
+            extracted.pose[:3], dtype=np.float32
+        )
+        np.testing.assert_allclose(transformed_vertices, expected_reference_points)
 
         triangle = np.asarray(extracted.vertices)[np.asarray(extracted.faces[0])]
         assert np.cross(triangle[1] - triangle[0], triangle[2] - triangle[0])[2] > 0.0


### PR DESCRIPTION
## Summary

- Bake the full USD local-to-world transform into mesh vertices during scene parsing.
- Preserve the `reference_prim_path` transform when baking vertices.
- Reverse polygon winding for reflected transforms to preserve face orientation.
- Add a regression test for a reflected mesh parsed relative to a reference frame.

## Problem

`UsdSceneParser.get_mesh_attrs()` decomposed a USD mesh transform into a pose and an unsigned scale. This loses reflection information from negative scales.
<img width="551" height="326" alt="leg_below_ground_and_flipped" src="https://github.com/user-attachments/assets/97b632d2-4463-44b3-a0e7-67f80325a01e" />
<img width="515" height="415" alt="unfixed" src="https://github.com/user-attachments/assets/76c46f5a-b979-4e4d-b6e6-f82fac95f750" />

As a result, meshes with reflected transform chains could be reconstructed with an incorrect rotation. In my Isaac Sim desk scene, one cuRobo collision mesh was placed below the ground even though the source USD geometry was correctly positioned.

## Testing

- Manually verified with an Isaac Sim scene containing the affected desk asset; the collision mesh now aligns with the USD geometry and is no longer below ground.
- Added a regression test covering a mesh with negative scale and a reference frame.
- The automated test suite was not run locally because this checkout did not have the required `pytest` and USD dependencies installed.
<img width="690" height="496" alt="fixed" src="https://github.com/user-attachments/assets/ef016c98-ee41-43af-8cb1-4b26851ae906" />
