### PR TITLE
Improve TSDF mapper (high res color, feature, faster mesh extraction)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# Agent Instructions
+
+This file is the entry point for coding agents working in this repository. Keep
+changes small, inspect the existing code before editing, and follow the
+repository-specific rules in `.agent/`.
+
+## Rule Files
+
+- Read `.agent/design_principles.mdc` before non-trivial code changes.
+- Use `.agent/python_rules.mdc` and `.agent/package_format_rules.mdc` for Python
+  code.
+- Use `.agent/cpp_rules.mdc` for C++, CUDA, and Warp-adjacent native code.
+- Use `.agent/tests.mdc` before adding or changing tests.
+- Use `.agent/sphinx_md.mdc`, `.agent/documenter.mdc`, and
+  `.agent/diataxis.mdc` for documentation changes.
+- Use `.agent/file_naming.mdc` when creating or moving implementation files.
+
+## Development Workflow
+
+- Prefer `rg`/`rg --files` for repository search.
+- Activate `.venv` before running Python commands when it exists.
+- Preserve user changes in the working tree. Do not revert unrelated files.
+- Keep public APIs minimal and user-focused. Do not expose implementation details
+  unless they are required by the user-facing contract.
+- Prefer existing local patterns and helpers over new abstractions.
+- Use only `Copyright (c) 2026` in SPDX copyright headers for new files;
+  preserve existing headers when modifying older files.
+- Add focused tests for behavioral changes. Do not use `float64` in tests.
+- Keep CUDA graph enabled for normal runtime, examples, and performance-sensitive
+  paths. Disable CUDA graph only in tests or debugging paths where eager
+  execution helps catch correctness issues.
+
+## Python Conventions
+
+- Add type hints to all function signatures.
+- Use concise docstrings that describe behavior, inputs, outputs, and tensor
+  shapes when relevant.
+- For dataclasses, document fields where they are declared.
+- Use logging/error helpers from `curobo/_src/util/logging.py` instead of raw
+  prints or ad hoc exceptions in library code.
+- Keep `_src` package initializers marker-only unless they intentionally build a
+  public API aggregation layer.
+- Public modules under `curobo/` should curate user-facing imports. Internal
+  code should import concrete implementation modules directly.
+
+## Naming
+
+- Internal implementation files under `curobo/_src/` should use the
+  category-first pattern from `.agent/file_naming.mdc`.
+- Public API modules under `curobo/` should use descriptive, user-friendly names.
+
+## Documentation
+
+- Prefer Markdown with MyST syntax for new Sphinx documentation.
+- Keep docs in the correct Diataxis category: tutorial, guide, concept, or
+  reference.
+- Write user-facing docs around the outcome and contract, not internal
+  implementation details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,23 @@
   `BlockSparseTSDFCfg`, `BlockSparseTSDFIntegratorCfg`, and
   `BlockSparseESDFIntegratorCfg` now expose `block_size`, replacing the
   old module-level `BLOCK_SIZE` constant.
+- Replace mapper per-block RGB storage with a per-block local RGB control
+  grid. `BlockSparseTSDFCfg`, `BlockSparseTSDFIntegratorCfg`, and
+  `BlockSparseESDFIntegratorCfg` now expose `color_grid_size`, a
+  construction-time kernel specialization value in `[1, block_size]`.
+  RGB readout, raycast, mesh, and occupied-voxel extraction sample the
+  nearest color-grid node.
+- Integrate camera RGB into the mapper color grid with weighted bilinear
+  RGB-D sampling. The camera RGB kernel reads pixels as packed `wp.vec3ub`
+  values.
 - Add a cached per-`(block_size, seeding_method)` Warp kernel factory for
   block-sparse mapper kernels. Mapper construction now specializes kernels
   for the selected block size and compiles only the pipeline stages that
   are enabled by configuration.
-- Store per-block RGB and feature accumulators in fp16 and cap their
-  weights with `MapperCfg.accumulator_w_max`. This reduces feature-map
-  memory use and gives old observations EMA-like decay for dynamic scenes.
+- Store mapper color-grid RGB and feature accumulators in fp16 and cap
+  their weights with `MapperCfg.accumulator_w_max`. This reduces
+  feature-map memory use and gives old observations EMA-like decay for
+  dynamic scenes.
 - Add feature-mapping docs, videos, and an interactive getting-started
   example at `curobo/examples/getting_started/feature_mapping.py`.
 - Add polygon-face mesh construction with quad triangulation support.
@@ -109,11 +119,16 @@
 - `Mapper.get_matching_feature_voxels()` now returns `MatchedVoxels`.
   Code that accessed matched voxel fields directly should use
   `matched.voxels`, for example `matched.voxels.centers`.
-- Raw mapper storage fields `tsdf.data.block_rgb`, `block_features`, and
-  `block_feature_weight` are now `torch.float16`. Upcast to `float()` before
-  doing arithmetic on them directly. RGB accumulators are stored normalized
-  to `[0, 1]`; public helper outputs continue to return uint8 colors where
-  documented.
+- Raw mapper RGB storage `tsdf.data.block_rgb` is removed. Use
+  `tsdf.data.block_grid_rgb`, shaped
+  `(max_blocks, color_grid_size ** 3, 4)`, with fp16 normalized RGBW
+  accumulators. `use_color_grid` and `has_color_grid` are also removed; the
+  color grid is always present and `color_grid_size` defines its resolution.
+  `block_features` and `block_feature_weight` remain fp16; upcast to
+  `float()` before doing arithmetic on them directly.
+- Mapper block checkpoints now store `block_grid_rgb` and include
+  `color_grid_size` in metadata. Old checkpoints that contain only
+  `block_rgb` are not supported.
 - Direct imports from removed internal mapper kernel modules such as
   `wp_hash`, `wp_coord`, `wp_raycast`, and `wp_raycast_common` must move to
   the per-instance kernel factory accessors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,25 @@
 - Add feature-aware volumetric mapping. `CameraObservation` can carry an
   optional channels-last `feature_grid`; `MapperCfg.feature_dim` enables
   RGB and neural-feature fusion into per-block accumulators.
+- Allow RGB and neural features to use independent per-block spatial
+  resolutions. `feature_block_grid_size` controls feature storage and
+  integration independently from `color_grid_size`, so applications can
+  trade feature detail against memory without reducing RGB detail. It
+  defaults to `1`.
 - Add feature-query helpers for mapped volumes. `extract_occupied_voxels()`
   returns `OccupiedVoxels`, and `get_matching_feature_voxels()` returns
   `MatchedVoxels` with matched block ids, cosine scores, and
   `scores_per_voxel()`. Feature matching also supports optional
   `minimum_score` filtering. `OccupiedVoxels` and `MatchedVoxels` are
   exported from `curobo.perception`.
+- Add visibility-tested textured mapper outputs. `Mapper.extract_textured_mesh()`
+  exports textured meshes from RGB observations, and
+  `Mapper.extract_occupied_voxels()` supports `subvoxel_factor`, `max_points`,
+  and `texture_observations` for textured surface previews without per-frame
+  mesh extraction.
+- Speed up mapper mesh extraction for real-time visualization by using a
+  contiguous triangle-soup output path that avoids shared-vertex sorting and
+  lookup overhead.
 - Make mapper block size configurable per mapper instance. `MapperCfg`,
   `BlockSparseTSDFCfg`, `BlockSparseTSDFIntegratorCfg`, and
   `BlockSparseESDFIntegratorCfg` now expose `block_size`, replacing the
@@ -38,6 +51,9 @@
   dynamic scenes.
 - Add feature-mapping docs, videos, and an interactive getting-started
   example at `curobo/examples/getting_started/feature_mapping.py`.
+- Add repository-level `AGENTS.md` guidance for coding agents, covering cuRobo
+  development, testing, Python/CUDA, naming, and documentation conventions to
+  make agent-assisted contributions easier and more consistent.
 - Add polygon-face mesh construction with quad triangulation support.
 - Add compact mapper TSDF block checkpointing. `Mapper.save_blocks()`,
   `Mapper.load_blocks()`, and `Mapper.import_blocks()` persist active sparse
@@ -105,17 +121,20 @@
   `BlockSparseESDFIntegratorCfg.block_size` are regular dataclass fields
   instead of read-only properties backed by `BLOCK_SIZE`. Config equality,
   hashing, and repr now include `block_size`.
-- `MapperCfg.block_size` defaults to `4` instead of the previous implicit
-  `8`. Set `block_size=8` explicitly to preserve the old mapper block size.
+- `MapperCfg.block_size` now defaults to `8` instead of `4`. Set
+  `block_size=4` explicitly to preserve the previous `MapperCfg` default.
+- `Mapper.extract_mesh()` no longer accepts the `approximate` argument and now
+  always returns triangle-soup topology. Its `refine_iterations` default changes
+  from `2` to `0`.
 - `constants.BLOCK_SIZE` is removed. Use `cfg.block_size` for mapper
   configuration or `constants.REFERENCE_BLOCK_SIZE` for allocation scaling.
 - `MapperCfg.rgb_scale`, `MapperCfg.block_fill_ratio`, and
   `integration_method` are removed. Voxel-project is now the only TSDF
   integration backend; the old `sort_filter` integration path and
   `SortFilterIntegrator` are gone.
-- `Mapper.extract_occupied_voxels()` now returns an `OccupiedVoxels`
-  object instead of tuple-like outputs. Use `.centers`, `.colors_uint8()`,
-  `.features()`, and `len(voxels)`.
+- `Mapper.extract_occupied_voxels()` now defaults to `surface_only=True`
+  and returns an `OccupiedVoxels` object instead of tuple-like outputs.
+  Use `.centers`, `.colors_uint8()`, `.features()`, and `len(voxels)`.
 - `Mapper.get_matching_feature_voxels()` now returns `MatchedVoxels`.
   Code that accessed matched voxel fields directly should use
   `matched.voxels`, for example `matched.voxels.centers`.
@@ -124,11 +143,14 @@
   `(max_blocks, color_grid_size ** 3, 4)`, with fp16 normalized RGBW
   accumulators. `use_color_grid` and `has_color_grid` are also removed; the
   color grid is always present and `color_grid_size` defines its resolution.
-  `block_features` and `block_feature_weight` remain fp16; upcast to
+  `block_features` and `block_feature_weight` remain fp16 and are now shaped
+  `(max_blocks, feature_block_grid_size ** 3, feature_dim)` and
+  `(max_blocks, feature_block_grid_size ** 3)`, respectively. Upcast to
   `float()` before doing arithmetic on them directly.
-- Mapper block checkpoints now store `block_grid_rgb` and include
-  `color_grid_size` in metadata. Old checkpoints that contain only
-  `block_rgb` are not supported.
+- Mapper block checkpoint schema `1.0` stores `block_grid_rgb` and includes
+  both `color_grid_size` and `feature_block_grid_size` in metadata. Earlier
+  checkpoint schemas, including checkpoints that contain only `block_rgb`,
+  are not supported.
 - Direct imports from removed internal mapper kernel modules such as
   `wp_hash`, `wp_coord`, `wp_raycast`, and `wp_raycast_common` must move to
   the per-instance kernel factory accessors.

--- a/curobo/_src/curobolib/backends/pybind/line_search_kernel_launch.cu
+++ b/curobo/_src/curobolib/backends/pybind/line_search_kernel_launch.cu
@@ -96,8 +96,8 @@
      <<< blocksPerGrid, threadsPerBlock, 0, stream >>> (
        best_cost.data_ptr<float>(),
        best_action.data_ptr<float>(),
-       best_iteration.data_ptr<int16_t>(),
-       current_iteration.data_ptr<int16_t>(),
+       best_iteration.data_ptr<int32_t>(),
+       current_iteration.data_ptr<int32_t>(),
        converged_global.data_ptr<uint8_t>(),
        convergence_iteration,
        cost_delta_threshold,

--- a/curobo/_src/curobolib/cuda_ops/optimization.py
+++ b/curobo/_src/curobolib/cuda_ops/optimization.py
@@ -8,7 +8,6 @@ from torch.autograd import Function
 from curobo._src.curobolib.backends import optimization as optimization_cu
 from curobo._src.curobolib.cuda_ops.tensor_checks import (
     check_float32_tensors,
-    check_int16_tensors,
     check_int32_tensors,
     check_uint8_tensors,
 )
@@ -72,14 +71,11 @@ def wolfe_line_search(
         step_direction=step_direction,
         line_search_scale=line_search_context.line_search_scale,
     )
-    check_int16_tensors(
-        device,
-        best_iteration=iteration_state.best_iteration,
-        current_iteration=iteration_state.current_iteration,
-    )
     check_uint8_tensors(device, converged=iteration_state.converged)
     check_int32_tensors(
         device,
+        best_iteration=iteration_state.best_iteration,
+        current_iteration=iteration_state.current_iteration,
         exploration_idx=exploration_idx,
         selected_idx=selected_idx,
     )

--- a/curobo/_src/curobolib/kernels/optimization/line_search/line_search_helpers.cuh
+++ b/curobo/_src/curobolib/kernels/optimization/line_search/line_search_helpers.cuh
@@ -138,8 +138,8 @@ namespace line_search{
           ScalarType* exploration_cost,
           ScalarType* selected_cost,
           ScalarType* best_cost,
-          int16_t* best_iteration,
-          int16_t* current_iteration,
+          int32_t* best_iteration,
+          int32_t* current_iteration,
           uint8_t* converged_global,
           bool& update_best_shared,
           bool& converged_shared)

--- a/curobo/_src/curobolib/kernels/optimization/line_search/line_search_kernel.cuh
+++ b/curobo/_src/curobolib/kernels/optimization/line_search/line_search_kernel.cuh
@@ -30,8 +30,8 @@ namespace curobo{
         // inputs for update best operation
         ScalarType *best_cost, // batchsize x 1
         ScalarType *best_action, // batchsize x opt_dim
-        int16_t *best_iteration, // batchsize x 1
-        int16_t *current_iteration, // batchsize x 1
+        int32_t *best_iteration, // batchsize x 1
+        int32_t *current_iteration, // batchsize x 1
         uint8_t *converged_global, // batchsize x 1
         const int convergence_iteration, // 1
         const float cost_delta_threshold, // 1

--- a/curobo/_src/geom/types.py
+++ b/curobo/_src/geom/types.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 # Standard Library
+import struct
+import zlib
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -24,6 +26,109 @@ from curobo._src.types.device_cfg import DeviceCfg
 from curobo._src.types.pose import Pose
 from curobo._src.util.logging import log_and_raise, log_warn
 from curobo._src.util_file import get_assets_path, join_path
+
+
+class _ArrayTextureImage:
+    """Minimal image wrapper for trimesh texture export."""
+
+    format: Optional[str] = None
+
+    def __init__(self, image: np.ndarray) -> None:
+        """Create a texture image wrapper from a uint8 image of shape ``[H, W, C]``."""
+        image = np.asarray(image, dtype=np.uint8)
+        if image.ndim == 2:
+            self._image = np.ascontiguousarray(image)
+            self.mode = "L"
+        elif image.ndim == 3 and image.shape[2] == 1:
+            self._image = np.ascontiguousarray(image[..., 0])
+            self.mode = "L"
+        elif image.ndim == 3 and image.shape[2] == 3:
+            self._image = np.ascontiguousarray(image)
+            self.mode = "RGB"
+        elif image.ndim == 3 and image.shape[2] == 4:
+            self._image = np.ascontiguousarray(image)
+            self.mode = "RGBA"
+        else:
+            log_and_raise(
+                "Texture image must have shape [H, W], [H, W, 1], [H, W, 3], "
+                + "or [H, W, 4]"
+            )
+
+        self.height = int(self._image.shape[0])
+        self.width = int(self._image.shape[1])
+        self.size = (self.width, self.height)
+
+    def __array__(
+        self, dtype: Optional[np.dtype] = None, copy: Optional[bool] = None
+    ) -> np.ndarray:
+        """Return the backing image as a numpy array."""
+        image = self._image
+        if dtype is not None:
+            image = image.astype(dtype, copy=False)
+        if copy:
+            image = image.copy()
+        return image
+
+    def tobytes(self) -> bytes:
+        """Return raw image bytes."""
+        return self._image.tobytes()
+
+    def convert(self, mode: str) -> "_ArrayTextureImage":
+        """Convert the image to an RGB or RGBA channel layout."""
+        if mode == self.mode:
+            return _ArrayTextureImage(self._image)
+        if mode == "RGB":
+            if self.mode == "L":
+                return _ArrayTextureImage(np.repeat(self._image[..., None], 3, axis=2))
+            if self.mode == "RGBA":
+                return _ArrayTextureImage(self._image[..., :3])
+        if mode == "RGBA":
+            if self.mode == "L":
+                rgb_image = np.repeat(self._image[..., None], 3, axis=2)
+                alpha = np.full(self._image.shape + (1,), 255, dtype=np.uint8)
+                return _ArrayTextureImage(np.concatenate((rgb_image, alpha), axis=2))
+            if self.mode == "RGB":
+                alpha = np.full(self._image.shape[:2] + (1,), 255, dtype=np.uint8)
+                return _ArrayTextureImage(np.concatenate((self._image, alpha), axis=2))
+        log_and_raise("Texture image conversion to " + mode + " is not supported")
+
+    def save(self, fp: Any, format: Optional[str] = None) -> None:
+        """Save the image as PNG bytes to a path or writable file object."""
+        if format is not None and format.lower() != "png":
+            log_and_raise("Only PNG texture export is supported for array-backed textures")
+        data = self._to_png()
+        if hasattr(fp, "write"):
+            fp.write(data)
+            return
+        with open(fp, "wb") as image_file:
+            image_file.write(data)
+
+    def _to_png(self) -> bytes:
+        """Encode the backing image as a PNG byte stream."""
+        if self.mode == "L":
+            color_type = 0
+        elif self.mode == "RGB":
+            color_type = 2
+        elif self.mode == "RGBA":
+            color_type = 6
+        else:
+            log_and_raise("Texture image mode " + self.mode + " cannot be encoded as PNG")
+
+        header = struct.pack(">IIBBBBB", self.width, self.height, 8, color_type, 0, 0, 0)
+        raw_rows = b"".join(b"\x00" + np.ascontiguousarray(row).tobytes() for row in self._image)
+        compressed = zlib.compress(raw_rows)
+        return (
+            b"\x89PNG\r\n\x1a\n"
+            + self._png_chunk(b"IHDR", header)
+            + self._png_chunk(b"IDAT", compressed)
+            + self._png_chunk(b"IEND", b"")
+        )
+
+    @staticmethod
+    def _png_chunk(name: bytes, data: bytes) -> bytes:
+        """Create a PNG chunk."""
+        checksum = zlib.crc32(name + data) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + name + data + struct.pack(">I", checksum)
 
 
 @dataclass
@@ -89,9 +194,14 @@ class Obstacle:
             file_path: Path to save mesh file.
             transform_with_pose: Transform obstacle with pose before saving.
         """
-        mesh_scene = self.get_trimesh_mesh(transform_with_pose=transform_with_pose)
-
-
+        has_texture = (
+            getattr(self, "texture_uvs", None) is not None
+            and getattr(self, "texture_image", None) is not None
+        )
+        mesh_scene = self.get_trimesh_mesh(
+            process=not has_texture,
+            transform_with_pose=transform_with_pose,
+        )
         mesh_scene.export(file_path)
 
     def get_cuboid(self) -> Cuboid:
@@ -473,6 +583,12 @@ class Mesh(Obstacle):
     #: Vertex normals of mesh.
     vertex_normals: Optional[List[List[float]]] = None
 
+    #: Per-vertex UV coordinates for textured visualization/export.
+    texture_uvs: Optional[Union[List[List[float]], np.ndarray, torch.Tensor]] = None
+
+    #: Texture image for ``texture_uvs``. Expected shape is ``(H, W, 3)``.
+    texture_image: Optional[Union[np.ndarray, torch.Tensor]] = None
+
     #: Face colors of mesh. Should be float in range of [0, 1].
     face_colors: Optional[List[List[float]]] = None
 
@@ -566,7 +682,22 @@ class Mesh(Obstacle):
                 vertex_colors=self.vertex_colors,
                 vertex_normals=self.vertex_normals,
                 face_colors=self.face_colors,
+                process=process,
             )
+            if self.texture_uvs is not None and self.texture_image is not None:
+                uv = self.texture_uvs
+                image = self.texture_image
+                if isinstance(uv, torch.Tensor):
+                    uv = uv.detach().cpu().numpy()
+                if isinstance(image, torch.Tensor):
+                    image = image.detach().cpu().numpy()
+                if isinstance(image, np.ndarray):
+                    image = _ArrayTextureImage(image)
+                material = trimesh.visual.material.SimpleMaterial(
+                    image=image,
+                    diffuse=[255, 255, 255, 255],
+                )
+                m.visual = trimesh.visual.texture.TextureVisuals(uv=uv, material=material)
         if transform_with_pose:
             m.apply_transform(self.get_transform_matrix())
 
@@ -584,6 +715,10 @@ class Mesh(Obstacle):
             self.face_colors = self.face_colors.cpu()
         if self.vertex_colors is not None:
             self.vertex_colors = self.vertex_colors.cpu()
+        if isinstance(self.texture_uvs, torch.Tensor):
+            self.texture_uvs = self.texture_uvs.cpu()
+        if isinstance(self.texture_image, torch.Tensor):
+            self.texture_image = self.texture_image.cpu()
         return self
 
     def to_gpu(self):

--- a/curobo/_src/optim/components/best_tracker.py
+++ b/curobo/_src/optim/components/best_tracker.py
@@ -42,10 +42,10 @@ class BestTracker:
             dtype=self.device_cfg.dtype,
         )
         self.iteration = torch.zeros(
-            (num_problems,), device=self.device_cfg.device, dtype=torch.int16
+            (num_problems,), device=self.device_cfg.device, dtype=torch.int32
         )
         self.current_iteration = torch.zeros(
-            (num_problems,), device=self.device_cfg.device, dtype=torch.int16
+            (num_problems,), device=self.device_cfg.device, dtype=torch.int32
         )
         self.previous_step_direction = torch.zeros(
             (num_problems, action_horizon, action_dim),

--- a/curobo/_src/perception/mapper/checkpoint_blocks.py
+++ b/curobo/_src/perception/mapper/checkpoint_blocks.py
@@ -24,12 +24,13 @@ from curobo._src.perception.mapper.constants import (
     PY_HASH_PRIME_Y,
     PY_HASH_PRIME_Z,
     PY_POSITIVE_MASK,
+    _validate_color_grid_size,
 )
 from curobo.logging import log_and_raise
 
 
 BLOCK_CHECKPOINT_FORMAT = "curobo.mapper_blocks"
-BLOCK_CHECKPOINT_SCHEMA_VERSION = 0.8
+BLOCK_CHECKPOINT_SCHEMA_VERSION = 0.9
 
 BLOCK_CHECKPOINT_KEYS = {
     "format",
@@ -46,6 +47,7 @@ BLOCK_METADATA_KEYS = {
     "has_dynamic",
     "has_static",
     "feature_dim",
+    "color_grid_size",
 }
 
 
@@ -63,6 +65,7 @@ def build_block_metadata(tsdf) -> Dict[str, Any]:
         "has_dynamic": bool(data.has_dynamic),
         "has_static": bool(data.has_static),
         "feature_dim": int(data.feature_dim),
+        "color_grid_size": int(data.color_grid_size),
     }
 
 
@@ -162,6 +165,11 @@ def validate_block_metadata(block_metadata: Any) -> None:
     require_positive_float(block_metadata, "voxel_size")
     require_positive_float(block_metadata, "truncation_distance")
     require_positive_int(block_metadata, "block_size")
+    require_positive_int(block_metadata, "color_grid_size")
+    _validate_color_grid_size(
+        int(block_metadata["color_grid_size"]),
+        int(block_metadata["block_size"]),
+    )
     require_nonnegative_int(block_metadata, "feature_dim")
     require_bool(block_metadata, "has_dynamic")
     require_bool(block_metadata, "has_static")
@@ -190,13 +198,15 @@ def validate_block_payload(
     n_blocks = int(coords.shape[0])
     block_size = int(block_metadata["block_size"])
     block_voxels = block_size**3
+    color_grid_size = int(block_metadata["color_grid_size"])
+    color_grid_voxels = color_grid_size**3
     has_dynamic = bool(block_metadata["has_dynamic"])
     has_static = bool(block_metadata["has_static"])
     feature_dim = int(block_metadata["feature_dim"])
 
     expected_keys = {"active_block_coords"}
     if has_dynamic:
-        expected_keys.update(("block_data", "block_rgb"))
+        expected_keys.update(("block_data", "block_grid_rgb"))
     if feature_dim > 0:
         expected_keys.update(("block_features", "block_feature_weight"))
     if has_static:
@@ -208,8 +218,12 @@ def validate_block_payload(
     if has_dynamic:
         block_data = require_tensor(blocks, "block_data", torch.float16)
         require_shape(block_data, "block_data", (n_blocks, block_voxels, 2))
-        block_rgb = require_tensor(blocks, "block_rgb", torch.float16)
-        require_shape(block_rgb, "block_rgb", (n_blocks, 4))
+        block_grid_rgb = require_tensor(blocks, "block_grid_rgb", torch.float16)
+        require_shape(
+            block_grid_rgb,
+            "block_grid_rgb",
+            (n_blocks, color_grid_voxels, 4),
+        )
 
     if feature_dim > 0:
         block_features = require_tensor(blocks, "block_features", torch.float16)
@@ -260,6 +274,12 @@ def validate_block_metadata_for_target(
         log_and_raise(
             f"feature_dim mismatch: checkpoint={block_metadata['feature_dim']}, "
             f"target={data.feature_dim}."
+        )
+    if int(block_metadata["color_grid_size"]) != int(data.color_grid_size):
+        log_and_raise(
+            "color_grid_size mismatch: "
+            f"checkpoint={block_metadata['color_grid_size']}, "
+            f"target={data.color_grid_size}."
         )
 
     source_center = [float(x) for x in block_metadata["grid_center"]]
@@ -431,17 +451,21 @@ def apply_constant_dynamic_weight(
         block_data[..., 0] = (sdf * import_weight).to(dtype=block_data.dtype)
         block_data[..., 1] = observed.to(dtype=block_data.dtype) * import_weight
 
-    block_rgb = blocks["block_rgb"]
-    old_rgb_weight = block_rgb[:, 3].float()
+    block_grid_rgb = blocks["block_grid_rgb"]
+    old_rgb_weight = block_grid_rgb[..., 3].float()
     observed_rgb = old_rgb_weight > 0.0
     if observed_rgb.any():
-        avg_rgb = torch.zeros_like(block_rgb[:, :3], dtype=torch.float32)
+        avg_rgb = torch.zeros_like(block_grid_rgb[..., :3], dtype=torch.float32)
         avg_rgb[observed_rgb] = (
-            block_rgb[:, :3].float()[observed_rgb]
+            block_grid_rgb[..., :3].float()[observed_rgb]
             / old_rgb_weight[observed_rgb].unsqueeze(-1)
         )
-        block_rgb[:, :3] = (avg_rgb * import_weight).to(dtype=block_rgb.dtype)
-        block_rgb[:, 3] = observed_rgb.to(dtype=block_rgb.dtype) * import_weight
+        block_grid_rgb[..., :3] = (avg_rgb * import_weight).to(
+            dtype=block_grid_rgb.dtype
+        )
+        block_grid_rgb[..., 3] = (
+            observed_rgb.to(dtype=block_grid_rgb.dtype) * import_weight
+        )
 
 
 def apply_constant_feature_weight(

--- a/curobo/_src/perception/mapper/checkpoint_blocks.py
+++ b/curobo/_src/perception/mapper/checkpoint_blocks.py
@@ -25,12 +25,13 @@ from curobo._src.perception.mapper.constants import (
     PY_HASH_PRIME_Z,
     PY_POSITIVE_MASK,
     _validate_color_grid_size,
+    _validate_feature_block_grid_size,
 )
 from curobo.logging import log_and_raise
 
 
 BLOCK_CHECKPOINT_FORMAT = "curobo.mapper_blocks"
-BLOCK_CHECKPOINT_SCHEMA_VERSION = 0.9
+BLOCK_CHECKPOINT_SCHEMA_VERSION = 1.0
 
 BLOCK_CHECKPOINT_KEYS = {
     "format",
@@ -47,6 +48,7 @@ BLOCK_METADATA_KEYS = {
     "has_dynamic",
     "has_static",
     "feature_dim",
+    "feature_block_grid_size",
     "color_grid_size",
 }
 
@@ -65,6 +67,7 @@ def build_block_metadata(tsdf) -> Dict[str, Any]:
         "has_dynamic": bool(data.has_dynamic),
         "has_static": bool(data.has_static),
         "feature_dim": int(data.feature_dim),
+        "feature_block_grid_size": int(data.feature_block_grid_size),
         "color_grid_size": int(data.color_grid_size),
     }
 
@@ -166,8 +169,13 @@ def validate_block_metadata(block_metadata: Any) -> None:
     require_positive_float(block_metadata, "truncation_distance")
     require_positive_int(block_metadata, "block_size")
     require_positive_int(block_metadata, "color_grid_size")
+    require_positive_int(block_metadata, "feature_block_grid_size")
     _validate_color_grid_size(
         int(block_metadata["color_grid_size"]),
+        int(block_metadata["block_size"]),
+    )
+    _validate_feature_block_grid_size(
+        int(block_metadata["feature_block_grid_size"]),
         int(block_metadata["block_size"]),
     )
     require_nonnegative_int(block_metadata, "feature_dim")
@@ -200,6 +208,8 @@ def validate_block_payload(
     block_voxels = block_size**3
     color_grid_size = int(block_metadata["color_grid_size"])
     color_grid_voxels = color_grid_size**3
+    feature_block_grid_size = int(block_metadata["feature_block_grid_size"])
+    feature_grid_voxels = feature_block_grid_size**3
     has_dynamic = bool(block_metadata["has_dynamic"])
     has_static = bool(block_metadata["has_static"])
     feature_dim = int(block_metadata["feature_dim"])
@@ -227,11 +237,19 @@ def validate_block_payload(
 
     if feature_dim > 0:
         block_features = require_tensor(blocks, "block_features", torch.float16)
-        require_shape(block_features, "block_features", (n_blocks, feature_dim))
+        require_shape(
+            block_features,
+            "block_features",
+            (n_blocks, feature_grid_voxels, feature_dim),
+        )
         block_feature_weight = require_tensor(
             blocks, "block_feature_weight", torch.float16
         )
-        require_shape(block_feature_weight, "block_feature_weight", (n_blocks,))
+        require_shape(
+            block_feature_weight,
+            "block_feature_weight",
+            (n_blocks, feature_grid_voxels),
+        )
 
     if has_static:
         static_block_data = require_tensor(blocks, "static_block_data", torch.float16)
@@ -280,6 +298,14 @@ def validate_block_metadata_for_target(
             "color_grid_size mismatch: "
             f"checkpoint={block_metadata['color_grid_size']}, "
             f"target={data.color_grid_size}."
+        )
+    if int(block_metadata["feature_block_grid_size"]) != int(
+        data.feature_block_grid_size
+    ):
+        log_and_raise(
+            "feature_block_grid_size mismatch: "
+            f"checkpoint={block_metadata['feature_block_grid_size']}, "
+            f"target={data.feature_block_grid_size}."
         )
 
     source_center = [float(x) for x in block_metadata["grid_center"]]

--- a/curobo/_src/perception/mapper/constants.py
+++ b/curobo/_src/perception/mapper/constants.py
@@ -106,20 +106,41 @@ def _validate_block_size(block_size: int) -> None:
         )
 
 
+def _validate_block_grid_size(
+    grid_size: int,
+    block_size: int,
+    field_name: str,
+) -> None:
+    """Validate a compile-time per-block control-grid resolution."""
+    if not isinstance(grid_size, int) or isinstance(grid_size, bool):
+        log_and_raise(
+            f"{field_name} must be a plain int, got "
+            f"{type(grid_size).__name__} ({grid_size!r})."
+        )
+    if grid_size < 1:
+        log_and_raise(f"{field_name} must be >= 1, got {grid_size}.")
+    if grid_size > block_size:
+        log_and_raise(
+            f"{field_name} must be <= block_size, got "
+            f"{field_name}={grid_size}, block_size={block_size}."
+        )
+
+
 def _validate_color_grid_size(color_grid_size: int, block_size: int) -> None:
     """Validate the compile-time RGB control-grid resolution."""
-    if not isinstance(color_grid_size, int) or isinstance(color_grid_size, bool):
-        log_and_raise(
-            "color_grid_size must be a plain int, got "
-            f"{type(color_grid_size).__name__} ({color_grid_size!r})."
-        )
-    if color_grid_size < 1:
-        log_and_raise(f"color_grid_size must be >= 1, got {color_grid_size}.")
-    if color_grid_size > block_size:
-        log_and_raise(
-            "color_grid_size must be <= block_size, got "
-            f"color_grid_size={color_grid_size}, block_size={block_size}."
-        )
+    _validate_block_grid_size(color_grid_size, block_size, "color_grid_size")
+
+
+def _validate_feature_block_grid_size(
+    feature_block_grid_size: int,
+    block_size: int,
+) -> None:
+    """Validate the compile-time feature control-grid resolution."""
+    _validate_block_grid_size(
+        feature_block_grid_size,
+        block_size,
+        "feature_block_grid_size",
+    )
 
 
 def _validate_feature_channels_per_thread(feature_channels_per_thread: int) -> None:

--- a/curobo/_src/perception/mapper/constants.py
+++ b/curobo/_src/perception/mapper/constants.py
@@ -106,6 +106,22 @@ def _validate_block_size(block_size: int) -> None:
         )
 
 
+def _validate_color_grid_size(color_grid_size: int, block_size: int) -> None:
+    """Validate the compile-time RGB control-grid resolution."""
+    if not isinstance(color_grid_size, int) or isinstance(color_grid_size, bool):
+        log_and_raise(
+            "color_grid_size must be a plain int, got "
+            f"{type(color_grid_size).__name__} ({color_grid_size!r})."
+        )
+    if color_grid_size < 1:
+        log_and_raise(f"color_grid_size must be >= 1, got {color_grid_size}.")
+    if color_grid_size > block_size:
+        log_and_raise(
+            "color_grid_size must be <= block_size, got "
+            f"color_grid_size={color_grid_size}, block_size={block_size}."
+        )
+
+
 def _validate_feature_channels_per_thread(feature_channels_per_thread: int) -> None:
     """Validate feature-channel grouping for the generated integration kernel.
 

--- a/curobo/_src/perception/mapper/integrator_esdf.py
+++ b/curobo/_src/perception/mapper/integrator_esdf.py
@@ -191,6 +191,10 @@ class BlockSparseESDFIntegratorCfg:
     #: Compile-time cap for feature channels accumulated by one tiled
     #: feature-kernel CTA.
     max_feature_tile_channels: int = 4096
+    #: Enable a per-block local RGBW control grid for stored color.
+    use_color_grid: bool = False
+    #: Number of RGBW control points per block edge when ``use_color_grid`` is enabled.
+    color_grid_size: int = 1
     #: Feature integration launch policy: ``"auto"``, ``"grouped"``, or
     #: ``"tiled"``. Resolved by the TSDF integrator to the low-level launch bool.
     feature_integration_kernel: str = "auto"
@@ -286,6 +290,15 @@ class BlockSparseESDFIntegratorCfg:
             log_and_raise(
                 "max_support_pixels_per_block_camera must be positive: "
                 f"{self.max_support_pixels_per_block_camera}"
+            )
+        if not isinstance(self.use_color_grid, bool):
+            log_and_raise(
+                "use_color_grid must be bool, got "
+                f"{type(self.use_color_grid).__name__}."
+            )
+        if self.color_grid_size <= 0:
+            log_and_raise(
+                f"color_grid_size must be positive, got color_grid_size={self.color_grid_size}."
             )
         _validate_feature_integration_kernel(self.feature_integration_kernel)
         if not isinstance(self.profile_integration_kernel_timings, bool):
@@ -387,6 +400,8 @@ class BlockSparseESDFIntegrator:
             max_support_pixels_per_block_camera=config.max_support_pixels_per_block_camera,
             feature_channels_per_thread=config.feature_channels_per_thread,
             max_feature_tile_channels=config.max_feature_tile_channels,
+            use_color_grid=config.use_color_grid,
+            color_grid_size=config.color_grid_size,
             feature_integration_kernel=config.feature_integration_kernel,
             profile_integration_kernel_timings=config.profile_integration_kernel_timings,
             accumulator_w_max=config.accumulator_w_max,
@@ -709,6 +724,7 @@ class BlockSparseESDFIntegrator:
         refine_iterations: int = 2,
         surface_only: bool = True,
         level: float = 0.0,
+        approximate: bool = False,
     ) -> Mesh:
         """Extract mesh using GPU marching cubes.
 
@@ -716,6 +732,8 @@ class BlockSparseESDFIntegrator:
             refine_iterations: Newton-Raphson iterations for vertex refinement.
             surface_only: Only extract mesh near surface (|sdf| < truncation).
             level: Isosurface level (typically 0.0).
+            approximate: If True, use the approximate triangle-soup extractor
+                instead of the shared-vertex extractor.
 
         Returns:
             Mesh object with vertices, faces, and colors.
@@ -724,6 +742,7 @@ class BlockSparseESDFIntegrator:
             level=level,
             refine_iterations=refine_iterations,
             surface_only=surface_only,
+            approximate=approximate,
         )
 
         return mesh

--- a/curobo/_src/perception/mapper/integrator_esdf.py
+++ b/curobo/_src/perception/mapper/integrator_esdf.py
@@ -56,6 +56,7 @@ from curobo._src.perception.mapper.block_allocation import (
 )
 from curobo._src.perception.mapper.constants import (
     DEFAULT_HASH_LAYOUT,
+    _validate_color_grid_size,
     _validate_feature_channels_per_thread,
     _validate_feature_grid_shape,
     _validate_feature_integration_kernel,
@@ -191,9 +192,8 @@ class BlockSparseESDFIntegratorCfg:
     #: Compile-time cap for feature channels accumulated by one tiled
     #: feature-kernel CTA.
     max_feature_tile_channels: int = 4096
-    #: Enable a per-block local RGBW control grid for stored color.
-    use_color_grid: bool = False
-    #: Number of RGBW control points per block edge when ``use_color_grid`` is enabled.
+    #: Number of RGBW control points per block edge. This is a construction-time
+    #: kernel specialization value.
     color_grid_size: int = 1
     #: Feature integration launch policy: ``"auto"``, ``"grouped"``, or
     #: ``"tiled"``. Resolved by the TSDF integrator to the low-level launch bool.
@@ -291,15 +291,7 @@ class BlockSparseESDFIntegratorCfg:
                 "max_support_pixels_per_block_camera must be positive: "
                 f"{self.max_support_pixels_per_block_camera}"
             )
-        if not isinstance(self.use_color_grid, bool):
-            log_and_raise(
-                "use_color_grid must be bool, got "
-                f"{type(self.use_color_grid).__name__}."
-            )
-        if self.color_grid_size <= 0:
-            log_and_raise(
-                f"color_grid_size must be positive, got color_grid_size={self.color_grid_size}."
-            )
+        _validate_color_grid_size(self.color_grid_size, self.block_size)
         _validate_feature_integration_kernel(self.feature_integration_kernel)
         if not isinstance(self.profile_integration_kernel_timings, bool):
             log_and_raise(
@@ -400,7 +392,6 @@ class BlockSparseESDFIntegrator:
             max_support_pixels_per_block_camera=config.max_support_pixels_per_block_camera,
             feature_channels_per_thread=config.feature_channels_per_thread,
             max_feature_tile_channels=config.max_feature_tile_channels,
-            use_color_grid=config.use_color_grid,
             color_grid_size=config.color_grid_size,
             feature_integration_kernel=config.feature_integration_kernel,
             profile_integration_kernel_timings=config.profile_integration_kernel_timings,

--- a/curobo/_src/perception/mapper/integrator_esdf.py
+++ b/curobo/_src/perception/mapper/integrator_esdf.py
@@ -44,6 +44,7 @@ Usage:
 """
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Tuple
 
@@ -56,12 +57,13 @@ from curobo._src.perception.mapper.block_allocation import (
 )
 from curobo._src.perception.mapper.constants import (
     DEFAULT_HASH_LAYOUT,
+    _validate_block_size,
     _validate_color_grid_size,
+    _validate_feature_block_grid_size,
     _validate_feature_channels_per_thread,
     _validate_feature_grid_shape,
     _validate_feature_integration_kernel,
     _validate_lidar_config,
-    _validate_block_size,
     validate_grid_shape_for_hash_layout,
 )
 from curobo._src.perception.mapper.esdf.edt_jump_flooding import JumpFloodingEDT
@@ -88,9 +90,8 @@ from curobo._src.perception.mapper.storage import (
 from curobo._src.types.camera import CameraObservation
 from curobo._src.types.lidar import LidarObservation
 from curobo._src.util.cuda_graph_util import GraphExecutor
-from curobo._src.util.logging import log_info
+from curobo._src.util.logging import log_and_raise, log_info
 from curobo._src.util.torch_util import profile_class_methods
-from curobo.logging import log_and_raise
 
 
 @dataclass
@@ -150,6 +151,13 @@ class BlockSparseESDFIntegratorCfg:
     grid_shape: Tuple[int, int, int] = None
     image_height: Optional[int] = None  # For buffer pre-allocation
     image_width: Optional[int] = None  # For buffer pre-allocation
+    #: Number of RGB cameras used by projective texture export. Defaults to
+    #: ``num_cameras`` when unset.
+    texture_num_cameras: Optional[int] = None
+    #: RGB texture camera image height in pixels. Defaults to ``image_height``.
+    texture_camera_image_height: Optional[int] = None
+    #: RGB texture camera image width in pixels. Defaults to ``image_width``.
+    texture_camera_image_width: Optional[int] = None
     lidar_num_sensors: int = 0
     lidar_image_height: Optional[int] = None
     lidar_image_width: Optional[int] = None
@@ -174,6 +182,9 @@ class BlockSparseESDFIntegratorCfg:
     block_size: int = 8
     #: Per-block feature channel dimensionality. 0 disables features.
     feature_dim: int = 0
+    #: Number of feature control points per block edge. Independent from the
+    #: incoming camera and LiDAR feature image dimensions.
+    feature_block_grid_size: int = 1
     #: Compile-time feature-grid height. Required when ``feature_dim > 0``;
     #: must be ``None`` when features are disabled.
     feature_grid_height: Optional[int] = None
@@ -291,7 +302,49 @@ class BlockSparseESDFIntegratorCfg:
                 "max_support_pixels_per_block_camera must be positive: "
                 f"{self.max_support_pixels_per_block_camera}"
             )
+        if self.image_height is None or self.image_width is None:
+            log_and_raise(
+                "BlockSparseESDFIntegratorCfg requires image_height and image_width. "
+                f"Got image_height={self.image_height}, image_width={self.image_width}."
+            )
+        if self.image_height <= 0 or self.image_width <= 0:
+            log_and_raise(
+                "image_height and image_width must be positive, got "
+                f"image_height={self.image_height}, image_width={self.image_width}."
+            )
+        if self.num_cameras <= 0:
+            log_and_raise(f"num_cameras must be positive, got num_cameras={self.num_cameras}.")
+        if (
+            self.texture_camera_image_height is None
+        ) != (self.texture_camera_image_width is None):
+            log_and_raise(
+                "texture_camera_image_height and texture_camera_image_width must be "
+                "specified together."
+            )
+        if self.texture_num_cameras is None:
+            self.texture_num_cameras = self.num_cameras
+        if self.texture_camera_image_height is None:
+            self.texture_camera_image_height = self.image_height
+            self.texture_camera_image_width = self.image_width
+        if self.texture_num_cameras <= 0:
+            log_and_raise(
+                "texture_num_cameras must be positive, got "
+                f"texture_num_cameras={self.texture_num_cameras}."
+            )
+        if (
+            self.texture_camera_image_height <= 0
+            or self.texture_camera_image_width <= 0
+        ):
+            log_and_raise(
+                "texture_camera_image_height and texture_camera_image_width must be "
+                "positive, got "
+                f"{self.texture_camera_image_height}x{self.texture_camera_image_width}."
+            )
         _validate_color_grid_size(self.color_grid_size, self.block_size)
+        _validate_feature_block_grid_size(
+            self.feature_block_grid_size,
+            self.block_size,
+        )
         _validate_feature_integration_kernel(self.feature_integration_kernel)
         if not isinstance(self.profile_integration_kernel_timings, bool):
             log_and_raise(
@@ -364,6 +417,9 @@ class BlockSparseESDFIntegrator:
             grid_shape=config.grid_shape,
             image_height=config.image_height,
             image_width=config.image_width,
+            texture_num_cameras=config.texture_num_cameras,
+            texture_camera_image_height=config.texture_camera_image_height,
+            texture_camera_image_width=config.texture_camera_image_width,
             lidar_num_sensors=config.lidar_num_sensors,
             lidar_image_height=config.lidar_image_height,
             lidar_image_width=config.lidar_image_width,
@@ -386,6 +442,7 @@ class BlockSparseESDFIntegrator:
             device=config.device,
             block_size=config.block_size,
             feature_dim=config.feature_dim,
+            feature_block_grid_size=config.feature_block_grid_size,
             feature_grid_height=config.feature_grid_height,
             feature_grid_width=config.feature_grid_width,
             max_visible_blocks_per_integration=config.max_visible_blocks_per_integration,
@@ -712,19 +769,16 @@ class BlockSparseESDFIntegrator:
     # =========================================================================
     def extract_mesh(
         self,
-        refine_iterations: int = 2,
+        refine_iterations: int = 0,
         surface_only: bool = True,
         level: float = 0.0,
-        approximate: bool = False,
     ) -> Mesh:
-        """Extract mesh using GPU marching cubes.
+        """Extract a triangle-soup mesh using GPU marching cubes.
 
         Args:
             refine_iterations: Newton-Raphson iterations for vertex refinement.
             surface_only: Only extract mesh near surface (|sdf| < truncation).
             level: Isosurface level (typically 0.0).
-            approximate: If True, use the approximate triangle-soup extractor
-                instead of the shared-vertex extractor.
 
         Returns:
             Mesh object with vertices, faces, and colors.
@@ -733,15 +787,42 @@ class BlockSparseESDFIntegrator:
             level=level,
             refine_iterations=refine_iterations,
             surface_only=surface_only,
-            approximate=approximate,
         )
 
         return mesh
+
+    def extract_textured_mesh(
+        self,
+        texture_observations: CameraObservation | Sequence[CameraObservation],
+        refine_iterations: int = 0,
+        surface_only: bool = True,
+        level: float = 0.0,
+        camera_min_distance: Optional[float] = None,
+        camera_max_distance: Optional[float] = None,
+        texture_depth_tolerance_m: Optional[float] = None,
+    ) -> Mesh:
+        """Extract a TSDF mesh with visibility-tested RGB texture."""
+        return self._tsdf_integrator.extract_textured_mesh(
+            texture_observations=texture_observations,
+            refine_iterations=refine_iterations,
+            surface_only=surface_only,
+            level=level,
+            camera_min_distance=camera_min_distance,
+            camera_max_distance=camera_max_distance,
+            texture_depth_tolerance_m=texture_depth_tolerance_m,
+        )
 
     def extract_occupied_voxels(
         self,
         surface_only: bool = False,
         sdf_threshold: Optional[float] = None,
+        *,
+        subvoxel_factor: int = 1,
+        max_points: Optional[int] = None,
+        texture_observations: CameraObservation | Sequence[CameraObservation] | None = None,
+        camera_min_distance: Optional[float] = None,
+        camera_max_distance: Optional[float] = None,
+        texture_depth_tolerance_m: Optional[float] = None,
     ) -> OccupiedVoxels:
         """Extract occupied voxel centers and per-voxel block indices.
 
@@ -757,6 +838,12 @@ class BlockSparseESDFIntegrator:
         return self._tsdf_integrator.extract_occupied_voxels(
             surface_only=surface_only,
             sdf_threshold=sdf_threshold,
+            subvoxel_factor=subvoxel_factor,
+            max_points=max_points,
+            texture_observations=texture_observations,
+            camera_min_distance=camera_min_distance,
+            camera_max_distance=camera_max_distance,
+            texture_depth_tolerance_m=texture_depth_tolerance_m,
         )
 
     def extract_matching_feature_voxels(

--- a/curobo/_src/perception/mapper/integrator_tsdf.py
+++ b/curobo/_src/perception/mapper/integrator_tsdf.py
@@ -66,6 +66,7 @@ from curobo._src.perception.mapper.kernel.wp_voxel_extraction import (
     extract_surface_voxels_block_sparse,
 )
 from curobo._src.perception.mapper.mesh_extractor import (
+    extract_approximate_mesh_block_sparse,
     extract_mesh_block_sparse,
 )
 from curobo._src.perception.mapper.storage import (
@@ -165,6 +166,12 @@ class BlockSparseTSDFIntegratorCfg:
     #: Compile-time cap for feature channels accumulated by one tiled
     #: feature-kernel CTA.
     max_feature_tile_channels: int = 4096
+    #: Enable a per-block local RGBW control grid. This keeps legacy block RGB
+    #: available while allowing larger block sizes to retain spatial color.
+    use_color_grid: bool = False
+    #: Number of RGBW control points per block edge when ``use_color_grid`` is
+    #: enabled. Total controls per block are ``color_grid_size ** 3``.
+    color_grid_size: int = 1
     #: Feature integration launch policy: ``"auto"``, ``"grouped"``, or
     #: ``"tiled"``. Resolved to a low-level tiled bool at construction time.
     feature_integration_kernel: str = "auto"
@@ -284,6 +291,15 @@ class BlockSparseTSDFIntegratorCfg:
                 f"max_support_pixels_per_block_camera="
                 f"{self.max_support_pixels_per_block_camera}."
             )
+        if not isinstance(self.use_color_grid, bool):
+            log_and_raise(
+                "use_color_grid must be bool, got "
+                f"{type(self.use_color_grid).__name__}."
+            )
+        if self.color_grid_size <= 0:
+            log_and_raise(
+                f"color_grid_size must be positive, got color_grid_size={self.color_grid_size}."
+            )
         _validate_feature_integration_kernel(self.feature_integration_kernel)
         if not isinstance(self.profile_integration_kernel_timings, bool):
             log_and_raise(
@@ -364,6 +380,8 @@ class BlockSparseTSDFIntegrator:
             feature_channels_per_thread=config.feature_channels_per_thread,
             max_feature_tile_channels=config.max_feature_tile_channels,
             max_support_pixels_per_block_camera=config.max_support_pixels_per_block_camera,
+            use_color_grid=config.use_color_grid,
+            color_grid_size=config.color_grid_size,
             accumulator_w_max=config.accumulator_w_max,
         )
         if kernels is None:
@@ -875,6 +893,7 @@ class BlockSparseTSDFIntegrator:
         refine_iterations: int = 2,
         surface_only: bool = False,
         level: float = 0.0,
+        approximate: bool = False,
     ) -> Mesh:
         """Extract mesh from the TSDF using marching cubes.
 
@@ -886,23 +905,35 @@ class BlockSparseTSDFIntegrator:
                 Excludes triangles from regions deep inside the object where TSDF
                 is clamped to -truncation_distance.
             level: Isosurface level (typically 0.0).
+            approximate: If True, use the approximate triangle-soup extractor
+                instead of the shared-vertex extractor.
 
 
         Returns:
             Mesh object with vertices, triangles, normals, and colors.
         """
-        vertices, triangles, normals, colors = extract_mesh_block_sparse(
-            self._tsdf,
-            level=level,
-            surface_only=surface_only,
-            refine_iterations=refine_iterations,
-            minimum_tsdf_weight=self.config.minimum_tsdf_weight,
-        )
+        if approximate:
+            vertices, triangles, normals, colors = extract_approximate_mesh_block_sparse(
+                self._tsdf,
+                level=level,
+                surface_only=surface_only,
+                minimum_tsdf_weight=self.config.minimum_tsdf_weight,
+            )
+        else:
+            vertices, triangles, normals, colors = extract_mesh_block_sparse(
+                self._tsdf,
+                level=level,
+                surface_only=surface_only,
+                refine_iterations=refine_iterations,
+                minimum_tsdf_weight=self.config.minimum_tsdf_weight,
+            )
 
         # Convert tensors to lists for Mesh class
         # faces should be (N, 3) for trimesh compatibility
         return Mesh(
-            name="block_sparse_tsdf_mesh",
+            name="block_sparse_tsdf_approximate_mesh"
+            if approximate
+            else "block_sparse_tsdf_mesh",
             vertices=vertices,  # .cpu().tolist(),
             faces=triangles,  # .cpu().tolist(),  # Keep as (N, 3), not flattened
             vertex_colors=(colors.float() / 255.0),  # .cpu().tolist(),
@@ -914,6 +945,7 @@ class BlockSparseTSDFIntegrator:
         level: float = 0.0,
         surface_only: bool = False,
         refine_iterations: int = 0,
+        approximate: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Extract mesh as raw tensors.
 
@@ -925,6 +957,8 @@ class BlockSparseTSDFIntegrator:
             refine_iterations: Number of Newton-Raphson iterations for vertex refinement.
                 0 = no refinement (linear interpolation only). Higher values (2-5)
                 produce smoother meshes at the cost of more computation.
+            approximate: If True, use the approximate triangle-soup extractor
+                instead of the shared-vertex extractor.
 
         Returns:
             Tuple of (vertices, triangles, normals, colors):
@@ -933,6 +967,13 @@ class BlockSparseTSDFIntegrator:
                 - normals: (N, 3) float32
                 - colors: (N, 3) uint8
         """
+        if approximate:
+            return extract_approximate_mesh_block_sparse(
+                self._tsdf,
+                level=level,
+                surface_only=surface_only,
+                minimum_tsdf_weight=self.config.minimum_tsdf_weight,
+            )
         return extract_mesh_block_sparse(
             self._tsdf,
             level=level,

--- a/curobo/_src/perception/mapper/integrator_tsdf.py
+++ b/curobo/_src/perception/mapper/integrator_tsdf.py
@@ -34,6 +34,7 @@ from curobo._src.perception.mapper.block_allocation import (
 )
 from curobo._src.perception.mapper.constants import (
     DEFAULT_HASH_LAYOUT,
+    _validate_color_grid_size,
     _validate_feature_channels_per_thread,
     _validate_feature_grid_shape,
     _validate_feature_integration_kernel,
@@ -166,11 +167,9 @@ class BlockSparseTSDFIntegratorCfg:
     #: Compile-time cap for feature channels accumulated by one tiled
     #: feature-kernel CTA.
     max_feature_tile_channels: int = 4096
-    #: Enable a per-block local RGBW control grid. This keeps legacy block RGB
-    #: available while allowing larger block sizes to retain spatial color.
-    use_color_grid: bool = False
-    #: Number of RGBW control points per block edge when ``use_color_grid`` is
-    #: enabled. Total controls per block are ``color_grid_size ** 3``.
+    #: Number of RGBW control points per block edge. This is a construction-time
+    #: kernel specialization value. Total controls per block are
+    #: ``color_grid_size ** 3``.
     color_grid_size: int = 1
     #: Feature integration launch policy: ``"auto"``, ``"grouped"``, or
     #: ``"tiled"``. Resolved to a low-level tiled bool at construction time.
@@ -179,7 +178,7 @@ class BlockSparseTSDFIntegratorCfg:
     #: ``get_stats()["last_integration_kernel_timings_ms"]``.
     profile_integration_kernel_timings: bool = False
     #: Upper bound on per-block accumulator weight after each frame. Caps
-    #: the fp16 weighted-sum magnitudes in ``block_rgb`` and
+    #: the fp16 weighted-sum magnitudes in ``block_grid_rgb`` and
     #: ``block_features``; also sets EMA decay rate
     #: ``W_max / mean_per_frame_weight`` for old observations. See
     #: :attr:`BlockSparseTSDFCfg.accumulator_w_max`.
@@ -291,15 +290,7 @@ class BlockSparseTSDFIntegratorCfg:
                 f"max_support_pixels_per_block_camera="
                 f"{self.max_support_pixels_per_block_camera}."
             )
-        if not isinstance(self.use_color_grid, bool):
-            log_and_raise(
-                "use_color_grid must be bool, got "
-                f"{type(self.use_color_grid).__name__}."
-            )
-        if self.color_grid_size <= 0:
-            log_and_raise(
-                f"color_grid_size must be positive, got color_grid_size={self.color_grid_size}."
-            )
+        _validate_color_grid_size(self.color_grid_size, self.block_size)
         _validate_feature_integration_kernel(self.feature_integration_kernel)
         if not isinstance(self.profile_integration_kernel_timings, bool):
             log_and_raise(
@@ -380,7 +371,6 @@ class BlockSparseTSDFIntegrator:
             feature_channels_per_thread=config.feature_channels_per_thread,
             max_feature_tile_channels=config.max_feature_tile_channels,
             max_support_pixels_per_block_camera=config.max_support_pixels_per_block_camera,
-            use_color_grid=config.use_color_grid,
             color_grid_size=config.color_grid_size,
             accumulator_w_max=config.accumulator_w_max,
         )

--- a/curobo/_src/perception/mapper/integrator_tsdf.py
+++ b/curobo/_src/perception/mapper/integrator_tsdf.py
@@ -22,6 +22,7 @@ Example:
 """
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Tuple
 
@@ -34,12 +35,13 @@ from curobo._src.perception.mapper.block_allocation import (
 )
 from curobo._src.perception.mapper.constants import (
     DEFAULT_HASH_LAYOUT,
+    _validate_block_size,
     _validate_color_grid_size,
+    _validate_feature_block_grid_size,
     _validate_feature_channels_per_thread,
     _validate_feature_grid_shape,
     _validate_feature_integration_kernel,
     _validate_lidar_config,
-    _validate_block_size,
     resolve_feature_integration_kernel,
     validate_grid_shape_for_hash_layout,
 )
@@ -66,10 +68,12 @@ from curobo._src.perception.mapper.kernel.wp_voxel_extraction import (
     extract_occupied_voxels_block_sparse,
     extract_surface_voxels_block_sparse,
 )
-from curobo._src.perception.mapper.mesh_extractor import (
-    extract_approximate_mesh_block_sparse,
-    extract_mesh_block_sparse,
+from curobo._src.perception.mapper.mesh_extractor import extract_mesh_block_sparse
+from curobo._src.perception.mapper.projector_texture import (
+    ProjectiveTextureProjector,
+    ProjectiveTextureProjectorCfg,
 )
+from curobo._src.perception.mapper.renderer import BlockSparseTSDFRenderer
 from curobo._src.perception.mapper.storage import (
     BlockSparseTSDF,
     BlockSparseTSDFCfg,
@@ -78,9 +82,8 @@ from curobo._src.perception.mapper.storage import (
 )
 from curobo._src.types.camera import CameraObservation
 from curobo._src.types.lidar import LidarObservation
-from curobo._src.util.logging import log_info
+from curobo._src.util.logging import log_and_raise, log_info
 from curobo._src.util.torch_util import profile_class_methods
-from curobo.logging import log_and_raise
 
 
 @dataclass
@@ -130,6 +133,13 @@ class BlockSparseTSDFIntegratorCfg:
     roughness: float = 3.0  # Geometric complexity multiplier
     image_height: Optional[int] = None  # For buffer pre-allocation
     image_width: Optional[int] = None  # For buffer pre-allocation
+    #: Number of RGB cameras used by projective texture export. Defaults to
+    #: ``num_cameras`` when unset.
+    texture_num_cameras: Optional[int] = None
+    #: RGB texture camera image height in pixels. Defaults to ``image_height``.
+    texture_camera_image_height: Optional[int] = None
+    #: RGB texture camera image width in pixels. Defaults to ``image_width``.
+    texture_camera_image_width: Optional[int] = None
     lidar_num_sensors: int = 0
     lidar_image_height: Optional[int] = None
     lidar_image_width: Optional[int] = None
@@ -148,6 +158,10 @@ class BlockSparseTSDFIntegratorCfg:
     block_size: int = 8
     #: Per-block feature channel dimensionality. 0 disables features.
     feature_dim: int = 0
+    #: Number of feature control points per block edge. Independent from
+    #: ``feature_grid_height`` and ``feature_grid_width``, which describe the
+    #: incoming 2D camera feature image.
+    feature_block_grid_size: int = 1
     #: Compile-time feature-grid height. Required when ``feature_dim > 0``;
     #: must be ``None`` when features are disabled.
     feature_grid_height: Optional[int] = None
@@ -177,8 +191,8 @@ class BlockSparseTSDFIntegratorCfg:
     #: Record per-kernel integration timings into
     #: ``get_stats()["last_integration_kernel_timings_ms"]``.
     profile_integration_kernel_timings: bool = False
-    #: Upper bound on per-block accumulator weight after each frame. Caps
-    #: the fp16 weighted-sum magnitudes in ``block_grid_rgb`` and
+    #: Upper bound on each RGB or feature-grid node's weight after each frame.
+    #: Caps the fp16 weighted-sum magnitudes in ``block_grid_rgb`` and
     #: ``block_features``; also sets EMA decay rate
     #: ``W_max / mean_per_frame_weight`` for old observations. See
     #: :attr:`BlockSparseTSDFCfg.accumulator_w_max`.
@@ -273,6 +287,32 @@ class BlockSparseTSDFIntegratorCfg:
             )
         if self.num_cameras <= 0:
             log_and_raise(f"num_cameras must be positive, got num_cameras={self.num_cameras}.")
+        if (
+            self.texture_camera_image_height is None
+        ) != (self.texture_camera_image_width is None):
+            log_and_raise(
+                "texture_camera_image_height and texture_camera_image_width must be "
+                "specified together."
+            )
+        if self.texture_num_cameras is None:
+            self.texture_num_cameras = self.num_cameras
+        if self.texture_camera_image_height is None:
+            self.texture_camera_image_height = self.image_height
+            self.texture_camera_image_width = self.image_width
+        if self.texture_num_cameras <= 0:
+            log_and_raise(
+                "texture_num_cameras must be positive, got "
+                f"texture_num_cameras={self.texture_num_cameras}."
+            )
+        if (
+            self.texture_camera_image_height <= 0
+            or self.texture_camera_image_width <= 0
+        ):
+            log_and_raise(
+                "texture_camera_image_height and texture_camera_image_width must be "
+                "positive, got "
+                f"{self.texture_camera_image_height}x{self.texture_camera_image_width}."
+            )
         _validate_feature_channels_per_thread(self.feature_channels_per_thread)
         _validate_feature_grid_shape(
             self.feature_dim,
@@ -291,6 +331,10 @@ class BlockSparseTSDFIntegratorCfg:
                 f"{self.max_support_pixels_per_block_camera}."
             )
         _validate_color_grid_size(self.color_grid_size, self.block_size)
+        _validate_feature_block_grid_size(
+            self.feature_block_grid_size,
+            self.block_size,
+        )
         _validate_feature_integration_kernel(self.feature_integration_kernel)
         if not isinstance(self.profile_integration_kernel_timings, bool):
             log_and_raise(
@@ -366,6 +410,7 @@ class BlockSparseTSDFIntegrator:
             static_obstacle_color=config.static_obstacle_color,
             block_size=config.block_size,
             feature_dim=config.feature_dim,
+            feature_block_grid_size=config.feature_block_grid_size,
             feature_grid_height=config.feature_grid_height,
             feature_grid_width=config.feature_grid_width,
             feature_channels_per_thread=config.feature_channels_per_thread,
@@ -377,6 +422,19 @@ class BlockSparseTSDFIntegrator:
         if kernels is None:
             kernels = make_block_sparse_kernels(config)
         self._tsdf = BlockSparseTSDF(tsdf_config, kernels=kernels)
+        texture_renderer = BlockSparseTSDFRenderer(self)
+        self._texture_projector = ProjectiveTextureProjector(
+            tsdf=self._tsdf,
+            renderer=texture_renderer,
+            config=ProjectiveTextureProjectorCfg(
+                texture_num_cameras=int(config.texture_num_cameras),
+                image_height=int(config.texture_camera_image_height),
+                image_width=int(config.texture_camera_image_width),
+                depth_minimum_distance=float(config.depth_minimum_distance),
+                depth_maximum_distance=float(config.depth_maximum_distance),
+                voxel_size=float(config.voxel_size),
+            ),
+        )
 
         # Frame counter for periodic operations
         self._frame_count = 0
@@ -880,12 +938,11 @@ class BlockSparseTSDFIntegrator:
 
     def extract_mesh(
         self,
-        refine_iterations: int = 2,
+        refine_iterations: int = 0,
         surface_only: bool = False,
         level: float = 0.0,
-        approximate: bool = False,
     ) -> Mesh:
-        """Extract mesh from the TSDF using marching cubes.
+        """Extract a triangle-soup mesh from the TSDF using marching cubes.
 
         Args:
             refine_iterations: Number of Newton-Raphson iterations for vertex refinement.
@@ -895,35 +952,25 @@ class BlockSparseTSDFIntegrator:
                 Excludes triangles from regions deep inside the object where TSDF
                 is clamped to -truncation_distance.
             level: Isosurface level (typically 0.0).
-            approximate: If True, use the approximate triangle-soup extractor
-                instead of the shared-vertex extractor.
-
 
         Returns:
-            Mesh object with vertices, triangles, normals, and colors.
+            Mesh object with one unique vertex for each triangle corner.
         """
-        if approximate:
-            vertices, triangles, normals, colors = extract_approximate_mesh_block_sparse(
-                self._tsdf,
-                level=level,
-                surface_only=surface_only,
-                minimum_tsdf_weight=self.config.minimum_tsdf_weight,
-            )
-        else:
-            vertices, triangles, normals, colors = extract_mesh_block_sparse(
-                self._tsdf,
-                level=level,
-                surface_only=surface_only,
-                refine_iterations=refine_iterations,
-                minimum_tsdf_weight=self.config.minimum_tsdf_weight,
-            )
+        vertices, normals, colors = extract_mesh_block_sparse(
+            self._tsdf,
+            level=level,
+            surface_only=surface_only,
+            refine_iterations=refine_iterations,
+            minimum_tsdf_weight=self.config.minimum_tsdf_weight,
+        )
+        triangles = torch.arange(
+            vertices.shape[0], dtype=torch.int32, device=vertices.device
+        ).view(-1, 3)
 
         # Convert tensors to lists for Mesh class
         # faces should be (N, 3) for trimesh compatibility
         return Mesh(
-            name="block_sparse_tsdf_approximate_mesh"
-            if approximate
-            else "block_sparse_tsdf_mesh",
+            name="block_sparse_tsdf_mesh",
             vertices=vertices,  # .cpu().tolist(),
             faces=triangles,  # .cpu().tolist(),  # Keep as (N, 3), not flattened
             vertex_colors=(colors.float() / 255.0),  # .cpu().tolist(),
@@ -935,9 +982,8 @@ class BlockSparseTSDFIntegrator:
         level: float = 0.0,
         surface_only: bool = False,
         refine_iterations: int = 0,
-        approximate: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Extract mesh as raw tensors.
+        """Extract a triangle-soup mesh as raw tensors.
 
         Args:
             level: Isosurface level (typically 0.0).
@@ -947,29 +993,189 @@ class BlockSparseTSDFIntegrator:
             refine_iterations: Number of Newton-Raphson iterations for vertex refinement.
                 0 = no refinement (linear interpolation only). Higher values (2-5)
                 produce smoother meshes at the cost of more computation.
-            approximate: If True, use the approximate triangle-soup extractor
-                instead of the shared-vertex extractor.
 
         Returns:
             Tuple of (vertices, triangles, normals, colors):
-                - vertices: (N, 3) float32
-                - triangles: (M, 3) int32
+                - vertices: (3 * M, 3) float32
+                - triangles: (M, 3) int32 identity indices into ``vertices``
                 - normals: (N, 3) float32
                 - colors: (N, 3) uint8
         """
-        if approximate:
-            return extract_approximate_mesh_block_sparse(
-                self._tsdf,
-                level=level,
-                surface_only=surface_only,
-                minimum_tsdf_weight=self.config.minimum_tsdf_weight,
-            )
-        return extract_mesh_block_sparse(
+        vertices, normals, colors = extract_mesh_block_sparse(
             self._tsdf,
             level=level,
             surface_only=surface_only,
             refine_iterations=refine_iterations,
             minimum_tsdf_weight=self.config.minimum_tsdf_weight,
+        )
+        triangles = torch.arange(
+            vertices.shape[0], dtype=torch.int32, device=vertices.device
+        ).view(-1, 3)
+        return vertices, triangles, normals, colors
+
+    def extract_textured_mesh(
+        self,
+        texture_observations: CameraObservation | Sequence[CameraObservation],
+        refine_iterations: int = 0,
+        surface_only: bool = True,
+        level: float = 0.0,
+        camera_min_distance: Optional[float] = None,
+        camera_max_distance: Optional[float] = None,
+        texture_depth_tolerance_m: Optional[float] = None,
+    ) -> Mesh:
+        """Extract a mesh with visibility-tested RGB texture.
+
+        The TSDF geometry can come from camera or LiDAR integration. Texture
+        projection consumes RGB images and aligned visibility depth. When an
+        observation omits depth, visibility depth is rendered from this TSDF.
+
+        Args:
+            texture_observations: Camera observation or sequence of camera
+                observations containing ``rgb_image``, ``intrinsics``, and
+                ``pose``. RGB tensors must be ``uint8``. Optional depth tensors
+                must be float32 camera-frame z in meters.
+            refine_iterations: Newton-Raphson iterations for vertex refinement.
+            surface_only: Only extract mesh near surface.
+            level: Isosurface level.
+            camera_min_distance: Minimum positive camera-frame Z distance used
+                for projection. Defaults to the mapper depth minimum.
+            camera_max_distance: Maximum camera-frame Z distance used for
+                projection. Defaults to the mapper depth maximum.
+            texture_depth_tolerance_m: Absolute visibility-depth tolerance. If
+                None, each sample uses ``max(2 * voxel_size, 0.01 * projected_z)``.
+
+        Returns:
+            Mesh with triangle-soup geometry, vertex colors, per-vertex UVs,
+            and an RGB texture atlas. Triangles that cannot be projected into
+            any RGB observation receive fallback UV patches filled from voxel
+            colors.
+        """
+        projection = self._texture_projector.prepare_mesh_projection(
+            texture_observations,
+            texture_depth_tolerance_m=texture_depth_tolerance_m,
+        )
+        vertices, triangles, normals, colors = self.extract_mesh_tensors(
+            level=level,
+            surface_only=surface_only,
+            refine_iterations=refine_iterations,
+        )
+        return self._texture_projector.project_mesh(
+            vertices,
+            triangles,
+            normals,
+            colors,
+            projection,
+            camera_min_distance=camera_min_distance,
+            camera_max_distance=camera_max_distance,
+        )
+
+    @staticmethod
+    def _validate_subvoxel_factor(subvoxel_factor: int) -> int:
+        """Return a positive integer subvoxel factor or raise."""
+        try:
+            factor = int(subvoxel_factor)
+        except (TypeError, ValueError):
+            log_and_raise(
+                f"subvoxel_factor must be a positive integer, got {subvoxel_factor}."
+            )
+        if isinstance(subvoxel_factor, bool) or factor != subvoxel_factor:
+            log_and_raise(
+                f"subvoxel_factor must be a positive integer, got {subvoxel_factor}."
+            )
+        if factor <= 0:
+            log_and_raise(f"subvoxel_factor must be positive, got {subvoxel_factor}.")
+        return factor
+
+    @staticmethod
+    def _validate_max_points(max_points: Optional[int]) -> Optional[int]:
+        """Return a positive integer point cap or ``None``."""
+        if max_points is None:
+            return None
+        try:
+            point_cap = int(max_points)
+        except (TypeError, ValueError):
+            log_and_raise(
+                f"max_points must be a positive integer or None, got {max_points}."
+            )
+        if isinstance(max_points, bool) or point_cap != max_points:
+            log_and_raise(
+                f"max_points must be a positive integer or None, got {max_points}."
+            )
+        if point_cap <= 0:
+            log_and_raise(f"max_points must be positive, got {max_points}.")
+        return point_cap
+
+    def _limit_voxels_for_point_cap(
+        self,
+        voxels: OccupiedVoxels,
+        *,
+        subvoxel_factor: int,
+        max_points: Optional[int],
+    ) -> OccupiedVoxels:
+        """Deterministically downsample source voxels before subvoxel expansion."""
+        point_cap = BlockSparseTSDFIntegrator._validate_max_points(max_points)
+        samples_per_voxel = subvoxel_factor**3
+        if point_cap is None or len(voxels) * samples_per_voxel <= point_cap:
+            return voxels
+
+        source_count = point_cap // samples_per_voxel
+        if source_count == 0:
+            empty_centers = voxels.centers[:0]
+            empty_blocks = voxels.block_idx_per_voxel[:0]
+            return OccupiedVoxels(
+                centers=empty_centers,
+                block_idx_per_voxel=empty_blocks,
+                block_data=voxels.block_data,
+            )
+
+        indices = torch.linspace(
+            0,
+            len(voxels) - 1,
+            steps=source_count,
+            device=voxels.centers.device,
+            dtype=torch.float32,
+        ).round().to(torch.long)
+        return OccupiedVoxels(
+            centers=voxels.centers[indices].contiguous(),
+            block_idx_per_voxel=voxels.block_idx_per_voxel[indices].contiguous(),
+            block_data=voxels.block_data,
+        )
+
+    def _expand_subvoxels(
+        self,
+        voxels: OccupiedVoxels,
+        *,
+        subvoxel_factor: int,
+    ) -> OccupiedVoxels:
+        """Return voxel centers or regular subvoxel sample centers."""
+        if subvoxel_factor == 1 or len(voxels) == 0:
+            return OccupiedVoxels(
+                centers=voxels.centers,
+                block_idx_per_voxel=voxels.block_idx_per_voxel,
+                block_data=voxels.block_data,
+                subvoxel_factor=subvoxel_factor,
+            )
+
+        device = voxels.centers.device
+        dtype = voxels.centers.dtype
+        offsets_1d = (
+            (torch.arange(subvoxel_factor, device=device, dtype=dtype) + 0.5)
+            / float(subvoxel_factor)
+            - 0.5
+        ) * float(self.config.voxel_size)
+        offset_grid = torch.stack(
+            torch.meshgrid(offsets_1d, offsets_1d, offsets_1d, indexing="ij"),
+            dim=-1,
+        ).reshape(-1, 3)
+        centers = (voxels.centers[:, None, :] + offset_grid[None, :, :]).reshape(-1, 3)
+        block_idx_per_voxel = voxels.block_idx_per_voxel.repeat_interleave(
+            subvoxel_factor**3
+        )
+        return OccupiedVoxels(
+            centers=centers.contiguous(),
+            block_idx_per_voxel=block_idx_per_voxel.contiguous(),
+            block_data=voxels.block_data,
+            subvoxel_factor=subvoxel_factor,
         )
 
     def get_stats(
@@ -1068,6 +1274,13 @@ class BlockSparseTSDFIntegrator:
         self,
         surface_only: bool = False,
         sdf_threshold: float = None,
+        *,
+        subvoxel_factor: int = 1,
+        max_points: Optional[int] = None,
+        texture_observations: CameraObservation | Sequence[CameraObservation] | None = None,
+        camera_min_distance: Optional[float] = None,
+        camera_max_distance: Optional[float] = None,
+        texture_depth_tolerance_m: Optional[float] = None,
     ) -> OccupiedVoxels:
         """Extract occupied voxel centers and per-voxel block indices.
 
@@ -1079,6 +1292,16 @@ class BlockSparseTSDFIntegrator:
             surface_only: If True, extract only surface voxels (|SDF| < sdf_threshold).
                           If False (default), include inside voxels too (SDF <= 0).
             sdf_threshold: Threshold for surface_only=True. Defaults to voxel_size.
+            subvoxel_factor: Number of point samples per extracted voxel axis.
+            max_points: Optional cap applied after subvoxel expansion by
+                downsampling source voxels before expansion.
+            texture_observations: Optional RGB or RGB-D texture observations used
+                to color output samples after visibility-depth checks. Missing
+                depth is rendered from the current TSDF.
+            camera_min_distance: Minimum camera-frame z used for texture projection.
+            camera_max_distance: Maximum camera-frame z used for texture projection.
+            texture_depth_tolerance_m: Absolute visibility-depth tolerance. If
+                None, each sample uses ``max(2 * voxel_size, 0.01 * projected_z)``.
 
         Returns:
             :class:`OccupiedVoxels` — ``.centers`` for voxel positions,
@@ -1086,16 +1309,34 @@ class BlockSparseTSDFIntegrator:
             ``.block_data`` as a read-only view over per-block storage.
             Use ``.colors_uint8()`` to gather per-voxel RGB.
         """
+        subvoxel_factor = BlockSparseTSDFIntegrator._validate_subvoxel_factor(
+            subvoxel_factor
+        )
         # Default threshold to voxel_size (matches dense behavior)
         if sdf_threshold is None:
             sdf_threshold = self.config.voxel_size
 
-        return extract_occupied_voxels_block_sparse(
+        voxels = extract_occupied_voxels_block_sparse(
             self._tsdf,
             surface_only=surface_only,
             sdf_threshold=sdf_threshold,
             minimum_tsdf_weight=self.config.minimum_tsdf_weight,
             grid_shape=self.config.grid_shape,
+        )
+        voxels = self._limit_voxels_for_point_cap(
+            voxels,
+            subvoxel_factor=subvoxel_factor,
+            max_points=max_points,
+        )
+        voxels = self._expand_subvoxels(voxels, subvoxel_factor=subvoxel_factor)
+        if texture_observations is None:
+            return voxels
+        return self._texture_projector.texture_occupied_voxels(
+            voxels,
+            texture_observations,
+            camera_min_distance=camera_min_distance,
+            camera_max_distance=camera_max_distance,
+            texture_depth_tolerance_m=texture_depth_tolerance_m,
         )
 
     def extract_matching_feature_voxels(
@@ -1191,8 +1432,13 @@ class BlockSparseTSDFIntegrator:
         # ulp loss on top of the post-frame rescale, and to match the
         # fp32 query vector for the dot product. Recycled pool slots may
         # retain stale storage, so score only active pool indices.
-        features = self._tsdf.data.block_features[active_pool_idx].float()
-        weight = self._tsdf.data.block_feature_weight[active_pool_idx].float().clamp(min=1e-6)
+        features = self._tsdf.data.block_features[active_pool_idx].float().sum(dim=1)
+        weight = (
+            self._tsdf.data.block_feature_weight[active_pool_idx]
+            .float()
+            .sum(dim=1)
+            .clamp(min=1e-6)
+        )
         normalized = features / weight.unsqueeze(-1)
 
         if feature_projector is not None:

--- a/curobo/_src/perception/mapper/kernel/builder/builder_block_sparse_kernel.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_block_sparse_kernel.py
@@ -66,6 +66,9 @@ class BlockSparseKernels:
     max_feature_tile_channels: int
     max_support_pixels_per_block_camera: int
     max_support_pixels_per_block_lidar: int
+    use_color_grid: bool
+    color_grid_size: int
+    color_grid_voxels: int
     hash_layout: HashLayout
 
     pack_entry: WarpFunction
@@ -90,6 +93,7 @@ class BlockSparseKernels:
     unpack_block_key: WarpFunction
     clear_new_blocks_kernel: WarpKernel
     clear_new_block_features_kernel: WarpKernel
+    clear_new_block_grid_rgb_kernel: WarpKernel
 
     world_to_continuous_voxel: WarpFunction
     voxel_to_world: WarpFunction
@@ -136,14 +140,26 @@ class BlockSparseKernels:
     extract_surface_voxels_kernel: WarpKernel
 
     count_surface_cubes_kernel: WarpKernel
+    append_active_blocks_kernel: WarpKernel
+    count_surface_cubes_from_blocks_kernel: WarpKernel
     append_surface_cubes_kernel: WarpKernel
+    append_surface_cubes_from_blocks_kernel: WarpKernel
     count_edges_block_sparse_kernel: WarpKernel
     generate_vertices_block_sparse_kernel: WarpKernel
     generate_triangles_shared_kernel: WarpKernel
     count_triangles_kernel: WarpKernel
+    count_total_triangles_kernel: WarpKernel
+    generate_approximate_mesh_block_sparse_kernel: WarpKernel
+    generate_approximate_mesh_atomic_kernel: WarpKernel
+    generate_approximate_mesh_current_state_kernel: WarpKernel
+    count_fast_mesh_block_triangles_kernel: WarpKernel
+    generate_fast_mesh_current_state_kernel: WarpKernel
+    copy_rgb_images_to_texture_atlas_kernel: WarpKernel
+    project_fast_mesh_uvs_kernel: WarpKernel
     sample_vertex_colors_kernel: WarpKernel
 
     rescale_block_accumulators_kernel: WarpKernel
+    rescale_block_grid_rgb_kernel: WarpKernel
 
     compute_block_keys_only_kernel: WarpKernel
     allocate_visible_blocks_from_keys_kernel: WarpKernel
@@ -151,8 +167,10 @@ class BlockSparseKernels:
     collect_blocks_in_aabb_kernel: WarpKernel
     clear_blocks_by_pool_kernel: WarpKernel
     clear_block_features_by_pool_kernel: WarpKernel
+    clear_block_grid_rgb_by_pool_kernel: WarpKernel
     integrate_voxels_kernel: WarpKernel
     integrate_block_rgb_from_support_kernel: WarpKernel
+    integrate_block_grid_rgb_kernel: WarpKernel
     integrate_features_from_support_grouped_kernel: WarpKernel
     integrate_features_from_support_tiled_kernel: WarpKernel
     # Backward-compatible aliases for callers/tests that still look up the
@@ -215,6 +233,17 @@ def _resolve_positive_int_attr(cfg: Any | None, name: str, default: int) -> int:
     if value is None:
         return default
     return int(value)
+
+
+def _resolve_bool_attr(cfg: Any | None, name: str, default: bool) -> bool:
+    if cfg is None or isinstance(cfg, int):
+        return default
+    value = getattr(cfg, name, default)
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        log_and_raise(f"{name} must be bool, got {type(value).__name__}.")
+    return bool(value)
 
 
 def _resolve_optional_positive_int_attr(cfg: Any | None, name: str) -> int | None:
@@ -341,6 +370,9 @@ def make_block_sparse_kernels(
     resolved_lidar_num_sensors = _resolve_positive_int_attr(cfg, "lidar_num_sensors", 0)
     resolved_lidar_image_height = _resolve_optional_positive_int_attr(cfg, "lidar_image_height")
     resolved_lidar_image_width = _resolve_optional_positive_int_attr(cfg, "lidar_image_width")
+    resolved_use_color_grid = _resolve_bool_attr(cfg, "use_color_grid", False)
+    resolved_color_grid_size = _resolve_positive_int_attr(cfg, "color_grid_size", 1)
+    resolved_color_grid_voxels = resolved_color_grid_size**3
     resolved_grid_shape = _resolve_grid_shape(cfg)
     resolved_esdf_grid_shape = _resolve_esdf_grid_shape(cfg)
     resolved_origin_xyz = _resolve_origin_xyz(cfg)
@@ -367,6 +399,8 @@ def make_block_sparse_kernels(
         )
     if resolved_num_samples <= 0:
         log_and_raise(f"num_samples must be > 0, got {resolved_num_samples}.")
+    if resolved_color_grid_size <= 0:
+        log_and_raise(f"color_grid_size must be > 0, got {resolved_color_grid_size}.")
     if resolved_voxel_size <= 0.0:
         log_and_raise(f"voxel_size must be > 0, got {resolved_voxel_size}.")
     if resolved_truncation_distance < 0.0:
@@ -464,21 +498,30 @@ def make_block_sparse_kernels(
         world_to_block_coords=coord_exports["world_to_block_coords"],
         world_to_block_and_local=coord_exports["world_to_block_and_local"],
         world_to_continuous_voxel=coord_exports["world_to_continuous_voxel"],
+        use_color_grid=resolved_use_color_grid,
+        color_grid_size=resolved_color_grid_size,
     )
     mesh_exports = make_mesh_kernels(
         resolved_block_size,
+        num_cameras=resolved_num_cameras,
+        image_height=resolved_image_height,
+        image_width=resolved_image_width,
         hash_lookup=hash_exports["hash_lookup"],
         compute_avg_rgb_uint8_from_block=hash_exports["compute_avg_rgb_uint8_from_block"],
+        sample_rgb=raycast_exports["sample_rgb"],
         sample_voxel=raycast_exports["sample_voxel"],
         sample_tsdf_trilinear=raycast_exports["sample_tsdf_trilinear"],
         compute_gradient=raycast_exports["compute_gradient"],
         compute_gradient_nearest=raycast_exports["compute_gradient_nearest"],
         block_grid_to_key_coords=coord_exports["block_grid_to_key_coords"],
         block_key_to_voxel_base=coord_exports["block_key_to_voxel_base"],
+        use_color_grid=resolved_use_color_grid,
     )
     rescale_exports = make_rescale_kernels(
         resolved_block_size,
         feature_dim=resolved_feature_dim,
+        use_color_grid=resolved_use_color_grid,
+        color_grid_size=resolved_color_grid_size,
     )
     integrate_exports = make_camera_integrate_kernels(
         resolved_block_size,
@@ -495,6 +538,8 @@ def make_block_sparse_kernels(
         feature_channels_per_thread=feature_channels_per_thread,
         max_feature_tile_channels=resolved_max_feature_tile_channels,
         max_support_pixels_per_block_camera=resolved_max_support_pixels_per_block_camera,
+        use_color_grid=resolved_use_color_grid,
+        color_grid_size=resolved_color_grid_size,
         pack_key_only=hash_exports["pack_key_only"],
         unpack_block_key=hash_exports["unpack_block_key"],
         find_or_insert_block=hash_exports["find_or_insert_block"],
@@ -505,6 +550,7 @@ def make_block_sparse_kernels(
         block_local_to_world=coord_exports["block_local_to_world"],
         block_grid_to_key_coords=coord_exports["block_grid_to_key_coords"],
         block_key_to_grid_coords=coord_exports["block_key_to_grid_coords"],
+        block_key_to_voxel_base=coord_exports["block_key_to_voxel_base"],
     )
     lidar_integrate_exports = make_lidar_integrate_kernels(
         resolved_block_size,
@@ -561,6 +607,9 @@ def make_block_sparse_kernels(
         max_feature_tile_channels=resolved_max_feature_tile_channels,
         max_support_pixels_per_block_camera=resolved_max_support_pixels_per_block_camera,
         max_support_pixels_per_block_lidar=resolved_max_support_pixels_per_block_lidar,
+        use_color_grid=resolved_use_color_grid,
+        color_grid_size=resolved_color_grid_size,
+        color_grid_voxels=resolved_color_grid_voxels,
         hash_layout=hash_layout,
         **hash_exports,
         **coord_exports,

--- a/curobo/_src/perception/mapper/kernel/builder/builder_block_sparse_kernel.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_block_sparse_kernel.py
@@ -13,11 +13,12 @@ from typing import Any, TypeAlias
 from curobo._src.perception.mapper.constants import (
     DEFAULT_HASH_LAYOUT,
     HashLayout,
+    _validate_block_size,
     _validate_color_grid_size,
+    _validate_feature_block_grid_size,
     _validate_feature_channels_per_thread,
     _validate_feature_grid_shape,
     _validate_lidar_config,
-    _validate_block_size,
 )
 from curobo._src.perception.mapper.kernel.builder.builder_coord import make_coord_kernels
 from curobo._src.perception.mapper.kernel.builder.builder_decay import make_decay_kernels
@@ -52,6 +53,9 @@ class BlockSparseKernels:
     num_cameras: int
     image_height: int
     image_width: int
+    texture_num_cameras: int
+    texture_camera_image_height: int
+    texture_camera_image_width: int
     lidar_num_sensors: int
     lidar_image_height: int
     lidar_image_width: int
@@ -69,6 +73,8 @@ class BlockSparseKernels:
     max_support_pixels_per_block_lidar: int
     color_grid_size: int
     color_grid_voxels: int
+    feature_block_grid_size: int
+    feature_grid_voxels: int
     hash_layout: HashLayout
 
     pack_entry: WarpFunction
@@ -128,8 +134,6 @@ class BlockSparseKernels:
     ray_block_exit_t: WarpFunction
     raycast_block_sparse_kernel: WarpKernel
     raycast_block_sparse_color_kernel: WarpKernel
-    raycast_block_sparse_accelerated_kernel: WarpKernel
-    raycast_block_sparse_accelerated_color_kernel: WarpKernel
     count_surface_voxels_kernel: WarpKernel
     count_occupied_voxels_kernel: WarpKernel
     count_occupied_voxels_masked_kernel: WarpKernel
@@ -137,23 +141,12 @@ class BlockSparseKernels:
     extract_occupied_voxels_masked_kernel: WarpKernel
     extract_surface_voxels_kernel: WarpKernel
 
-    count_surface_cubes_kernel: WarpKernel
     append_active_blocks_kernel: WarpKernel
     count_surface_cubes_from_blocks_kernel: WarpKernel
-    append_surface_cubes_kernel: WarpKernel
     append_surface_cubes_from_blocks_kernel: WarpKernel
-    count_edges_block_sparse_kernel: WarpKernel
-    generate_vertices_block_sparse_kernel: WarpKernel
-    generate_triangles_shared_kernel: WarpKernel
-    count_triangles_kernel: WarpKernel
     count_total_triangles_kernel: WarpKernel
-    generate_approximate_mesh_block_sparse_kernel: WarpKernel
-    generate_approximate_mesh_atomic_kernel: WarpKernel
-    generate_approximate_mesh_current_state_kernel: WarpKernel
-    count_fast_mesh_block_triangles_kernel: WarpKernel
-    generate_fast_mesh_current_state_kernel: WarpKernel
-    copy_rgb_images_to_texture_atlas_kernel: WarpKernel
-    project_fast_mesh_uvs_kernel: WarpKernel
+    generate_mesh_kernel: WarpKernel
+    project_mesh_uvs_kernel: WarpKernel
     sample_vertex_colors_kernel: WarpKernel
 
     rescale_block_accumulators_kernel: WarpKernel
@@ -175,7 +168,7 @@ class BlockSparseKernels:
     lidar_compute_block_keys_only_kernel: WarpKernel
     lidar_build_support_pixels_from_keys_kernel: WarpKernel
     lidar_integrate_voxels_kernel: WarpKernel
-    lidar_integrate_block_grid_rgb_from_support_kernel: WarpKernel
+    lidar_integrate_block_grid_rgb_kernel: WarpKernel
     lidar_integrate_features_from_support_grouped_kernel: WarpKernel
     lidar_integrate_features_from_support_tiled_kernel: WarpKernel
 
@@ -322,6 +315,33 @@ def _resolve_lidar_feature_grid_shape(cfg: Any | None) -> tuple[int, int] | None
     return (height, width)
 
 
+def _resolve_texture_camera_config(
+    cfg: Any | None,
+    *,
+    num_cameras: int,
+    image_height: int,
+    image_width: int,
+) -> tuple[int, int, int]:
+    texture_num_cameras = _resolve_optional_positive_int_attr(cfg, "texture_num_cameras")
+    texture_image_height = _resolve_optional_positive_int_attr(
+        cfg, "texture_camera_image_height"
+    )
+    texture_image_width = _resolve_optional_positive_int_attr(
+        cfg, "texture_camera_image_width"
+    )
+    if texture_num_cameras is None:
+        texture_num_cameras = num_cameras
+    if (texture_image_height is None) != (texture_image_width is None):
+        log_and_raise(
+            "texture_camera_image_height and texture_camera_image_width must be "
+            "specified together."
+        )
+    if texture_image_height is None:
+        texture_image_height = image_height
+        texture_image_width = image_width
+    return texture_num_cameras, texture_image_height, texture_image_width
+
+
 def _validate_seeding_method(cfg: Any | None, seeding_method: str | None) -> None:
     selected = seeding_method
     if selected is None and cfg is not None and not isinstance(cfg, int):
@@ -350,11 +370,27 @@ def make_block_sparse_kernels(
     resolved_num_cameras = _resolve_positive_int_attr(cfg, "num_cameras", 1)
     resolved_image_height = _resolve_positive_int_attr(cfg, "image_height", 1)
     resolved_image_width = _resolve_positive_int_attr(cfg, "image_width", 1)
+    (
+        resolved_texture_num_cameras,
+        resolved_texture_camera_image_height,
+        resolved_texture_camera_image_width,
+    ) = _resolve_texture_camera_config(
+        cfg,
+        num_cameras=resolved_num_cameras,
+        image_height=resolved_image_height,
+        image_width=resolved_image_width,
+    )
     resolved_lidar_num_sensors = _resolve_positive_int_attr(cfg, "lidar_num_sensors", 0)
     resolved_lidar_image_height = _resolve_optional_positive_int_attr(cfg, "lidar_image_height")
     resolved_lidar_image_width = _resolve_optional_positive_int_attr(cfg, "lidar_image_width")
     resolved_color_grid_size = _resolve_positive_int_attr(cfg, "color_grid_size", 1)
     resolved_color_grid_voxels = resolved_color_grid_size**3
+    resolved_feature_block_grid_size = _resolve_positive_int_attr(
+        cfg,
+        "feature_block_grid_size",
+        1,
+    )
+    resolved_feature_grid_voxels = resolved_feature_block_grid_size**3
     resolved_grid_shape = _resolve_grid_shape(cfg)
     resolved_esdf_grid_shape = _resolve_esdf_grid_shape(cfg)
     resolved_origin_xyz = _resolve_origin_xyz(cfg)
@@ -379,9 +415,26 @@ def make_block_sparse_kernels(
             "image_height and image_width must be > 0, got "
             f"{resolved_image_height}x{resolved_image_width}."
         )
+    if resolved_texture_num_cameras <= 0:
+        log_and_raise(
+            "texture_num_cameras must be > 0, got "
+            f"{resolved_texture_num_cameras}."
+        )
+    if (
+        resolved_texture_camera_image_height <= 0
+        or resolved_texture_camera_image_width <= 0
+    ):
+        log_and_raise(
+            "texture_camera_image_height and texture_camera_image_width must be > 0, got "
+            f"{resolved_texture_camera_image_height}x{resolved_texture_camera_image_width}."
+        )
     if resolved_num_samples <= 0:
         log_and_raise(f"num_samples must be > 0, got {resolved_num_samples}.")
     _validate_color_grid_size(resolved_color_grid_size, resolved_block_size)
+    _validate_feature_block_grid_size(
+        resolved_feature_block_grid_size,
+        resolved_block_size,
+    )
     if resolved_voxel_size <= 0.0:
         log_and_raise(f"voxel_size must be > 0, got {resolved_voxel_size}.")
     if resolved_truncation_distance < 0.0:
@@ -482,9 +535,9 @@ def make_block_sparse_kernels(
     )
     mesh_exports = make_mesh_kernels(
         resolved_block_size,
-        num_cameras=resolved_num_cameras,
-        image_height=resolved_image_height,
-        image_width=resolved_image_width,
+        num_cameras=resolved_texture_num_cameras,
+        image_height=resolved_texture_camera_image_height,
+        image_width=resolved_texture_camera_image_width,
         hash_lookup=hash_exports["hash_lookup"],
         sample_rgb=raycast_exports["sample_rgb"],
         sample_voxel=raycast_exports["sample_voxel"],
@@ -498,6 +551,7 @@ def make_block_sparse_kernels(
         resolved_block_size,
         feature_dim=resolved_feature_dim,
         color_grid_size=resolved_color_grid_size,
+        feature_block_grid_size=resolved_feature_block_grid_size,
     )
     integrate_exports = make_camera_integrate_kernels(
         resolved_block_size,
@@ -515,6 +569,7 @@ def make_block_sparse_kernels(
         max_feature_tile_channels=resolved_max_feature_tile_channels,
         max_support_pixels_per_block_camera=resolved_max_support_pixels_per_block_camera,
         color_grid_size=resolved_color_grid_size,
+        feature_block_grid_size=resolved_feature_block_grid_size,
         pack_key_only=hash_exports["pack_key_only"],
         unpack_block_key=hash_exports["unpack_block_key"],
         find_or_insert_block=hash_exports["find_or_insert_block"],
@@ -543,12 +598,14 @@ def make_block_sparse_kernels(
         max_feature_tile_channels=resolved_max_feature_tile_channels,
         max_support_pixels_per_block_lidar=resolved_max_support_pixels_per_block_lidar,
         color_grid_size=resolved_color_grid_size,
+        feature_block_grid_size=resolved_feature_block_grid_size,
         pack_key_only=hash_exports["pack_key_only"],
         unpack_block_key=hash_exports["unpack_block_key"],
         hash_lookup=hash_exports["hash_lookup"],
         world_to_continuous_voxel=coord_exports["world_to_continuous_voxel"],
         block_local_to_world=coord_exports["block_local_to_world"],
         block_grid_to_key_coords=coord_exports["block_grid_to_key_coords"],
+        block_key_to_voxel_base=coord_exports["block_key_to_voxel_base"],
     )
     esdf_exports = make_esdf_kernels(
         resolved_block_size,
@@ -568,6 +625,9 @@ def make_block_sparse_kernels(
         num_cameras=resolved_num_cameras,
         image_height=resolved_image_height,
         image_width=resolved_image_width,
+        texture_num_cameras=resolved_texture_num_cameras,
+        texture_camera_image_height=resolved_texture_camera_image_height,
+        texture_camera_image_width=resolved_texture_camera_image_width,
         lidar_num_sensors=resolved_lidar_num_sensors,
         lidar_image_height=lidar_kernel_image_height,
         lidar_image_width=lidar_kernel_image_width,
@@ -585,6 +645,8 @@ def make_block_sparse_kernels(
         max_support_pixels_per_block_lidar=resolved_max_support_pixels_per_block_lidar,
         color_grid_size=resolved_color_grid_size,
         color_grid_voxels=resolved_color_grid_voxels,
+        feature_block_grid_size=resolved_feature_block_grid_size,
+        feature_grid_voxels=resolved_feature_grid_voxels,
         hash_layout=hash_layout,
         **hash_exports,
         **coord_exports,

--- a/curobo/_src/perception/mapper/kernel/builder/builder_block_sparse_kernel.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_block_sparse_kernel.py
@@ -13,6 +13,7 @@ from typing import Any, TypeAlias
 from curobo._src.perception.mapper.constants import (
     DEFAULT_HASH_LAYOUT,
     HashLayout,
+    _validate_color_grid_size,
     _validate_feature_channels_per_thread,
     _validate_feature_grid_shape,
     _validate_lidar_config,
@@ -66,7 +67,6 @@ class BlockSparseKernels:
     max_feature_tile_channels: int
     max_support_pixels_per_block_camera: int
     max_support_pixels_per_block_lidar: int
-    use_color_grid: bool
     color_grid_size: int
     color_grid_voxels: int
     hash_layout: HashLayout
@@ -79,8 +79,6 @@ class BlockSparseKernels:
     is_valid_block_key: WarpFunction
     spatial_hash: WarpFunction
     pack_rgb: WarpFunction
-    compute_avg_rgb_from_block: WarpFunction
-    compute_avg_rgb_uint8_from_block: WarpFunction
     hash_lookup: WarpFunction
     free_list_pop: WarpFunction
     free_list_push: WarpFunction
@@ -117,7 +115,7 @@ class BlockSparseKernels:
     enumerate_blocks_from_aabb_kernel: WarpKernel
     filter_blocks_by_sdf_kernel: WarpKernel
     stamp_sdf_kernel: WarpKernel
-    update_block_rgb_kernel: WarpKernel
+    update_block_grid_rgb_kernel: WarpKernel
 
     sample_voxel: WarpFunction
     sample_tsdf: WarpFunction
@@ -169,19 +167,15 @@ class BlockSparseKernels:
     clear_block_features_by_pool_kernel: WarpKernel
     clear_block_grid_rgb_by_pool_kernel: WarpKernel
     integrate_voxels_kernel: WarpKernel
-    integrate_block_rgb_from_support_kernel: WarpKernel
     integrate_block_grid_rgb_kernel: WarpKernel
     integrate_features_from_support_grouped_kernel: WarpKernel
     integrate_features_from_support_tiled_kernel: WarpKernel
-    # Backward-compatible aliases for callers/tests that still look up the
-    # pre-refactor field names. Both point at the support-list consumers.
-    integrate_block_rgb_kernel: WarpKernel
     integrate_features_grouped_kernel: WarpKernel
 
     lidar_compute_block_keys_only_kernel: WarpKernel
     lidar_build_support_pixels_from_keys_kernel: WarpKernel
     lidar_integrate_voxels_kernel: WarpKernel
-    lidar_integrate_block_rgb_from_support_kernel: WarpKernel
+    lidar_integrate_block_grid_rgb_from_support_kernel: WarpKernel
     lidar_integrate_features_from_support_grouped_kernel: WarpKernel
     lidar_integrate_features_from_support_tiled_kernel: WarpKernel
 
@@ -233,17 +227,6 @@ def _resolve_positive_int_attr(cfg: Any | None, name: str, default: int) -> int:
     if value is None:
         return default
     return int(value)
-
-
-def _resolve_bool_attr(cfg: Any | None, name: str, default: bool) -> bool:
-    if cfg is None or isinstance(cfg, int):
-        return default
-    value = getattr(cfg, name, default)
-    if value is None:
-        return default
-    if not isinstance(value, bool):
-        log_and_raise(f"{name} must be bool, got {type(value).__name__}.")
-    return bool(value)
 
 
 def _resolve_optional_positive_int_attr(cfg: Any | None, name: str) -> int | None:
@@ -370,7 +353,6 @@ def make_block_sparse_kernels(
     resolved_lidar_num_sensors = _resolve_positive_int_attr(cfg, "lidar_num_sensors", 0)
     resolved_lidar_image_height = _resolve_optional_positive_int_attr(cfg, "lidar_image_height")
     resolved_lidar_image_width = _resolve_optional_positive_int_attr(cfg, "lidar_image_width")
-    resolved_use_color_grid = _resolve_bool_attr(cfg, "use_color_grid", False)
     resolved_color_grid_size = _resolve_positive_int_attr(cfg, "color_grid_size", 1)
     resolved_color_grid_voxels = resolved_color_grid_size**3
     resolved_grid_shape = _resolve_grid_shape(cfg)
@@ -399,8 +381,7 @@ def make_block_sparse_kernels(
         )
     if resolved_num_samples <= 0:
         log_and_raise(f"num_samples must be > 0, got {resolved_num_samples}.")
-    if resolved_color_grid_size <= 0:
-        log_and_raise(f"color_grid_size must be > 0, got {resolved_color_grid_size}.")
+    _validate_color_grid_size(resolved_color_grid_size, resolved_block_size)
     if resolved_voxel_size <= 0.0:
         log_and_raise(f"voxel_size must be > 0, got {resolved_voxel_size}.")
     if resolved_truncation_distance < 0.0:
@@ -475,6 +456,7 @@ def make_block_sparse_kernels(
     )
     stamp_exports = make_stamp_kernels(
         resolved_block_size,
+        color_grid_size=resolved_color_grid_size,
         grid_shape=resolved_grid_shape,
         origin_xyz=resolved_origin_xyz,
         voxel_size=resolved_voxel_size,
@@ -489,8 +471,6 @@ def make_block_sparse_kernels(
     raycast_exports = make_raycast_kernels(
         resolved_block_size,
         hash_lookup=hash_exports["hash_lookup"],
-        compute_avg_rgb_from_block=hash_exports["compute_avg_rgb_from_block"],
-        compute_avg_rgb_uint8_from_block=hash_exports["compute_avg_rgb_uint8_from_block"],
         voxel_to_world=coord_exports["voxel_to_world"],
         voxel_to_world_corner=coord_exports["voxel_to_world_corner"],
         block_grid_to_key_coords=coord_exports["block_grid_to_key_coords"],
@@ -498,7 +478,6 @@ def make_block_sparse_kernels(
         world_to_block_coords=coord_exports["world_to_block_coords"],
         world_to_block_and_local=coord_exports["world_to_block_and_local"],
         world_to_continuous_voxel=coord_exports["world_to_continuous_voxel"],
-        use_color_grid=resolved_use_color_grid,
         color_grid_size=resolved_color_grid_size,
     )
     mesh_exports = make_mesh_kernels(
@@ -507,7 +486,6 @@ def make_block_sparse_kernels(
         image_height=resolved_image_height,
         image_width=resolved_image_width,
         hash_lookup=hash_exports["hash_lookup"],
-        compute_avg_rgb_uint8_from_block=hash_exports["compute_avg_rgb_uint8_from_block"],
         sample_rgb=raycast_exports["sample_rgb"],
         sample_voxel=raycast_exports["sample_voxel"],
         sample_tsdf_trilinear=raycast_exports["sample_tsdf_trilinear"],
@@ -515,12 +493,10 @@ def make_block_sparse_kernels(
         compute_gradient_nearest=raycast_exports["compute_gradient_nearest"],
         block_grid_to_key_coords=coord_exports["block_grid_to_key_coords"],
         block_key_to_voxel_base=coord_exports["block_key_to_voxel_base"],
-        use_color_grid=resolved_use_color_grid,
     )
     rescale_exports = make_rescale_kernels(
         resolved_block_size,
         feature_dim=resolved_feature_dim,
-        use_color_grid=resolved_use_color_grid,
         color_grid_size=resolved_color_grid_size,
     )
     integrate_exports = make_camera_integrate_kernels(
@@ -538,7 +514,6 @@ def make_block_sparse_kernels(
         feature_channels_per_thread=feature_channels_per_thread,
         max_feature_tile_channels=resolved_max_feature_tile_channels,
         max_support_pixels_per_block_camera=resolved_max_support_pixels_per_block_camera,
-        use_color_grid=resolved_use_color_grid,
         color_grid_size=resolved_color_grid_size,
         pack_key_only=hash_exports["pack_key_only"],
         unpack_block_key=hash_exports["unpack_block_key"],
@@ -567,6 +542,7 @@ def make_block_sparse_kernels(
         feature_channels_per_thread=feature_channels_per_thread,
         max_feature_tile_channels=resolved_max_feature_tile_channels,
         max_support_pixels_per_block_lidar=resolved_max_support_pixels_per_block_lidar,
+        color_grid_size=resolved_color_grid_size,
         pack_key_only=hash_exports["pack_key_only"],
         unpack_block_key=hash_exports["unpack_block_key"],
         hash_lookup=hash_exports["hash_lookup"],
@@ -607,7 +583,6 @@ def make_block_sparse_kernels(
         max_feature_tile_channels=resolved_max_feature_tile_channels,
         max_support_pixels_per_block_camera=resolved_max_support_pixels_per_block_camera,
         max_support_pixels_per_block_lidar=resolved_max_support_pixels_per_block_lidar,
-        use_color_grid=resolved_use_color_grid,
         color_grid_size=resolved_color_grid_size,
         color_grid_voxels=resolved_color_grid_voxels,
         hash_layout=hash_layout,

--- a/curobo/_src/perception/mapper/kernel/builder/builder_camera_integrate.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_camera_integrate.py
@@ -38,6 +38,7 @@ def make_camera_integrate_kernels(
     max_feature_tile_channels: int,
     max_support_pixels_per_block_camera: int,
     color_grid_size: int,
+    feature_block_grid_size: int,
     pack_key_only,
     unpack_block_key,
     find_or_insert_block,
@@ -71,6 +72,9 @@ def make_camera_integrate_kernels(
     color_grid_voxels = int(color_grid_size) ** 3
     COLOR_GRID_VOXELS = wp.constant(wp.int32(color_grid_voxels))
     COLOR_GRID_CELLS = wp.constant(wp.int32(color_grid_voxels * 4))
+    feature_grid_voxels = int(feature_block_grid_size) ** 3
+    FEATURE_BLOCK_GRID_SIZE = wp.constant(wp.int32(feature_block_grid_size))
+    FEATURE_GRID_VOXELS = wp.constant(wp.int32(feature_grid_voxels))
     if feature_grid_shape is None:
         feature_grid_height = 1
         feature_grid_width = 1
@@ -79,10 +83,25 @@ def make_camera_integrate_kernels(
         feature_grid_width = int(feature_grid_shape[1])
     FEATURE_GRID_HEIGHT = wp.constant(wp.int32(feature_grid_height))
     FEATURE_GRID_WIDTH = wp.constant(wp.int32(feature_grid_width))
-    suffix = (
-        f"bs{block_size}_cfg"
-        f"{warp_constant_suffix(block_size, feature_dim, num_cameras, image_height, image_width, num_samples, grid_shape, origin_xyz, voxel_size, truncation_distance, feature_grid_shape, feature_channels_per_thread, max_feature_tile_channels, max_support_pixels_per_block_camera, color_grid_size)}"
+    suffix_hash = warp_constant_suffix(
+        block_size,
+        feature_dim,
+        num_cameras,
+        image_height,
+        image_width,
+        num_samples,
+        grid_shape,
+        origin_xyz,
+        voxel_size,
+        truncation_distance,
+        feature_grid_shape,
+        feature_channels_per_thread,
+        max_feature_tile_channels,
+        max_support_pixels_per_block_camera,
+        color_grid_size,
+        feature_block_grid_size,
     )
+    suffix = f"bs{block_size}_cfg{suffix_hash}"
 
     # Cross-domain helpers are explicit parameters so Warp sees them as
     # local closure bindings when compiling dependent kernels.
@@ -422,31 +441,31 @@ def make_camera_integrate_kernels(
     def clear_block_features_by_pool_kernel(
         clear_pool_indices: wp.array(dtype=wp.int32),
         clear_count: wp.array(dtype=wp.int32),
-        block_features: wp.array2d(dtype=wp.float16),
-        block_feature_weight: wp.array(dtype=wp.float16),
+        block_features: wp.array3d(dtype=wp.float16),
+        block_feature_weight: wp.array2d(dtype=wp.float16),
         max_blocks: wp.int32,
     ):
-        """Zero feature accumulators for already allocated blocks.
+        """Zero feature-grid accumulators for already allocated blocks.
 
-        Launch with ``dim = (n_clear, feature_dim)`` so one thread
-        clears one ``(block, channel)`` cell; the thread with
-        ``ch == 0`` also zeroes the per-block feature weight.
+        Launch with ``dim = (n_clear, feature_grid_voxels, feature_dim)`` so
+        one thread clears one ``(block, node, channel)`` cell; the thread
+        with ``ch == 0`` also zeroes the per-node feature weight.
         """
-        slot_idx, ch = wp.tid()
+        slot_idx, node_idx, ch = wp.tid()
 
         count = clear_count[0]
         if count > max_blocks:
             count = max_blocks
-        if slot_idx >= count:
+        if slot_idx >= count or node_idx >= FEATURE_GRID_VOXELS:
             return
 
         pool_idx = clear_pool_indices[slot_idx]
         if pool_idx < wp.int32(0) or pool_idx >= max_blocks:
             return
 
-        block_features[pool_idx, ch] = wp.float16(0.0)
+        block_features[pool_idx, node_idx, ch] = wp.float16(0.0)
         if ch == wp.int32(0):
-            block_feature_weight[pool_idx] = wp.float16(0.0)
+            block_feature_weight[pool_idx, node_idx] = wp.float16(0.0)
 
     @warp_kernel(f"integrate_voxels_kernel_{suffix}")
     def integrate_voxels_kernel(
@@ -546,6 +565,8 @@ def make_camera_integrate_kernels(
         cam_quaternions: wp.array2d(dtype=wp.float32),
         depth_images: wp.array3d(dtype=wp.float32),
         rgb_images_flat: wp.array2d(dtype=wp.vec3ub),
+        support_counts: wp.array2d(dtype=wp.int32),
+        support_pixels: wp.array3d(dtype=wp.int32),
         depth_min: float,
         depth_max: float,
         block_coords: wp.array(dtype=wp.int32),
@@ -774,15 +795,45 @@ def make_camera_integrate_kernels(
                             )
                             total_w = total_w + weight11
 
+        old_r = wp.float32(block_grid_rgb[pool_idx, node_idx, 0])
+        old_g = wp.float32(block_grid_rgb[pool_idx, node_idx, 1])
+        old_b = wp.float32(block_grid_rgb[pool_idx, node_idx, 2])
+        old_w = wp.float32(block_grid_rgb[pool_idx, node_idx, 3])
         if total_w > wp.float32(0.0):
-            old_r = wp.float32(block_grid_rgb[pool_idx, node_idx, 0])
-            old_g = wp.float32(block_grid_rgb[pool_idx, node_idx, 1])
-            old_b = wp.float32(block_grid_rgb[pool_idx, node_idx, 2])
-            old_w = wp.float32(block_grid_rgb[pool_idx, node_idx, 3])
             block_grid_rgb[pool_idx, node_idx, 0] = wp.float16(old_r + total_r)
             block_grid_rgb[pool_idx, node_idx, 1] = wp.float16(old_g + total_g)
             block_grid_rgb[pool_idx, node_idx, 2] = wp.float16(old_b + total_b)
             block_grid_rgb[pool_idx, node_idx, 3] = wp.float16(old_w + total_w)
+            return
+
+        support_r = wp.float32(0.0)
+        support_g = wp.float32(0.0)
+        support_b = wp.float32(0.0)
+        support_w = wp.float32(0.0)
+        for cam_i in range(num_cameras):
+            count = support_counts[vis_idx, cam_i]
+            if count > wp.int32(0):
+                pixel_idx = support_pixels[vis_idx, cam_i, 0]
+                py = pixel_idx // IMAGE_WIDTH
+                px = pixel_idx - py * IMAGE_WIDTH
+                if (
+                    py >= wp.int32(0)
+                    and py < IMAGE_HEIGHT
+                    and px >= wp.int32(0)
+                    and px < IMAGE_WIDTH
+                ):
+                    row = cam_i * IMAGE_HEIGHT + py
+                    rgb = rgb_images_flat[row, px]
+                    support_r = support_r + wp.float32(rgb[0]) * inv_255
+                    support_g = support_g + wp.float32(rgb[1]) * inv_255
+                    support_b = support_b + wp.float32(rgb[2]) * inv_255
+                    support_w = support_w + wp.float32(1.0)
+
+        if support_w > wp.float32(0.0):
+            block_grid_rgb[pool_idx, node_idx, 0] = wp.float16(old_r + support_r)
+            block_grid_rgb[pool_idx, node_idx, 1] = wp.float16(old_g + support_g)
+            block_grid_rgb[pool_idx, node_idx, 2] = wp.float16(old_b + support_b)
+            block_grid_rgb[pool_idx, node_idx, 3] = wp.float16(old_w + support_w)
 
     @warp_kernel(
         f"integrate_features_from_support_grouped_kernel_{suffix}_fcpt"
@@ -791,69 +842,173 @@ def make_camera_integrate_kernels(
     def integrate_features_from_support_grouped_kernel(
         visible_pool_indices: wp.array(dtype=wp.int32),
         n_visible: wp.int32,
+        intrinsics: wp.array3d(dtype=wp.float32),
+        cam_positions: wp.array2d(dtype=wp.float32),
+        cam_quaternions: wp.array2d(dtype=wp.float32),
+        depth_images: wp.array3d(dtype=wp.float32),
         support_counts: wp.array2d(dtype=wp.int32),
         support_pixels: wp.array3d(dtype=wp.int32),
         feature_grid: wp.array4d(dtype=wp.float16),
-        block_features: wp.array2d(dtype=wp.float16),
-        block_feature_weight: wp.array(dtype=wp.float16),
+        depth_min: float,
+        depth_max: float,
+        block_coords: wp.array(dtype=wp.int32),
+        block_features: wp.array3d(dtype=wp.float16),
+        block_feature_weight: wp.array2d(dtype=wp.float16),
     ):
-        """Per-block feature aggregation from allocation-time support pixels."""
+        """Per-node feature-grid integration with support fallback for empty nodes."""
         n_channel_groups = (
             FEATURE_DIM + FEATURE_CHANNELS_PER_THREAD - wp.int32(1)
         ) // FEATURE_CHANNELS_PER_THREAD
-        vis_idx, cam_i, feature_channel_group_idx = wp.tid()
+        vis_idx, node_idx, feature_channel_group_idx = wp.tid()
 
-        if vis_idx >= n_visible or feature_channel_group_idx >= n_channel_groups:
+        if (
+            vis_idx >= n_visible
+            or node_idx >= FEATURE_GRID_VOXELS
+            or feature_channel_group_idx >= n_channel_groups
+        ):
             return
 
         pool_idx = visible_pool_indices[vis_idx]
         if pool_idx < wp.int32(0):
             return
 
-        count = support_counts[vis_idx, cam_i]
-        if count > SUPPORT_CAPACITY:
-            count = SUPPORT_CAPACITY
-        if count <= wp.int32(0):
-            return
+        bx = block_coords[pool_idx * 3 + 0]
+        by = block_coords[pool_idx * 3 + 1]
+        bz = block_coords[pool_idx * 3 + 2]
+
+        gx_node = node_idx % FEATURE_BLOCK_GRID_SIZE
+        gy_node = (node_idx // FEATURE_BLOCK_GRID_SIZE) % FEATURE_BLOCK_GRID_SIZE
+        gz_node = node_idx // (FEATURE_BLOCK_GRID_SIZE * FEATURE_BLOCK_GRID_SIZE)
+
+        local_x = wp.float32(0.0)
+        local_y = wp.float32(0.0)
+        local_z = wp.float32(0.0)
+        if FEATURE_BLOCK_GRID_SIZE > wp.int32(1):
+            span = wp.float32(BLOCK_SIZE - wp.int32(1))
+            denom = wp.float32(FEATURE_BLOCK_GRID_SIZE - wp.int32(1))
+            local_x = wp.float32(0.5) + wp.float32(gx_node) * span / denom
+            local_y = wp.float32(0.5) + wp.float32(gy_node) * span / denom
+            local_z = wp.float32(0.5) + wp.float32(gz_node) * span / denom
+        else:
+            center = wp.float32(BLOCK_SIZE) * wp.float32(0.5)
+            local_x = center
+            local_y = center
+            local_z = center
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        center_offset_x = wp.float32(GRID_W) * wp.float32(0.5)
+        center_offset_y = wp.float32(GRID_H) * wp.float32(0.5)
+        center_offset_z = wp.float32(GRID_D) * wp.float32(0.5)
+        node_world = (
+            wp.vec3(ORIGIN_X, ORIGIN_Y, ORIGIN_Z)
+            + wp.vec3(
+                wp.float32(base[0]) + local_x - center_offset_x,
+                wp.float32(base[1]) + local_y - center_offset_y,
+                wp.float32(base[2]) + local_z - center_offset_z,
+            )
+            * VOXEL_SIZE
+        )
 
         base_feature_channel = feature_channel_group_idx * FEATURE_CHANNELS_PER_THREAD
         feature_acc = wp.zeros(FEATURE_CHANNELS_PER_THREAD, dtype=wp.float32)
+        total_w = wp.float32(0.0)
 
-        for k in range(support_capacity):
-            if k < count:
-                pixel_idx = support_pixels[vis_idx, cam_i, k]
-                py = pixel_idx // IMAGE_WIDTH
-                px = pixel_idx - py * IMAGE_WIDTH
-                if (
-                    py >= wp.int32(0)
-                    and py < IMAGE_HEIGHT
-                    and px >= wp.int32(0)
-                    and px < IMAGE_WIDTH
-                ):
-                    gy = (py * FEATURE_GRID_HEIGHT) // IMAGE_HEIGHT
-                    gx = (px * FEATURE_GRID_WIDTH) // IMAGE_WIDTH
-                    if gy < wp.int32(0):
-                        gy = wp.int32(0)
-                    if gx < wp.int32(0):
-                        gx = wp.int32(0)
-                    if gy >= FEATURE_GRID_HEIGHT:
-                        gy = FEATURE_GRID_HEIGHT - wp.int32(1)
-                    if gx >= FEATURE_GRID_WIDTH:
-                        gx = FEATURE_GRID_WIDTH - wp.int32(1)
-                    for feature_channel_offset in range(FEATURE_CHANNELS_PER_THREAD):
-                        feature_channel = base_feature_channel + feature_channel_offset
-                        if feature_channel < FEATURE_DIM:
-                            feature_acc[feature_channel_offset] = (
-                                feature_acc[feature_channel_offset]
-                                + wp.float32(
-                                    feature_grid[
-                                        cam_i,
-                                        gy,
-                                        gx,
-                                        feature_channel,
-                                    ]
+        for cam_i in range(num_cameras):
+            cam_pos = wp.vec3(
+                cam_positions[cam_i, 0],
+                cam_positions[cam_i, 1],
+                cam_positions[cam_i, 2],
+            )
+            cam_quat = wp.quaternion(
+                cam_quaternions[cam_i, 1],
+                cam_quaternions[cam_i, 2],
+                cam_quaternions[cam_i, 3],
+                cam_quaternions[cam_i, 0],
+            )
+            node_cam = wp.quat_rotate(wp.quat_inverse(cam_quat), node_world - cam_pos)
+            z_cam = node_cam[2]
+            if z_cam > depth_min and z_cam <= depth_max:
+                fx = intrinsics[cam_i, 0, 0]
+                fy = intrinsics[cam_i, 1, 1]
+                cx_i = intrinsics[cam_i, 0, 2]
+                cy_i = intrinsics[cam_i, 1, 2]
+                u = fx * node_cam[0] / z_cam + cx_i
+                v = fy * node_cam[1] / z_cam + cy_i
+                px = wp.int32(wp.floor(u + wp.float32(0.5)))
+                py = wp.int32(wp.floor(v + wp.float32(0.5)))
+                if px >= 0 and px < IMAGE_WIDTH and py >= 0 and py < IMAGE_HEIGHT:
+                    depth = depth_images[cam_i, py, px]
+                    sdf = depth - z_cam
+                    if depth >= depth_min and depth <= depth_max and sdf >= -TRUNCATION_DIST and sdf <= TRUNCATION_DIST:
+                        weight = compute_tsdf_weight(depth, VOXEL_SIZE)
+                        gy = (py * FEATURE_GRID_HEIGHT) // IMAGE_HEIGHT
+                        gx = (px * FEATURE_GRID_WIDTH) // IMAGE_WIDTH
+                        if gy < wp.int32(0):
+                            gy = wp.int32(0)
+                        if gx < wp.int32(0):
+                            gx = wp.int32(0)
+                        if gy >= FEATURE_GRID_HEIGHT:
+                            gy = FEATURE_GRID_HEIGHT - wp.int32(1)
+                        if gx >= FEATURE_GRID_WIDTH:
+                            gx = FEATURE_GRID_WIDTH - wp.int32(1)
+                        for feature_channel_offset in range(FEATURE_CHANNELS_PER_THREAD):
+                            feature_channel = base_feature_channel + feature_channel_offset
+                            if feature_channel < FEATURE_DIM:
+                                feature_acc[feature_channel_offset] = (
+                                    feature_acc[feature_channel_offset]
+                                    + wp.float32(
+                                        feature_grid[
+                                            cam_i,
+                                            gy,
+                                            gx,
+                                            feature_channel,
+                                        ]
+                                    )
+                                    * weight
                                 )
-                            )
+                        total_w = total_w + weight
+
+        if total_w <= wp.float32(0.0):
+            for cam_i in range(num_cameras):
+                count = support_counts[vis_idx, cam_i]
+                if count > wp.int32(0):
+                    pixel_idx = support_pixels[vis_idx, cam_i, 0]
+                    py = pixel_idx // IMAGE_WIDTH
+                    px = pixel_idx - py * IMAGE_WIDTH
+                    if (
+                        py >= wp.int32(0)
+                        and py < IMAGE_HEIGHT
+                        and px >= wp.int32(0)
+                        and px < IMAGE_WIDTH
+                    ):
+                        gy = (py * FEATURE_GRID_HEIGHT) // IMAGE_HEIGHT
+                        gx = (px * FEATURE_GRID_WIDTH) // IMAGE_WIDTH
+                        if gy < wp.int32(0):
+                            gy = wp.int32(0)
+                        if gx < wp.int32(0):
+                            gx = wp.int32(0)
+                        if gy >= FEATURE_GRID_HEIGHT:
+                            gy = FEATURE_GRID_HEIGHT - wp.int32(1)
+                        if gx >= FEATURE_GRID_WIDTH:
+                            gx = FEATURE_GRID_WIDTH - wp.int32(1)
+                        for feature_channel_offset in range(FEATURE_CHANNELS_PER_THREAD):
+                            feature_channel = base_feature_channel + feature_channel_offset
+                            if feature_channel < FEATURE_DIM:
+                                feature_acc[feature_channel_offset] = (
+                                    feature_acc[feature_channel_offset]
+                                    + wp.float32(
+                                        feature_grid[
+                                            cam_i,
+                                            gy,
+                                            gx,
+                                            feature_channel,
+                                        ]
+                                    )
+                                )
+                        total_w = total_w + wp.float32(1.0)
+
+        if total_w <= wp.float32(0.0):
+            return
 
         for feature_channel_offset in range(FEATURE_CHANNELS_PER_THREAD):
             feature_channel = base_feature_channel + feature_channel_offset
@@ -861,11 +1016,12 @@ def make_camera_integrate_kernels(
                 wp.atomic_add(
                     block_features,
                     pool_idx,
+                    node_idx,
                     feature_channel,
                     wp.float16(feature_acc[feature_channel_offset]),
                 )
         if base_feature_channel == wp.int32(0):
-            wp.atomic_add(block_feature_weight, pool_idx, wp.float16(wp.float32(count)))
+            wp.atomic_add(block_feature_weight, pool_idx, node_idx, wp.float16(total_w))
 
     @warp_kernel(
         f"integrate_features_from_support_tiled_kernel_{suffix}_tile"
@@ -874,76 +1030,174 @@ def make_camera_integrate_kernels(
     def integrate_features_from_support_tiled_kernel(
         visible_pool_indices: wp.array(dtype=wp.int32),
         n_visible: wp.int32,
+        intrinsics: wp.array3d(dtype=wp.float32),
+        cam_positions: wp.array2d(dtype=wp.float32),
+        cam_quaternions: wp.array2d(dtype=wp.float32),
+        depth_images: wp.array3d(dtype=wp.float32),
         support_counts: wp.array2d(dtype=wp.int32),
         support_pixels: wp.array3d(dtype=wp.int32),
         feature_grid: wp.array4d(dtype=wp.float16),
-        block_features: wp.array2d(dtype=wp.float16),
-        block_feature_weight: wp.array(dtype=wp.float16),
+        depth_min: float,
+        depth_max: float,
+        block_coords: wp.array(dtype=wp.int32),
+        block_features: wp.array3d(dtype=wp.float16),
+        block_feature_weight: wp.array2d(dtype=wp.float16),
     ):
-        """Tile prototype: one CTA accumulates a feature-channel slice."""
+        """Tiled per-node feature-grid integration."""
         n_channel_tiles = (
             FEATURE_DIM + FEATURE_TILE_CHANNELS - wp.int32(1)
         ) // FEATURE_TILE_CHANNELS
-        vis_idx, cam_i, feature_tile_idx, lane = wp.tid()
+        vis_idx, node_idx, feature_tile_idx, lane = wp.tid()
 
-        if vis_idx >= n_visible or feature_tile_idx >= n_channel_tiles:
+        if (
+            vis_idx >= n_visible
+            or node_idx >= FEATURE_GRID_VOXELS
+            or feature_tile_idx >= n_channel_tiles
+        ):
             return
 
         pool_idx = visible_pool_indices[vis_idx]
         if pool_idx < wp.int32(0):
             return
 
-        count = support_counts[vis_idx, cam_i]
-        if count > SUPPORT_CAPACITY:
-            count = SUPPORT_CAPACITY
-        if count <= wp.int32(0):
-            return
+        bx = block_coords[pool_idx * 3 + 0]
+        by = block_coords[pool_idx * 3 + 1]
+        bz = block_coords[pool_idx * 3 + 2]
+
+        gx_node = node_idx % FEATURE_BLOCK_GRID_SIZE
+        gy_node = (node_idx // FEATURE_BLOCK_GRID_SIZE) % FEATURE_BLOCK_GRID_SIZE
+        gz_node = node_idx // (FEATURE_BLOCK_GRID_SIZE * FEATURE_BLOCK_GRID_SIZE)
+
+        local_x = wp.float32(0.0)
+        local_y = wp.float32(0.0)
+        local_z = wp.float32(0.0)
+        if FEATURE_BLOCK_GRID_SIZE > wp.int32(1):
+            span = wp.float32(BLOCK_SIZE - wp.int32(1))
+            denom = wp.float32(FEATURE_BLOCK_GRID_SIZE - wp.int32(1))
+            local_x = wp.float32(0.5) + wp.float32(gx_node) * span / denom
+            local_y = wp.float32(0.5) + wp.float32(gy_node) * span / denom
+            local_z = wp.float32(0.5) + wp.float32(gz_node) * span / denom
+        else:
+            center = wp.float32(BLOCK_SIZE) * wp.float32(0.5)
+            local_x = center
+            local_y = center
+            local_z = center
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        center_offset_x = wp.float32(GRID_W) * wp.float32(0.5)
+        center_offset_y = wp.float32(GRID_H) * wp.float32(0.5)
+        center_offset_z = wp.float32(GRID_D) * wp.float32(0.5)
+        node_world = (
+            wp.vec3(ORIGIN_X, ORIGIN_Y, ORIGIN_Z)
+            + wp.vec3(
+                wp.float32(base[0]) + local_x - center_offset_x,
+                wp.float32(base[1]) + local_y - center_offset_y,
+                wp.float32(base[2]) + local_z - center_offset_z,
+            )
+            * VOXEL_SIZE
+        )
 
         base_feature_channel = feature_tile_idx * FEATURE_TILE_CHANNELS
         feature_acc = wp.tile_zeros(shape=feature_tile_channels, dtype=wp.float32)
+        total_w = wp.float32(0.0)
 
-        for k in range(support_capacity):
-            if k < count:
-                pixel_idx = support_pixels[vis_idx, cam_i, k]
-                py = pixel_idx // IMAGE_WIDTH
-                px = pixel_idx - py * IMAGE_WIDTH
-                if (
-                    py >= wp.int32(0)
-                    and py < IMAGE_HEIGHT
-                    and px >= wp.int32(0)
-                    and px < IMAGE_WIDTH
-                ):
-                    gy = (py * FEATURE_GRID_HEIGHT) // IMAGE_HEIGHT
-                    gx = (px * FEATURE_GRID_WIDTH) // IMAGE_WIDTH
-                    if gy < wp.int32(0):
-                        gy = wp.int32(0)
-                    if gx < wp.int32(0):
-                        gx = wp.int32(0)
-                    if gy >= FEATURE_GRID_HEIGHT:
-                        gy = FEATURE_GRID_HEIGHT - wp.int32(1)
-                    if gx >= FEATURE_GRID_WIDTH:
-                        gx = FEATURE_GRID_WIDTH - wp.int32(1)
+        for cam_i in range(num_cameras):
+            cam_pos = wp.vec3(
+                cam_positions[cam_i, 0],
+                cam_positions[cam_i, 1],
+                cam_positions[cam_i, 2],
+            )
+            cam_quat = wp.quaternion(
+                cam_quaternions[cam_i, 1],
+                cam_quaternions[cam_i, 2],
+                cam_quaternions[cam_i, 3],
+                cam_quaternions[cam_i, 0],
+            )
+            node_cam = wp.quat_rotate(wp.quat_inverse(cam_quat), node_world - cam_pos)
+            z_cam = node_cam[2]
+            if z_cam > depth_min and z_cam <= depth_max:
+                fx = intrinsics[cam_i, 0, 0]
+                fy = intrinsics[cam_i, 1, 1]
+                cx_i = intrinsics[cam_i, 0, 2]
+                cy_i = intrinsics[cam_i, 1, 2]
+                u = fx * node_cam[0] / z_cam + cx_i
+                v = fy * node_cam[1] / z_cam + cy_i
+                px = wp.int32(wp.floor(u + wp.float32(0.5)))
+                py = wp.int32(wp.floor(v + wp.float32(0.5)))
+                if px >= 0 and px < IMAGE_WIDTH and py >= 0 and py < IMAGE_HEIGHT:
+                    depth = depth_images[cam_i, py, px]
+                    sdf = depth - z_cam
+                    if depth >= depth_min and depth <= depth_max and sdf >= -TRUNCATION_DIST and sdf <= TRUNCATION_DIST:
+                        weight = compute_tsdf_weight(depth, VOXEL_SIZE)
+                        gy = (py * FEATURE_GRID_HEIGHT) // IMAGE_HEIGHT
+                        gx = (px * FEATURE_GRID_WIDTH) // IMAGE_WIDTH
+                        if gy < wp.int32(0):
+                            gy = wp.int32(0)
+                        if gx < wp.int32(0):
+                            gx = wp.int32(0)
+                        if gy >= FEATURE_GRID_HEIGHT:
+                            gy = FEATURE_GRID_HEIGHT - wp.int32(1)
+                        if gx >= FEATURE_GRID_WIDTH:
+                            gx = FEATURE_GRID_WIDTH - wp.int32(1)
+                        feature_vals_h = wp.tile_load(
+                            feature_grid[cam_i, gy, gx],
+                            shape=feature_tile_channels,
+                            offset=base_feature_channel,
+                            bounds_check=True,
+                        )
+                        feature_acc = feature_acc + wp.tile_astype(
+                            feature_vals_h,
+                            dtype=wp.float32,
+                        ) * weight
+                        total_w = total_w + weight
 
-                    feature_vals_h = wp.tile_load(
-                        feature_grid[cam_i, gy, gx],
-                        shape=feature_tile_channels,
-                        offset=base_feature_channel,
-                        bounds_check=True,
-                    )
-                    feature_acc = feature_acc + wp.tile_astype(
-                        feature_vals_h,
-                        dtype=wp.float32,
-                    )
+        if total_w <= wp.float32(0.0):
+            for cam_i in range(num_cameras):
+                count = support_counts[vis_idx, cam_i]
+                if count > wp.int32(0):
+                    pixel_idx = support_pixels[vis_idx, cam_i, 0]
+                    py = pixel_idx // IMAGE_WIDTH
+                    px = pixel_idx - py * IMAGE_WIDTH
+                    if (
+                        py >= wp.int32(0)
+                        and py < IMAGE_HEIGHT
+                        and px >= wp.int32(0)
+                        and px < IMAGE_WIDTH
+                    ):
+                        gy = (py * FEATURE_GRID_HEIGHT) // IMAGE_HEIGHT
+                        gx = (px * FEATURE_GRID_WIDTH) // IMAGE_WIDTH
+                        if gy < wp.int32(0):
+                            gy = wp.int32(0)
+                        if gx < wp.int32(0):
+                            gx = wp.int32(0)
+                        if gy >= FEATURE_GRID_HEIGHT:
+                            gy = FEATURE_GRID_HEIGHT - wp.int32(1)
+                        if gx >= FEATURE_GRID_WIDTH:
+                            gx = FEATURE_GRID_WIDTH - wp.int32(1)
+                        feature_vals_h = wp.tile_load(
+                            feature_grid[cam_i, gy, gx],
+                            shape=feature_tile_channels,
+                            offset=base_feature_channel,
+                            bounds_check=True,
+                        )
+                        feature_acc = feature_acc + wp.tile_astype(
+                            feature_vals_h,
+                            dtype=wp.float32,
+                        )
+                        total_w = total_w + wp.float32(1.0)
+
+        if total_w <= wp.float32(0.0):
+            return
 
         feature_acc_h = wp.tile_astype(feature_acc, dtype=wp.float16)
         wp.tile_atomic_add(
-            block_features[pool_idx],
+            block_features[pool_idx, node_idx],
             feature_acc_h,
             offset=base_feature_channel,
             bounds_check=True,
         )
         if feature_tile_idx == wp.int32(0) and lane == wp.int32(0):
-            wp.atomic_add(block_feature_weight, pool_idx, wp.float16(wp.float32(count)))
+            wp.atomic_add(block_feature_weight, pool_idx, node_idx, wp.float16(total_w))
 
     return {
         "compute_block_keys_only_kernel": compute_block_keys_only_kernel,

--- a/curobo/_src/perception/mapper/kernel/builder/builder_camera_integrate.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_camera_integrate.py
@@ -37,6 +37,8 @@ def make_camera_integrate_kernels(
     feature_channels_per_thread: int,
     max_feature_tile_channels: int,
     max_support_pixels_per_block_camera: int,
+    use_color_grid: bool,
+    color_grid_size: int,
     pack_key_only,
     unpack_block_key,
     find_or_insert_block,
@@ -47,6 +49,7 @@ def make_camera_integrate_kernels(
     block_local_to_world,
     block_grid_to_key_coords,
     block_key_to_grid_coords,
+    block_key_to_voxel_base,
 ) -> dict[str, object]:
     """Build camera projective TSDF integration kernels."""
     BLOCK_SIZE = wp.constant(block_size)
@@ -65,6 +68,11 @@ def make_camera_integrate_kernels(
     safe_step = (float(block_size) * float(voxel_size)) / 1.42
     STEP_SIZE = wp.constant(wp.float32(safe_step))
     FEATURE_DIM = wp.constant(wp.int32(feature_dim))
+    USE_COLOR_GRID = wp.constant(bool(use_color_grid))
+    COLOR_GRID_SIZE = wp.constant(wp.int32(color_grid_size))
+    color_grid_voxels = int(color_grid_size) ** 3
+    COLOR_GRID_VOXELS = wp.constant(wp.int32(color_grid_voxels))
+    COLOR_GRID_CELLS = wp.constant(wp.int32(color_grid_voxels * 4))
     if feature_grid_shape is None:
         feature_grid_height = 1
         feature_grid_width = 1
@@ -75,7 +83,7 @@ def make_camera_integrate_kernels(
     FEATURE_GRID_WIDTH = wp.constant(wp.int32(feature_grid_width))
     suffix = (
         f"bs{block_size}_cfg"
-        f"{warp_constant_suffix(block_size, feature_dim, num_cameras, image_height, image_width, num_samples, grid_shape, origin_xyz, voxel_size, truncation_distance, feature_grid_shape, feature_channels_per_thread, max_feature_tile_channels, max_support_pixels_per_block_camera)}"
+        f"{warp_constant_suffix(block_size, feature_dim, num_cameras, image_height, image_width, num_samples, grid_shape, origin_xyz, voxel_size, truncation_distance, feature_grid_shape, feature_channels_per_thread, max_feature_tile_channels, max_support_pixels_per_block_camera, use_color_grid, color_grid_size)}"
     )
 
     # Cross-domain helpers are explicit parameters so Warp sees them as
@@ -337,6 +345,30 @@ def make_camera_integrate_kernels(
         if out_idx < max_blocks:
             clear_pool_indices[out_idx] = pool_idx
 
+    @warp_kernel(f"clear_new_block_grid_rgb_kernel_{suffix}")
+    def clear_new_block_grid_rgb_kernel(
+        block_grid_rgb: wp.array3d(dtype=wp.float16),
+        new_blocks: wp.array(dtype=wp.int32),
+        new_block_count: wp.array(dtype=wp.int32),
+        max_blocks: wp.int32,
+    ):
+        """Zero RGB grid accumulators for blocks allocated during this frame."""
+        slot_idx, cell_idx = wp.tid()
+
+        count = new_block_count[0]
+        if count > max_blocks:
+            count = max_blocks
+        if slot_idx >= count or cell_idx >= COLOR_GRID_CELLS:
+            return
+
+        pool_idx = new_blocks[slot_idx]
+        if pool_idx < wp.int32(0) or pool_idx >= max_blocks:
+            return
+
+        node_idx = cell_idx // wp.int32(4)
+        ch = cell_idx - node_idx * wp.int32(4)
+        block_grid_rgb[pool_idx, node_idx, ch] = wp.float16(0.0)
+
     @warp_kernel(f"clear_blocks_by_pool_kernel_{suffix}")
     def clear_blocks_by_pool_kernel(
         clear_pool_indices: wp.array(dtype=wp.int32),
@@ -366,6 +398,30 @@ def make_camera_integrate_kernels(
             block_rgb[pool_idx, local_idx] = wp.float16(0.0)
         if local_idx == wp.int32(0):
             block_sums[pool_idx] = wp.float32(0.0)
+
+    @warp_kernel(f"clear_block_grid_rgb_by_pool_kernel_{suffix}")
+    def clear_block_grid_rgb_by_pool_kernel(
+        clear_pool_indices: wp.array(dtype=wp.int32),
+        clear_count: wp.array(dtype=wp.int32),
+        block_grid_rgb: wp.array3d(dtype=wp.float16),
+        max_blocks: wp.int32,
+    ):
+        """Zero RGB grid accumulators for explicitly cleared block slots."""
+        slot_idx, cell_idx = wp.tid()
+
+        count = clear_count[0]
+        if count > max_blocks:
+            count = max_blocks
+        if slot_idx >= count or cell_idx >= COLOR_GRID_CELLS:
+            return
+
+        pool_idx = clear_pool_indices[slot_idx]
+        if pool_idx < wp.int32(0) or pool_idx >= max_blocks:
+            return
+
+        node_idx = cell_idx // wp.int32(4)
+        ch = cell_idx - node_idx * wp.int32(4)
+        block_grid_rgb[pool_idx, node_idx, ch] = wp.float16(0.0)
 
     @warp_kernel(f"clear_block_features_by_pool_kernel_{suffix}")
     def clear_block_features_by_pool_kernel(
@@ -485,6 +541,141 @@ def make_camera_integrate_kernels(
             old_w = wp.float32(block_data[pool_idx, local_idx, 1])
             block_data[pool_idx, local_idx, 0] = wp.float16(old_sw + total_sw)
             block_data[pool_idx, local_idx, 1] = wp.float16(old_w + total_w)
+
+    @warp_kernel(f"integrate_block_grid_rgb_kernel_{suffix}")
+    def integrate_block_grid_rgb_kernel(
+        visible_pool_indices: wp.array(dtype=wp.int32),
+        n_visible: wp.int32,
+        intrinsics: wp.array3d(dtype=wp.float32),
+        cam_positions: wp.array2d(dtype=wp.float32),
+        cam_quaternions: wp.array2d(dtype=wp.float32),
+        depth_images: wp.array3d(dtype=wp.float32),
+        rgb_images_flat: wp.array3d(dtype=wp.uint8),
+        depth_min: float,
+        depth_max: float,
+        block_coords: wp.array(dtype=wp.int32),
+        block_grid_rgb: wp.array3d(dtype=wp.float16),
+    ):
+        """Project each RGB-grid node into cameras and integrate weighted RGBW."""
+        vis_idx, node_idx = wp.tid()
+        if vis_idx >= n_visible or node_idx >= COLOR_GRID_VOXELS:
+            return
+        if not USE_COLOR_GRID:
+            return
+
+        pool_idx = visible_pool_indices[vis_idx]
+        if pool_idx < 0:
+            return
+
+        bx = block_coords[pool_idx * 3 + 0]
+        by = block_coords[pool_idx * 3 + 1]
+        bz = block_coords[pool_idx * 3 + 2]
+
+        gx_node = node_idx % COLOR_GRID_SIZE
+        gy_node = (node_idx // COLOR_GRID_SIZE) % COLOR_GRID_SIZE
+        gz_node = node_idx // (COLOR_GRID_SIZE * COLOR_GRID_SIZE)
+
+        local_x = wp.float32(0.0)
+        local_y = wp.float32(0.0)
+        local_z = wp.float32(0.0)
+        if COLOR_GRID_SIZE > wp.int32(1):
+            span = wp.float32(BLOCK_SIZE - wp.int32(1))
+            denom = wp.float32(COLOR_GRID_SIZE - wp.int32(1))
+            local_x = wp.float32(0.5) + wp.float32(gx_node) * span / denom
+            local_y = wp.float32(0.5) + wp.float32(gy_node) * span / denom
+            local_z = wp.float32(0.5) + wp.float32(gz_node) * span / denom
+        else:
+            center = wp.float32(BLOCK_SIZE) * wp.float32(0.5)
+            local_x = center
+            local_y = center
+            local_z = center
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        center_offset_x = wp.float32(GRID_W) * wp.float32(0.5)
+        center_offset_y = wp.float32(GRID_H) * wp.float32(0.5)
+        center_offset_z = wp.float32(GRID_D) * wp.float32(0.5)
+        node_world = (
+            wp.vec3(ORIGIN_X, ORIGIN_Y, ORIGIN_Z)
+            + wp.vec3(
+                wp.float32(base[0]) + local_x - center_offset_x,
+                wp.float32(base[1]) + local_y - center_offset_y,
+                wp.float32(base[2]) + local_z - center_offset_z,
+            )
+            * VOXEL_SIZE
+        )
+
+        inv_255 = wp.float32(1.0 / 255.0)
+        total_r = wp.float32(0.0)
+        total_g = wp.float32(0.0)
+        total_b = wp.float32(0.0)
+        total_w = wp.float32(0.0)
+
+        for cam_i in range(num_cameras):
+            cam_pos = wp.vec3(
+                cam_positions[cam_i, 0],
+                cam_positions[cam_i, 1],
+                cam_positions[cam_i, 2],
+            )
+            cam_quat = wp.quaternion(
+                cam_quaternions[cam_i, 1],
+                cam_quaternions[cam_i, 2],
+                cam_quaternions[cam_i, 3],
+                cam_quaternions[cam_i, 0],
+            )
+            cam_quat_inv = wp.quat_inverse(cam_quat)
+            node_cam = wp.quat_rotate(cam_quat_inv, node_world - cam_pos)
+
+            z_cam = node_cam[2]
+            if z_cam > depth_min and z_cam <= depth_max:
+                fx = intrinsics[cam_i, 0, 0]
+                fy = intrinsics[cam_i, 1, 1]
+                cx_i = intrinsics[cam_i, 0, 2]
+                cy_i = intrinsics[cam_i, 1, 2]
+
+                u = fx * node_cam[0] / z_cam + cx_i
+                v = fy * node_cam[1] / z_cam + cy_i
+
+                px = wp.int32(u)
+                py = wp.int32(v)
+
+                if px >= 0 and px < IMAGE_WIDTH and py >= 0 and py < IMAGE_HEIGHT:
+                    depth = depth_images[cam_i, py, px]
+                    if depth >= depth_min and depth <= depth_max:
+                        sdf = depth - z_cam
+                        if sdf >= -TRUNCATION_DIST and sdf <= TRUNCATION_DIST:
+                            base_weight = compute_tsdf_weight(depth, VOXEL_SIZE)
+                            coverage = (fx * VOXEL_SIZE / z_cam) * (fy * VOXEL_SIZE / z_cam)
+                            weight = base_weight * wp.max(coverage, 1.0)
+                            rgb_row = cam_i * IMAGE_HEIGHT + py
+                            total_r = (
+                                total_r
+                                + wp.float32(rgb_images_flat[rgb_row, px, 0])
+                                * inv_255
+                                * weight
+                            )
+                            total_g = (
+                                total_g
+                                + wp.float32(rgb_images_flat[rgb_row, px, 1])
+                                * inv_255
+                                * weight
+                            )
+                            total_b = (
+                                total_b
+                                + wp.float32(rgb_images_flat[rgb_row, px, 2])
+                                * inv_255
+                                * weight
+                            )
+                            total_w = total_w + weight
+
+        if total_w > wp.float32(0.0):
+            old_r = wp.float32(block_grid_rgb[pool_idx, node_idx, 0])
+            old_g = wp.float32(block_grid_rgb[pool_idx, node_idx, 1])
+            old_b = wp.float32(block_grid_rgb[pool_idx, node_idx, 2])
+            old_w = wp.float32(block_grid_rgb[pool_idx, node_idx, 3])
+            block_grid_rgb[pool_idx, node_idx, 0] = wp.float16(old_r + total_r)
+            block_grid_rgb[pool_idx, node_idx, 1] = wp.float16(old_g + total_g)
+            block_grid_rgb[pool_idx, node_idx, 2] = wp.float16(old_b + total_b)
+            block_grid_rgb[pool_idx, node_idx, 3] = wp.float16(old_w + total_w)
 
     @warp_kernel(
         f"integrate_block_rgb_from_support_kernel_{suffix}_sc{support_capacity}"
@@ -705,10 +896,13 @@ def make_camera_integrate_kernels(
         "allocate_visible_blocks_from_keys_kernel": allocate_visible_blocks_from_keys_kernel,
         "build_support_pixels_from_keys_kernel": build_support_pixels_from_keys_kernel,
         "collect_blocks_in_aabb_kernel": collect_blocks_in_aabb_kernel,
+        "clear_new_block_grid_rgb_kernel": clear_new_block_grid_rgb_kernel,
         "clear_blocks_by_pool_kernel": clear_blocks_by_pool_kernel,
+        "clear_block_grid_rgb_by_pool_kernel": clear_block_grid_rgb_by_pool_kernel,
         "clear_block_features_by_pool_kernel": clear_block_features_by_pool_kernel,
         "integrate_voxels_kernel": integrate_voxels_kernel,
         "integrate_block_rgb_from_support_kernel": integrate_block_rgb_from_support_kernel,
+        "integrate_block_grid_rgb_kernel": integrate_block_grid_rgb_kernel,
         "integrate_features_from_support_grouped_kernel": (
             integrate_features_from_support_grouped_kernel
         ),

--- a/curobo/_src/perception/mapper/kernel/builder/builder_camera_integrate.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_camera_integrate.py
@@ -37,7 +37,6 @@ def make_camera_integrate_kernels(
     feature_channels_per_thread: int,
     max_feature_tile_channels: int,
     max_support_pixels_per_block_camera: int,
-    use_color_grid: bool,
     color_grid_size: int,
     pack_key_only,
     unpack_block_key,
@@ -68,7 +67,6 @@ def make_camera_integrate_kernels(
     safe_step = (float(block_size) * float(voxel_size)) / 1.42
     STEP_SIZE = wp.constant(wp.float32(safe_step))
     FEATURE_DIM = wp.constant(wp.int32(feature_dim))
-    USE_COLOR_GRID = wp.constant(bool(use_color_grid))
     COLOR_GRID_SIZE = wp.constant(wp.int32(color_grid_size))
     color_grid_voxels = int(color_grid_size) ** 3
     COLOR_GRID_VOXELS = wp.constant(wp.int32(color_grid_voxels))
@@ -83,7 +81,7 @@ def make_camera_integrate_kernels(
     FEATURE_GRID_WIDTH = wp.constant(wp.int32(feature_grid_width))
     suffix = (
         f"bs{block_size}_cfg"
-        f"{warp_constant_suffix(block_size, feature_dim, num_cameras, image_height, image_width, num_samples, grid_shape, origin_xyz, voxel_size, truncation_distance, feature_grid_shape, feature_channels_per_thread, max_feature_tile_channels, max_support_pixels_per_block_camera, use_color_grid, color_grid_size)}"
+        f"{warp_constant_suffix(block_size, feature_dim, num_cameras, image_height, image_width, num_samples, grid_shape, origin_xyz, voxel_size, truncation_distance, feature_grid_shape, feature_channels_per_thread, max_feature_tile_channels, max_support_pixels_per_block_camera, color_grid_size)}"
     )
 
     # Cross-domain helpers are explicit parameters so Warp sees them as
@@ -374,7 +372,6 @@ def make_camera_integrate_kernels(
         clear_pool_indices: wp.array(dtype=wp.int32),
         clear_count: wp.array(dtype=wp.int32),
         block_data: wp.array3d(dtype=wp.float16),
-        block_rgb: wp.array2d(dtype=wp.float16),
         block_sums: wp.array(dtype=wp.float32),
         max_blocks: wp.int32,
     ):
@@ -394,8 +391,6 @@ def make_camera_integrate_kernels(
         block_data[pool_idx, local_idx, 0] = wp.float16(0.0)
         block_data[pool_idx, local_idx, 1] = wp.float16(0.0)
 
-        if local_idx < wp.int32(4): # 0, 1, 2, 3
-            block_rgb[pool_idx, local_idx] = wp.float16(0.0)
         if local_idx == wp.int32(0):
             block_sums[pool_idx] = wp.float32(0.0)
 
@@ -550,7 +545,7 @@ def make_camera_integrate_kernels(
         cam_positions: wp.array2d(dtype=wp.float32),
         cam_quaternions: wp.array2d(dtype=wp.float32),
         depth_images: wp.array3d(dtype=wp.float32),
-        rgb_images_flat: wp.array3d(dtype=wp.uint8),
+        rgb_images_flat: wp.array2d(dtype=wp.vec3ub),
         depth_min: float,
         depth_max: float,
         block_coords: wp.array(dtype=wp.int32),
@@ -559,8 +554,6 @@ def make_camera_integrate_kernels(
         """Project each RGB-grid node into cameras and integrate weighted RGBW."""
         vis_idx, node_idx = wp.tid()
         if vis_idx >= n_visible or node_idx >= COLOR_GRID_VOXELS:
-            return
-        if not USE_COLOR_GRID:
             return
 
         pool_idx = visible_pool_indices[vis_idx]
@@ -635,37 +628,151 @@ def make_camera_integrate_kernels(
                 u = fx * node_cam[0] / z_cam + cx_i
                 v = fy * node_cam[1] / z_cam + cy_i
 
-                px = wp.int32(u)
-                py = wp.int32(v)
+                coverage = (fx * VOXEL_SIZE / z_cam) * (fy * VOXEL_SIZE / z_cam)
+                coverage_weight = wp.max(coverage, 1.0)
 
-                if px >= 0 and px < IMAGE_WIDTH and py >= 0 and py < IMAGE_HEIGHT:
-                    depth = depth_images[cam_i, py, px]
-                    if depth >= depth_min and depth <= depth_max:
-                        sdf = depth - z_cam
-                        if sdf >= -TRUNCATION_DIST and sdf <= TRUNCATION_DIST:
-                            base_weight = compute_tsdf_weight(depth, VOXEL_SIZE)
-                            coverage = (fx * VOXEL_SIZE / z_cam) * (fy * VOXEL_SIZE / z_cam)
-                            weight = base_weight * wp.max(coverage, 1.0)
-                            rgb_row = cam_i * IMAGE_HEIGHT + py
+                if (
+                    u >= wp.float32(0.0)
+                    and u <= wp.float32(IMAGE_WIDTH - wp.int32(1))
+                    and v >= wp.float32(0.0)
+                    and v <= wp.float32(IMAGE_HEIGHT - wp.int32(1))
+                ):
+                    px0 = wp.int32(wp.floor(u))
+                    py0 = wp.int32(wp.floor(v))
+                    px1 = wp.min(px0 + wp.int32(1), IMAGE_WIDTH - wp.int32(1))
+                    py1 = wp.min(py0 + wp.int32(1), IMAGE_HEIGHT - wp.int32(1))
+                    tx = u - wp.float32(px0)
+                    ty = v - wp.float32(py0)
+                    wx0 = wp.float32(1.0) - tx
+                    wy0 = wp.float32(1.0) - ty
+                    w00 = wx0 * wy0
+                    w10 = tx * wy0
+                    w01 = wx0 * ty
+                    w11 = tx * ty
+
+                    depth00 = depth_images[cam_i, py0, px0]
+                    if depth00 >= depth_min and depth00 <= depth_max:
+                        sdf00 = depth00 - z_cam
+                        if sdf00 >= -TRUNCATION_DIST and sdf00 <= TRUNCATION_DIST:
+                            weight00 = (
+                                w00
+                                * compute_tsdf_weight(depth00, VOXEL_SIZE)
+                                * coverage_weight
+                            )
+                            row00 = cam_i * IMAGE_HEIGHT + py0
+                            rgb00 = rgb_images_flat[row00, px0]
                             total_r = (
                                 total_r
-                                + wp.float32(rgb_images_flat[rgb_row, px, 0])
+                                + wp.float32(rgb00[0])
                                 * inv_255
-                                * weight
+                                * weight00
                             )
                             total_g = (
                                 total_g
-                                + wp.float32(rgb_images_flat[rgb_row, px, 1])
+                                + wp.float32(rgb00[1])
                                 * inv_255
-                                * weight
+                                * weight00
                             )
                             total_b = (
                                 total_b
-                                + wp.float32(rgb_images_flat[rgb_row, px, 2])
+                                + wp.float32(rgb00[2])
                                 * inv_255
-                                * weight
+                                * weight00
                             )
-                            total_w = total_w + weight
+                            total_w = total_w + weight00
+
+                    depth10 = depth_images[cam_i, py0, px1]
+                    if depth10 >= depth_min and depth10 <= depth_max:
+                        sdf10 = depth10 - z_cam
+                        if sdf10 >= -TRUNCATION_DIST and sdf10 <= TRUNCATION_DIST:
+                            weight10 = (
+                                w10
+                                * compute_tsdf_weight(depth10, VOXEL_SIZE)
+                                * coverage_weight
+                            )
+                            row10 = cam_i * IMAGE_HEIGHT + py0
+                            rgb10 = rgb_images_flat[row10, px1]
+                            total_r = (
+                                total_r
+                                + wp.float32(rgb10[0])
+                                * inv_255
+                                * weight10
+                            )
+                            total_g = (
+                                total_g
+                                + wp.float32(rgb10[1])
+                                * inv_255
+                                * weight10
+                            )
+                            total_b = (
+                                total_b
+                                + wp.float32(rgb10[2])
+                                * inv_255
+                                * weight10
+                            )
+                            total_w = total_w + weight10
+
+                    depth01 = depth_images[cam_i, py1, px0]
+                    if depth01 >= depth_min and depth01 <= depth_max:
+                        sdf01 = depth01 - z_cam
+                        if sdf01 >= -TRUNCATION_DIST and sdf01 <= TRUNCATION_DIST:
+                            weight01 = (
+                                w01
+                                * compute_tsdf_weight(depth01, VOXEL_SIZE)
+                                * coverage_weight
+                            )
+                            row01 = cam_i * IMAGE_HEIGHT + py1
+                            rgb01 = rgb_images_flat[row01, px0]
+                            total_r = (
+                                total_r
+                                + wp.float32(rgb01[0])
+                                * inv_255
+                                * weight01
+                            )
+                            total_g = (
+                                total_g
+                                + wp.float32(rgb01[1])
+                                * inv_255
+                                * weight01
+                            )
+                            total_b = (
+                                total_b
+                                + wp.float32(rgb01[2])
+                                * inv_255
+                                * weight01
+                            )
+                            total_w = total_w + weight01
+
+                    depth11 = depth_images[cam_i, py1, px1]
+                    if depth11 >= depth_min and depth11 <= depth_max:
+                        sdf11 = depth11 - z_cam
+                        if sdf11 >= -TRUNCATION_DIST and sdf11 <= TRUNCATION_DIST:
+                            weight11 = (
+                                w11
+                                * compute_tsdf_weight(depth11, VOXEL_SIZE)
+                                * coverage_weight
+                            )
+                            row11 = cam_i * IMAGE_HEIGHT + py1
+                            rgb11 = rgb_images_flat[row11, px1]
+                            total_r = (
+                                total_r
+                                + wp.float32(rgb11[0])
+                                * inv_255
+                                * weight11
+                            )
+                            total_g = (
+                                total_g
+                                + wp.float32(rgb11[1])
+                                * inv_255
+                                * weight11
+                            )
+                            total_b = (
+                                total_b
+                                + wp.float32(rgb11[2])
+                                * inv_255
+                                * weight11
+                            )
+                            total_w = total_w + weight11
 
         if total_w > wp.float32(0.0):
             old_r = wp.float32(block_grid_rgb[pool_idx, node_idx, 0])
@@ -676,59 +783,6 @@ def make_camera_integrate_kernels(
             block_grid_rgb[pool_idx, node_idx, 1] = wp.float16(old_g + total_g)
             block_grid_rgb[pool_idx, node_idx, 2] = wp.float16(old_b + total_b)
             block_grid_rgb[pool_idx, node_idx, 3] = wp.float16(old_w + total_w)
-
-    @warp_kernel(
-        f"integrate_block_rgb_from_support_kernel_{suffix}_sc{support_capacity}"
-    )
-    def integrate_block_rgb_from_support_kernel(
-        visible_pool_indices: wp.array(dtype=wp.int32),
-        n_visible: wp.int32,
-        support_counts: wp.array2d(dtype=wp.int32),
-        support_pixels: wp.array3d(dtype=wp.int32),
-        rgb_images_flat: wp.array3d(dtype=wp.uint8),
-        block_rgb: wp.array2d(dtype=wp.float16),
-    ):
-        """Per-block RGB aggregation from allocation-time support pixels."""
-        vis_idx, cam_i = wp.tid()
-        if vis_idx >= n_visible:
-            return
-
-        pool_idx = visible_pool_indices[vis_idx]
-        if pool_idx < wp.int32(0):
-            return
-
-        count = support_counts[vis_idx, cam_i]
-        if count > SUPPORT_CAPACITY:
-            count = SUPPORT_CAPACITY
-        if count <= wp.int32(0):
-            return
-
-        inv_255 = wp.float32(1.0 / 255.0)
-        total_r = wp.float32(0.0)
-        total_g = wp.float32(0.0)
-        total_b = wp.float32(0.0)
-
-        for k in range(support_capacity):
-            if k < count:
-                pixel_idx = support_pixels[vis_idx, cam_i, k]
-                py = pixel_idx // IMAGE_WIDTH
-                px = pixel_idx - py * IMAGE_WIDTH
-                if (
-                    py >= wp.int32(0)
-                    and py < IMAGE_HEIGHT
-                    and px >= wp.int32(0)
-                    and px < IMAGE_WIDTH
-                ):
-                    rgb_row = cam_i * IMAGE_HEIGHT + py
-                    total_r = total_r + wp.float32(rgb_images_flat[rgb_row, px, 0]) * inv_255
-                    total_g = total_g + wp.float32(rgb_images_flat[rgb_row, px, 1]) * inv_255
-                    total_b = total_b + wp.float32(rgb_images_flat[rgb_row, px, 2]) * inv_255
-
-        weight = wp.float32(count)
-        wp.atomic_add(block_rgb, pool_idx, 0, wp.float16(total_r))
-        wp.atomic_add(block_rgb, pool_idx, 1, wp.float16(total_g))
-        wp.atomic_add(block_rgb, pool_idx, 2, wp.float16(total_b))
-        wp.atomic_add(block_rgb, pool_idx, 3, wp.float16(weight))
 
     @warp_kernel(
         f"integrate_features_from_support_grouped_kernel_{suffix}_fcpt"
@@ -901,7 +955,6 @@ def make_camera_integrate_kernels(
         "clear_block_grid_rgb_by_pool_kernel": clear_block_grid_rgb_by_pool_kernel,
         "clear_block_features_by_pool_kernel": clear_block_features_by_pool_kernel,
         "integrate_voxels_kernel": integrate_voxels_kernel,
-        "integrate_block_rgb_from_support_kernel": integrate_block_rgb_from_support_kernel,
         "integrate_block_grid_rgb_kernel": integrate_block_grid_rgb_kernel,
         "integrate_features_from_support_grouped_kernel": (
             integrate_features_from_support_grouped_kernel
@@ -909,6 +962,5 @@ def make_camera_integrate_kernels(
         "integrate_features_from_support_tiled_kernel": (
             integrate_features_from_support_tiled_kernel
         ),
-        "integrate_block_rgb_kernel": integrate_block_rgb_from_support_kernel,
         "integrate_features_grouped_kernel": integrate_features_from_support_grouped_kernel,
     }

--- a/curobo/_src/perception/mapper/kernel/builder/builder_hash.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_hash.py
@@ -451,19 +451,19 @@ def make_hash_kernels(
 
     @warp_kernel(f"clear_new_block_features_kernel_{suffix}")
     def clear_new_block_features_kernel(
-        block_features: wp.array2d(dtype=wp.float16),
-        block_feature_weight: wp.array(dtype=wp.float16),
+        block_features: wp.array3d(dtype=wp.float16),
+        block_feature_weight: wp.array2d(dtype=wp.float16),
         new_blocks: wp.array(dtype=wp.int32),
         new_block_count: wp.array(dtype=wp.int32),
         max_blocks: wp.int32,
     ):
-        """Zero the per-block feature accumulator for freshly allocated blocks.
+        """Zero the per-block feature-grid accumulator for freshly allocated blocks.
 
-        Launch with ``dim = (max_clearable, feature_dim)`` so one thread
-        clears one ``(block, channel)`` cell; the thread with
-        ``ch == 0`` also zeroes the per-block feature weight.
+        Launch with ``dim = (max_clearable, feature_nodes, feature_dim)`` so
+        one thread clears one ``(block, node, channel)`` cell; the thread
+        with ``ch == 0`` also zeroes the per-node feature weight.
         """
-        slot_idx, ch = wp.tid()
+        slot_idx, node_idx, ch = wp.tid()
 
         count = new_block_count[0]
         if count > max_blocks:
@@ -472,9 +472,9 @@ def make_hash_kernels(
             return
 
         pool_idx = new_blocks[slot_idx]
-        block_features[pool_idx, ch] = wp.float16(0.0)
+        block_features[pool_idx, node_idx, ch] = wp.float16(0.0)
         if ch == wp.int32(0):
-            block_feature_weight[pool_idx] = wp.float16(0.0)
+            block_feature_weight[pool_idx, node_idx] = wp.float16(0.0)
 
     # Register all closures on the instance for external access.
     return {

--- a/curobo/_src/perception/mapper/kernel/builder/builder_hash.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_hash.py
@@ -145,47 +145,6 @@ def make_hash_kernels(
     def pack_rgb(r: wp.uint8, g: wp.uint8, b: wp.uint8) -> wp.int32:
         return (wp.int32(r) << 16) | (wp.int32(g) << 8) | wp.int32(b)
 
-    @warp_func(f"compute_avg_rgb_from_block_{suffix}")
-    def compute_avg_rgb_from_block(
-        block_rgb: wp.array2d(dtype=wp.float16),
-        pool_idx: wp.int32,
-    ) -> wp.vec3:
-        """Weighted-mean RGB for a block, rescaled to ``[0, 255]``.
-
-        Weighted sums are stored fp16 with RGB pre-normalized to
-        ``[0, 1]`` at the integration site; divide in fp32 and
-        multiply by 255 to match the legacy uint8-scaled output
-        consumers expect.
-        """
-        r_sum = wp.float32(block_rgb[pool_idx, 0])
-        g_sum = wp.float32(block_rgb[pool_idx, 1])
-        b_sum = wp.float32(block_rgb[pool_idx, 2])
-        w = wp.float32(block_rgb[pool_idx, 3])
-        if w < 1e-6:
-            return wp.vec3(0.0, 0.0, 0.0)
-        scale = 255.0 / w
-        r = wp.clamp(r_sum * scale, 0.0, 255.0)
-        g = wp.clamp(g_sum * scale, 0.0, 255.0)
-        b = wp.clamp(b_sum * scale, 0.0, 255.0)
-        return wp.vec3(r, g, b)
-
-    @warp_func(f"compute_avg_rgb_uint8_from_block_{suffix}")
-    def compute_avg_rgb_uint8_from_block(
-        block_rgb: wp.array2d(dtype=wp.float16),
-        pool_idx: wp.int32,
-    ) -> wp.vec3i:
-        r_sum = wp.float32(block_rgb[pool_idx, 0])
-        g_sum = wp.float32(block_rgb[pool_idx, 1])
-        b_sum = wp.float32(block_rgb[pool_idx, 2])
-        w = wp.float32(block_rgb[pool_idx, 3])
-        if w < 1e-6:
-            return wp.vec3i(0, 0, 0)
-        scale = 255.0 / w
-        r = wp.int32(wp.clamp(r_sum * scale, 0.0, 255.0))
-        g = wp.int32(wp.clamp(g_sum * scale, 0.0, 255.0))
-        b = wp.int32(wp.clamp(b_sum * scale, 0.0, 255.0))
-        return wp.vec3i(r, g, b)
-
     # =====================================================================
     # Hash Table Lookup
     # =====================================================================
@@ -473,7 +432,6 @@ def make_hash_kernels(
     @warp_kernel(f"clear_new_blocks_kernel_{suffix}")
     def clear_new_blocks_kernel(
         block_data: wp.array3d(dtype=wp.float16),
-        block_rgb: wp.array2d(dtype=wp.float16),
         new_blocks: wp.array(dtype=wp.int32),
         new_block_count: wp.array(dtype=wp.int32),
         max_blocks: wp.int32,
@@ -490,12 +448,6 @@ def make_hash_kernels(
 
         block_data[pool_idx, local_idx, 0] = wp.float16(0.0)
         block_data[pool_idx, local_idx, 1] = wp.float16(0.0)
-
-        if local_idx == 0:
-            block_rgb[pool_idx, 0] = wp.float16(0.0)
-            block_rgb[pool_idx, 1] = wp.float16(0.0)
-            block_rgb[pool_idx, 2] = wp.float16(0.0)
-            block_rgb[pool_idx, 3] = wp.float16(0.0)
 
     @warp_kernel(f"clear_new_block_features_kernel_{suffix}")
     def clear_new_block_features_kernel(
@@ -534,8 +486,6 @@ def make_hash_kernels(
         "is_valid_block_key": is_valid_block_key,
         "spatial_hash": spatial_hash,
         "pack_rgb": pack_rgb,
-        "compute_avg_rgb_from_block": compute_avg_rgb_from_block,
-        "compute_avg_rgb_uint8_from_block": compute_avg_rgb_uint8_from_block,
         "hash_lookup": hash_lookup,
         "free_list_pop": free_list_pop,
         "free_list_push": free_list_push,

--- a/curobo/_src/perception/mapper/kernel/builder/builder_lidar_integrate.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_lidar_integrate.py
@@ -32,12 +32,14 @@ def make_lidar_integrate_kernels(
     max_feature_tile_channels: int,
     max_support_pixels_per_block_lidar: int,
     color_grid_size: int,
+    feature_block_grid_size: int,
     pack_key_only,
     unpack_block_key,
     hash_lookup,
     world_to_continuous_voxel,
     block_local_to_world,
     block_grid_to_key_coords,
+    block_key_to_voxel_base,
 ) -> dict[str, object]:
     """Build LiDAR range-image integration kernels."""
     BLOCK_SIZE = wp.constant(block_size)
@@ -48,6 +50,9 @@ def make_lidar_integrate_kernels(
     GRID_D = wp.constant(wp.int32(grid_shape[0]))
     GRID_H = wp.constant(wp.int32(grid_shape[1]))
     GRID_W = wp.constant(wp.int32(grid_shape[2]))
+    ORIGIN_X = wp.constant(wp.float32(origin_xyz[0]))
+    ORIGIN_Y = wp.constant(wp.float32(origin_xyz[1]))
+    ORIGIN_Z = wp.constant(wp.float32(origin_xyz[2]))
     VOXEL_SIZE = wp.constant(wp.float32(voxel_size))
     TRUNCATION_DIST = wp.constant(wp.float32(truncation_distance))
     PI = wp.constant(wp.float32(3.141592653589793))
@@ -56,7 +61,11 @@ def make_lidar_integrate_kernels(
     STEP_SIZE = wp.constant(wp.float32(safe_step))
     FEATURE_DIM = wp.constant(wp.int32(feature_dim))
     color_grid_voxels = int(color_grid_size) ** 3
+    COLOR_GRID_SIZE = wp.constant(wp.int32(color_grid_size))
     COLOR_GRID_VOXELS = wp.constant(wp.int32(color_grid_voxels))
+    feature_grid_voxels = int(feature_block_grid_size) ** 3
+    FEATURE_BLOCK_GRID_SIZE = wp.constant(wp.int32(feature_block_grid_size))
+    FEATURE_GRID_VOXELS = wp.constant(wp.int32(feature_grid_voxels))
     if lidar_feature_grid_shape is None:
         lidar_feature_grid_height = 1
         lidar_feature_grid_width = 1
@@ -70,10 +79,25 @@ def make_lidar_integrate_kernels(
     FEATURE_TILE_CHANNELS = wp.constant(feature_tile_channels)
     support_capacity = int(max_support_pixels_per_block_lidar)
     SUPPORT_CAPACITY = wp.constant(support_capacity)
-    suffix = (
-        f"bs{block_size}_cfg"
-        f"{warp_constant_suffix(block_size, feature_dim, lidar_num_sensors, lidar_image_height, lidar_image_width, num_samples, grid_shape, origin_xyz, voxel_size, truncation_distance, lidar_feature_grid_shape, feature_channels_per_thread, max_feature_tile_channels, max_support_pixels_per_block_lidar, color_grid_size)}"
+    suffix_hash = warp_constant_suffix(
+        block_size,
+        feature_dim,
+        lidar_num_sensors,
+        lidar_image_height,
+        lidar_image_width,
+        num_samples,
+        grid_shape,
+        origin_xyz,
+        voxel_size,
+        truncation_distance,
+        lidar_feature_grid_shape,
+        feature_channels_per_thread,
+        max_feature_tile_channels,
+        max_support_pixels_per_block_lidar,
+        color_grid_size,
+        feature_block_grid_size,
     )
+    suffix = f"bs{block_size}_cfg{suffix_hash}"
 
     @wp.func
     def _lidar_pixel_ray(
@@ -113,6 +137,20 @@ def make_lidar_integrate_kernels(
         max_range: wp.float32,
     ) -> bool:
         return value >= min_range and value <= max_range
+
+    @wp.func
+    def _lidar_feature_grid_coords(px: wp.int32, py: wp.int32) -> wp.vec2i:
+        gx = (px * LIDAR_FEATURE_GRID_WIDTH) // LIDAR_IMAGE_WIDTH
+        gy = (py * LIDAR_FEATURE_GRID_HEIGHT) // LIDAR_IMAGE_HEIGHT
+        if gx < wp.int32(0):
+            gx = wp.int32(0)
+        if gy < wp.int32(0):
+            gy = wp.int32(0)
+        if gx >= LIDAR_FEATURE_GRID_WIDTH:
+            gx = LIDAR_FEATURE_GRID_WIDTH - wp.int32(1)
+        if gy >= LIDAR_FEATURE_GRID_HEIGHT:
+            gy = LIDAR_FEATURE_GRID_HEIGHT - wp.int32(1)
+        return wp.vec2i(gx, gy)
 
     @warp_kernel(f"lidar_compute_block_keys_only_kernel_{suffix}")
     def lidar_compute_block_keys_only_kernel(
@@ -469,15 +507,19 @@ def make_lidar_integrate_kernels(
             block_data[pool_idx, local_idx, 0] = wp.float16(old_sw + total_sw)
             block_data[pool_idx, local_idx, 1] = wp.float16(old_w + total_w)
 
-    @warp_kernel(
-        f"lidar_integrate_block_grid_rgb_from_support_kernel_{suffix}_sc{support_capacity}"
-    )
-    def lidar_integrate_block_grid_rgb_from_support_kernel(
+    @warp_kernel(f"lidar_integrate_block_grid_rgb_kernel_{suffix}")
+    def lidar_integrate_block_grid_rgb_kernel(
         visible_pool_indices: wp.array(dtype=wp.int32),
         n_visible: wp.int32,
+        lidar_positions: wp.array2d(dtype=wp.float32),
+        lidar_quaternions: wp.array2d(dtype=wp.float32),
+        range_images: wp.array3d(dtype=wp.float32),
+        rgb_images_flat: wp.array2d(dtype=wp.vec3ub),
         support_counts: wp.array2d(dtype=wp.int32),
         support_pixels: wp.array3d(dtype=wp.int32),
-        rgb_images_flat: wp.array3d(dtype=wp.uint8),
+        valid_range_m: wp.array2d(dtype=wp.float32),
+        elevation_range_rad: wp.array2d(dtype=wp.float32),
+        block_coords: wp.array(dtype=wp.int32),
         block_grid_rgb: wp.array3d(dtype=wp.float16),
     ):
         vis_idx, lidar_i, node_idx = wp.tid()
@@ -487,36 +529,215 @@ def make_lidar_integrate_kernels(
         if pool_idx < wp.int32(0):
             return
 
-        count = support_counts[vis_idx, lidar_i]
-        if count > SUPPORT_CAPACITY:
-            count = SUPPORT_CAPACITY
-        if count <= wp.int32(0):
+        bx = block_coords[pool_idx * 3 + 0]
+        by = block_coords[pool_idx * 3 + 1]
+        bz = block_coords[pool_idx * 3 + 2]
+
+        gx_node = node_idx % COLOR_GRID_SIZE
+        gy_node = (node_idx // COLOR_GRID_SIZE) % COLOR_GRID_SIZE
+        gz_node = node_idx // (COLOR_GRID_SIZE * COLOR_GRID_SIZE)
+
+        local_x = wp.float32(0.0)
+        local_y = wp.float32(0.0)
+        local_z = wp.float32(0.0)
+        if COLOR_GRID_SIZE > wp.int32(1):
+            span = wp.float32(BLOCK_SIZE - wp.int32(1))
+            denom = wp.float32(COLOR_GRID_SIZE - wp.int32(1))
+            local_x = wp.float32(0.5) + wp.float32(gx_node) * span / denom
+            local_y = wp.float32(0.5) + wp.float32(gy_node) * span / denom
+            local_z = wp.float32(0.5) + wp.float32(gz_node) * span / denom
+        else:
+            center = wp.float32(BLOCK_SIZE) * wp.float32(0.5)
+            local_x = center
+            local_y = center
+            local_z = center
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        center_offset_x = wp.float32(GRID_W) * wp.float32(0.5)
+        center_offset_y = wp.float32(GRID_H) * wp.float32(0.5)
+        center_offset_z = wp.float32(GRID_D) * wp.float32(0.5)
+        node_world = (
+            wp.vec3(ORIGIN_X, ORIGIN_Y, ORIGIN_Z)
+            + wp.vec3(
+                wp.float32(base[0]) + local_x - center_offset_x,
+                wp.float32(base[1]) + local_y - center_offset_y,
+                wp.float32(base[2]) + local_z - center_offset_z,
+            )
+            * VOXEL_SIZE
+        )
+
+        lidar_pos = wp.vec3(
+            lidar_positions[lidar_i, 0],
+            lidar_positions[lidar_i, 1],
+            lidar_positions[lidar_i, 2],
+        )
+        lidar_quat = wp.quaternion(
+            lidar_quaternions[lidar_i, 1],
+            lidar_quaternions[lidar_i, 2],
+            lidar_quaternions[lidar_i, 3],
+            lidar_quaternions[lidar_i, 0],
+        )
+        node_lidar = wp.quat_rotate(wp.quat_inverse(lidar_quat), node_world - lidar_pos)
+        node_range = wp.sqrt(wp.dot(node_lidar, node_lidar))
+        inv_255 = wp.float32(1.0 / 255.0)
+
+        min_range = valid_range_m[lidar_i, 0]
+        max_range = valid_range_m[lidar_i, 1]
+        if not _range_valid(node_range, min_range, max_range):
+            count = support_counts[vis_idx, lidar_i]
+            if count > wp.int32(0):
+                pixel_idx = support_pixels[vis_idx, lidar_i, 0]
+                px = pixel_idx % LIDAR_IMAGE_WIDTH
+                py = pixel_idx // LIDAR_IMAGE_WIDTH
+                if py >= wp.int32(0) and py < LIDAR_IMAGE_HEIGHT and px >= wp.int32(0) and px < LIDAR_IMAGE_WIDTH:
+                    row = lidar_i * LIDAR_IMAGE_HEIGHT + py
+                    rgb = rgb_images_flat[row, px]
+                    wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 0, wp.float16(wp.float32(rgb[0]) * inv_255))
+                    wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 1, wp.float16(wp.float32(rgb[1]) * inv_255))
+                    wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 2, wp.float16(wp.float32(rgb[2]) * inv_255))
+                    wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 3, wp.float16(1.0))
             return
 
-        inv_255 = wp.float32(1.0 / 255.0)
+        min_elev = elevation_range_rad[lidar_i, 0]
+        max_elev = elevation_range_rad[lidar_i, 1]
+        xy_norm = wp.sqrt(node_lidar[0] * node_lidar[0] + node_lidar[1] * node_lidar[1])
+        elevation = wp.atan2(node_lidar[2], xy_norm)
+        v_float = wp.float32(0.0)
+        if LIDAR_IMAGE_HEIGHT > wp.int32(1):
+            if elevation < min_elev or elevation > max_elev:
+                count = support_counts[vis_idx, lidar_i]
+                if count > wp.int32(0):
+                    pixel_idx = support_pixels[vis_idx, lidar_i, 0]
+                    px = pixel_idx % LIDAR_IMAGE_WIDTH
+                    py = pixel_idx // LIDAR_IMAGE_WIDTH
+                    if py >= wp.int32(0) and py < LIDAR_IMAGE_HEIGHT and px >= wp.int32(0) and px < LIDAR_IMAGE_WIDTH:
+                        row = lidar_i * LIDAR_IMAGE_HEIGHT + py
+                        rgb = rgb_images_flat[row, px]
+                        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 0, wp.float16(wp.float32(rgb[0]) * inv_255))
+                        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 1, wp.float16(wp.float32(rgb[1]) * inv_255))
+                        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 2, wp.float16(wp.float32(rgb[2]) * inv_255))
+                        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 3, wp.float16(1.0))
+                return
+            v_float = (max_elev - elevation) * (
+                wp.float32(LIDAR_IMAGE_HEIGHT - wp.int32(1)) / (max_elev - min_elev)
+            )
+
+        azimuth = wp.atan2(node_lidar[1], node_lidar[0])
+        u_float = (azimuth + PI) * (wp.float32(LIDAR_IMAGE_WIDTH) / TWO_PI)
+        if u_float >= wp.float32(LIDAR_IMAGE_WIDTH):
+            u_float = u_float - wp.float32(LIDAR_IMAGE_WIDTH)
+        if u_float < wp.float32(0.0):
+            u_float = u_float + wp.float32(LIDAR_IMAGE_WIDTH)
+
+        u0 = wp.int32(wp.floor(u_float))
+        if u0 < wp.int32(0):
+            u0 = u0 + LIDAR_IMAGE_WIDTH
+        if u0 >= LIDAR_IMAGE_WIDTH:
+            u0 = u0 - LIDAR_IMAGE_WIDTH
+        u1 = u0 + wp.int32(1)
+        if u1 >= LIDAR_IMAGE_WIDTH:
+            u1 = wp.int32(0)
+        fu = u_float - wp.floor(u_float)
+
+        v0 = wp.int32(0)
+        v1 = wp.int32(0)
+        fv = wp.float32(0.0)
+        if LIDAR_IMAGE_HEIGHT > wp.int32(1):
+            v0 = wp.int32(wp.floor(v_float))
+            if v0 < wp.int32(0) or v0 >= LIDAR_IMAGE_HEIGHT:
+                count = support_counts[vis_idx, lidar_i]
+                if count > wp.int32(0):
+                    pixel_idx = support_pixels[vis_idx, lidar_i, 0]
+                    px = pixel_idx % LIDAR_IMAGE_WIDTH
+                    py = pixel_idx // LIDAR_IMAGE_WIDTH
+                    if py >= wp.int32(0) and py < LIDAR_IMAGE_HEIGHT and px >= wp.int32(0) and px < LIDAR_IMAGE_WIDTH:
+                        row = lidar_i * LIDAR_IMAGE_HEIGHT + py
+                        rgb = rgb_images_flat[row, px]
+                        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 0, wp.float16(wp.float32(rgb[0]) * inv_255))
+                        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 1, wp.float16(wp.float32(rgb[1]) * inv_255))
+                        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 2, wp.float16(wp.float32(rgb[2]) * inv_255))
+                        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 3, wp.float16(1.0))
+                return
+            v1 = wp.min(v0 + wp.int32(1), LIDAR_IMAGE_HEIGHT - wp.int32(1))
+            fv = v_float - wp.float32(v0)
+
+        wx0 = wp.float32(1.0) - fu
+        wy0 = wp.float32(1.0) - fv
+        w00 = wx0 * wy0
+        w10 = fu * wy0
+        w01 = wx0 * fv
+        w11 = fu * fv
         total_r = wp.float32(0.0)
         total_g = wp.float32(0.0)
         total_b = wp.float32(0.0)
-        for k in range(support_capacity):
-            if k < count:
-                pixel_idx = support_pixels[vis_idx, lidar_i, k]
+        total_w = wp.float32(0.0)
+
+        range00 = range_images[lidar_i, v0, u0]
+        if _range_valid(range00, min_range, max_range):
+            sdf00 = range00 - node_range
+            if sdf00 >= -TRUNCATION_DIST and sdf00 <= TRUNCATION_DIST:
+                weight00 = w00 * compute_tsdf_weight(range00, VOXEL_SIZE)
+                row00 = lidar_i * LIDAR_IMAGE_HEIGHT + v0
+                rgb00 = rgb_images_flat[row00, u0]
+                total_r = total_r + wp.float32(rgb00[0]) * inv_255 * weight00
+                total_g = total_g + wp.float32(rgb00[1]) * inv_255 * weight00
+                total_b = total_b + wp.float32(rgb00[2]) * inv_255 * weight00
+                total_w = total_w + weight00
+
+        range10 = range_images[lidar_i, v0, u1]
+        if _range_valid(range10, min_range, max_range):
+            sdf10 = range10 - node_range
+            if sdf10 >= -TRUNCATION_DIST and sdf10 <= TRUNCATION_DIST:
+                weight10 = w10 * compute_tsdf_weight(range10, VOXEL_SIZE)
+                row10 = lidar_i * LIDAR_IMAGE_HEIGHT + v0
+                rgb10 = rgb_images_flat[row10, u1]
+                total_r = total_r + wp.float32(rgb10[0]) * inv_255 * weight10
+                total_g = total_g + wp.float32(rgb10[1]) * inv_255 * weight10
+                total_b = total_b + wp.float32(rgb10[2]) * inv_255 * weight10
+                total_w = total_w + weight10
+
+        range01 = range_images[lidar_i, v1, u0]
+        if _range_valid(range01, min_range, max_range):
+            sdf01 = range01 - node_range
+            if sdf01 >= -TRUNCATION_DIST and sdf01 <= TRUNCATION_DIST:
+                weight01 = w01 * compute_tsdf_weight(range01, VOXEL_SIZE)
+                row01 = lidar_i * LIDAR_IMAGE_HEIGHT + v1
+                rgb01 = rgb_images_flat[row01, u0]
+                total_r = total_r + wp.float32(rgb01[0]) * inv_255 * weight01
+                total_g = total_g + wp.float32(rgb01[1]) * inv_255 * weight01
+                total_b = total_b + wp.float32(rgb01[2]) * inv_255 * weight01
+                total_w = total_w + weight01
+
+        range11 = range_images[lidar_i, v1, u1]
+        if _range_valid(range11, min_range, max_range):
+            sdf11 = range11 - node_range
+            if sdf11 >= -TRUNCATION_DIST and sdf11 <= TRUNCATION_DIST:
+                weight11 = w11 * compute_tsdf_weight(range11, VOXEL_SIZE)
+                row11 = lidar_i * LIDAR_IMAGE_HEIGHT + v1
+                rgb11 = rgb_images_flat[row11, u1]
+                total_r = total_r + wp.float32(rgb11[0]) * inv_255 * weight11
+                total_g = total_g + wp.float32(rgb11[1]) * inv_255 * weight11
+                total_b = total_b + wp.float32(rgb11[2]) * inv_255 * weight11
+                total_w = total_w + weight11
+
+        if total_w > wp.float32(0.0):
+            wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 0, wp.float16(total_r))
+            wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 1, wp.float16(total_g))
+            wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 2, wp.float16(total_b))
+            wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 3, wp.float16(total_w))
+        else:
+            count = support_counts[vis_idx, lidar_i]
+            if count > wp.int32(0):
+                pixel_idx = support_pixels[vis_idx, lidar_i, 0]
                 px = pixel_idx % LIDAR_IMAGE_WIDTH
                 py = pixel_idx // LIDAR_IMAGE_WIDTH
-                row = lidar_i * LIDAR_IMAGE_HEIGHT + py
-                total_r = total_r + wp.float32(rgb_images_flat[row, px, 0]) * inv_255
-                total_g = total_g + wp.float32(rgb_images_flat[row, px, 1]) * inv_255
-                total_b = total_b + wp.float32(rgb_images_flat[row, px, 2]) * inv_255
-
-        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 0, wp.float16(total_r))
-        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 1, wp.float16(total_g))
-        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 2, wp.float16(total_b))
-        wp.atomic_add(
-            block_grid_rgb,
-            pool_idx,
-            node_idx,
-            3,
-            wp.float16(wp.float32(count)),
-        )
+                if py >= wp.int32(0) and py < LIDAR_IMAGE_HEIGHT and px >= wp.int32(0) and px < LIDAR_IMAGE_WIDTH:
+                    row = lidar_i * LIDAR_IMAGE_HEIGHT + py
+                    rgb = rgb_images_flat[row, px]
+                    wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 0, wp.float16(wp.float32(rgb[0]) * inv_255))
+                    wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 1, wp.float16(wp.float32(rgb[1]) * inv_255))
+                    wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 2, wp.float16(wp.float32(rgb[2]) * inv_255))
+                    wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 3, wp.float16(1.0))
 
     @warp_kernel(
         f"lidar_integrate_features_from_support_grouped_kernel_{suffix}_fcpt"
@@ -525,42 +746,262 @@ def make_lidar_integrate_kernels(
     def lidar_integrate_features_from_support_grouped_kernel(
         visible_pool_indices: wp.array(dtype=wp.int32),
         n_visible: wp.int32,
+        lidar_positions: wp.array2d(dtype=wp.float32),
+        lidar_quaternions: wp.array2d(dtype=wp.float32),
+        range_images: wp.array3d(dtype=wp.float32),
+        valid_range_m: wp.array2d(dtype=wp.float32),
+        elevation_range_rad: wp.array2d(dtype=wp.float32),
+        block_coords: wp.array(dtype=wp.int32),
         support_counts: wp.array2d(dtype=wp.int32),
         support_pixels: wp.array3d(dtype=wp.int32),
         feature_grid: wp.array4d(dtype=wp.float16),
-        block_features: wp.array2d(dtype=wp.float16),
-        block_feature_weight: wp.array(dtype=wp.float16),
+        block_features: wp.array3d(dtype=wp.float16),
+        block_feature_weight: wp.array2d(dtype=wp.float16),
     ):
-        vis_idx, lidar_i, feature_channel_group_idx = wp.tid()
         n_channel_groups = (FEATURE_DIM + FEATURE_CHANNELS_PER_THREAD - wp.int32(1)) // FEATURE_CHANNELS_PER_THREAD
-        if vis_idx >= n_visible or feature_channel_group_idx >= n_channel_groups:
+        vis_idx, lidar_i, node_group_idx = wp.tid()
+        node_idx = node_group_idx // n_channel_groups
+        feature_channel_group_idx = node_group_idx - node_idx * n_channel_groups
+        if (
+            vis_idx >= n_visible
+            or node_idx >= FEATURE_GRID_VOXELS
+            or feature_channel_group_idx >= n_channel_groups
+        ):
             return
 
         pool_idx = visible_pool_indices[vis_idx]
         if pool_idx < wp.int32(0):
             return
-        count = support_counts[vis_idx, lidar_i]
-        if count > SUPPORT_CAPACITY:
-            count = SUPPORT_CAPACITY
-        if count <= wp.int32(0):
-            return
+
+        bx = block_coords[pool_idx * 3 + 0]
+        by = block_coords[pool_idx * 3 + 1]
+        bz = block_coords[pool_idx * 3 + 2]
+
+        gx_node = node_idx % FEATURE_BLOCK_GRID_SIZE
+        gy_node = (node_idx // FEATURE_BLOCK_GRID_SIZE) % FEATURE_BLOCK_GRID_SIZE
+        gz_node = node_idx // (FEATURE_BLOCK_GRID_SIZE * FEATURE_BLOCK_GRID_SIZE)
+
+        local_x = wp.float32(0.0)
+        local_y = wp.float32(0.0)
+        local_z = wp.float32(0.0)
+        if FEATURE_BLOCK_GRID_SIZE > wp.int32(1):
+            span = wp.float32(BLOCK_SIZE - wp.int32(1))
+            denom = wp.float32(FEATURE_BLOCK_GRID_SIZE - wp.int32(1))
+            local_x = wp.float32(0.5) + wp.float32(gx_node) * span / denom
+            local_y = wp.float32(0.5) + wp.float32(gy_node) * span / denom
+            local_z = wp.float32(0.5) + wp.float32(gz_node) * span / denom
+        else:
+            center = wp.float32(BLOCK_SIZE) * wp.float32(0.5)
+            local_x = center
+            local_y = center
+            local_z = center
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        center_offset_x = wp.float32(GRID_W) * wp.float32(0.5)
+        center_offset_y = wp.float32(GRID_H) * wp.float32(0.5)
+        center_offset_z = wp.float32(GRID_D) * wp.float32(0.5)
+        node_world = (
+            wp.vec3(ORIGIN_X, ORIGIN_Y, ORIGIN_Z)
+            + wp.vec3(
+                wp.float32(base[0]) + local_x - center_offset_x,
+                wp.float32(base[1]) + local_y - center_offset_y,
+                wp.float32(base[2]) + local_z - center_offset_z,
+            )
+            * VOXEL_SIZE
+        )
 
         base_feature_channel = feature_channel_group_idx * FEATURE_CHANNELS_PER_THREAD
         feature_acc = wp.zeros(FEATURE_CHANNELS_PER_THREAD, dtype=wp.float32)
-        for k in range(support_capacity):
-            if k < count:
-                pixel_idx = support_pixels[vis_idx, lidar_i, k]
+        total_w = wp.float32(0.0)
+
+        lidar_pos = wp.vec3(
+            lidar_positions[lidar_i, 0],
+            lidar_positions[lidar_i, 1],
+            lidar_positions[lidar_i, 2],
+        )
+        lidar_quat = wp.quaternion(
+            lidar_quaternions[lidar_i, 1],
+            lidar_quaternions[lidar_i, 2],
+            lidar_quaternions[lidar_i, 3],
+            lidar_quaternions[lidar_i, 0],
+        )
+        node_lidar = wp.quat_rotate(wp.quat_inverse(lidar_quat), node_world - lidar_pos)
+        node_range = wp.sqrt(wp.dot(node_lidar, node_lidar))
+        min_range = valid_range_m[lidar_i, 0]
+        max_range = valid_range_m[lidar_i, 1]
+
+        if _range_valid(node_range, min_range, max_range):
+            min_elev = elevation_range_rad[lidar_i, 0]
+            max_elev = elevation_range_rad[lidar_i, 1]
+            xy_norm = wp.sqrt(node_lidar[0] * node_lidar[0] + node_lidar[1] * node_lidar[1])
+            elevation = wp.atan2(node_lidar[2], xy_norm)
+            can_project = bool(True)
+            v_float = wp.float32(0.0)
+            if LIDAR_IMAGE_HEIGHT > wp.int32(1):
+                if elevation < min_elev or elevation > max_elev:
+                    can_project = False
+                else:
+                    v_float = (max_elev - elevation) * (
+                        wp.float32(LIDAR_IMAGE_HEIGHT - wp.int32(1))
+                        / (max_elev - min_elev)
+                    )
+
+            if can_project:
+                azimuth = wp.atan2(node_lidar[1], node_lidar[0])
+                u_float = (azimuth + PI) * (wp.float32(LIDAR_IMAGE_WIDTH) / TWO_PI)
+                if u_float >= wp.float32(LIDAR_IMAGE_WIDTH):
+                    u_float = u_float - wp.float32(LIDAR_IMAGE_WIDTH)
+                if u_float < wp.float32(0.0):
+                    u_float = u_float + wp.float32(LIDAR_IMAGE_WIDTH)
+
+                u0 = wp.int32(wp.floor(u_float))
+                if u0 < wp.int32(0):
+                    u0 = u0 + LIDAR_IMAGE_WIDTH
+                if u0 >= LIDAR_IMAGE_WIDTH:
+                    u0 = u0 - LIDAR_IMAGE_WIDTH
+                u1 = u0 + wp.int32(1)
+                if u1 >= LIDAR_IMAGE_WIDTH:
+                    u1 = wp.int32(0)
+                fu = u_float - wp.floor(u_float)
+
+                v0 = wp.int32(0)
+                v1 = wp.int32(0)
+                fv = wp.float32(0.0)
+                can_sample = bool(True)
+                if LIDAR_IMAGE_HEIGHT > wp.int32(1):
+                    v0 = wp.int32(wp.floor(v_float))
+                    if v0 < wp.int32(0) or v0 >= LIDAR_IMAGE_HEIGHT:
+                        can_sample = False
+                    else:
+                        v1 = wp.min(v0 + wp.int32(1), LIDAR_IMAGE_HEIGHT - wp.int32(1))
+                        fv = v_float - wp.float32(v0)
+
+                if can_sample:
+                    wx0 = wp.float32(1.0) - fu
+                    wy0 = wp.float32(1.0) - fv
+                    w00 = wx0 * wy0
+                    w10 = fu * wy0
+                    w01 = wx0 * fv
+                    w11 = fu * fv
+
+                    range00 = range_images[lidar_i, v0, u0]
+                    if _range_valid(range00, min_range, max_range):
+                        sdf00 = range00 - node_range
+                        if sdf00 >= -TRUNCATION_DIST and sdf00 <= TRUNCATION_DIST:
+                            sample_w = w00 * compute_tsdf_weight(range00, VOXEL_SIZE)
+                            fg = _lidar_feature_grid_coords(u0, v0)
+                            for feature_channel_offset in range(feature_channels_per_thread):
+                                feature_channel = base_feature_channel + feature_channel_offset
+                                if feature_channel < FEATURE_DIM:
+                                    feature_acc[feature_channel_offset] = (
+                                        feature_acc[feature_channel_offset]
+                                        + wp.float32(
+                                            feature_grid[
+                                                lidar_i,
+                                                fg[1],
+                                                fg[0],
+                                                feature_channel,
+                                            ]
+                                        )
+                                        * sample_w
+                                    )
+                            total_w = total_w + sample_w
+
+                    range10 = range_images[lidar_i, v0, u1]
+                    if _range_valid(range10, min_range, max_range):
+                        sdf10 = range10 - node_range
+                        if sdf10 >= -TRUNCATION_DIST and sdf10 <= TRUNCATION_DIST:
+                            sample_w = w10 * compute_tsdf_weight(range10, VOXEL_SIZE)
+                            fg = _lidar_feature_grid_coords(u1, v0)
+                            for feature_channel_offset in range(feature_channels_per_thread):
+                                feature_channel = base_feature_channel + feature_channel_offset
+                                if feature_channel < FEATURE_DIM:
+                                    feature_acc[feature_channel_offset] = (
+                                        feature_acc[feature_channel_offset]
+                                        + wp.float32(
+                                            feature_grid[
+                                                lidar_i,
+                                                fg[1],
+                                                fg[0],
+                                                feature_channel,
+                                            ]
+                                        )
+                                        * sample_w
+                                    )
+                            total_w = total_w + sample_w
+
+                    range01 = range_images[lidar_i, v1, u0]
+                    if _range_valid(range01, min_range, max_range):
+                        sdf01 = range01 - node_range
+                        if sdf01 >= -TRUNCATION_DIST and sdf01 <= TRUNCATION_DIST:
+                            sample_w = w01 * compute_tsdf_weight(range01, VOXEL_SIZE)
+                            fg = _lidar_feature_grid_coords(u0, v1)
+                            for feature_channel_offset in range(feature_channels_per_thread):
+                                feature_channel = base_feature_channel + feature_channel_offset
+                                if feature_channel < FEATURE_DIM:
+                                    feature_acc[feature_channel_offset] = (
+                                        feature_acc[feature_channel_offset]
+                                        + wp.float32(
+                                            feature_grid[
+                                                lidar_i,
+                                                fg[1],
+                                                fg[0],
+                                                feature_channel,
+                                            ]
+                                        )
+                                        * sample_w
+                                    )
+                            total_w = total_w + sample_w
+
+                    range11 = range_images[lidar_i, v1, u1]
+                    if _range_valid(range11, min_range, max_range):
+                        sdf11 = range11 - node_range
+                        if sdf11 >= -TRUNCATION_DIST and sdf11 <= TRUNCATION_DIST:
+                            sample_w = w11 * compute_tsdf_weight(range11, VOXEL_SIZE)
+                            fg = _lidar_feature_grid_coords(u1, v1)
+                            for feature_channel_offset in range(feature_channels_per_thread):
+                                feature_channel = base_feature_channel + feature_channel_offset
+                                if feature_channel < FEATURE_DIM:
+                                    feature_acc[feature_channel_offset] = (
+                                        feature_acc[feature_channel_offset]
+                                        + wp.float32(
+                                            feature_grid[
+                                                lidar_i,
+                                                fg[1],
+                                                fg[0],
+                                                feature_channel,
+                                            ]
+                                        )
+                                        * sample_w
+                                    )
+                            total_w = total_w + sample_w
+
+        if total_w <= wp.float32(0.0):
+            count = support_counts[vis_idx, lidar_i]
+            if count > wp.int32(0):
+                pixel_idx = support_pixels[vis_idx, lidar_i, 0]
                 px = pixel_idx % LIDAR_IMAGE_WIDTH
                 py = pixel_idx // LIDAR_IMAGE_WIDTH
-                gx = (px * LIDAR_FEATURE_GRID_WIDTH) // LIDAR_IMAGE_WIDTH
-                gy = (py * LIDAR_FEATURE_GRID_HEIGHT) // LIDAR_IMAGE_HEIGHT
-                for feature_channel_offset in range(feature_channels_per_thread):
-                    feature_channel = base_feature_channel + feature_channel_offset
-                    if feature_channel < FEATURE_DIM:
-                        feature_acc[feature_channel_offset] = (
-                            feature_acc[feature_channel_offset]
-                            + wp.float32(feature_grid[lidar_i, gy, gx, feature_channel])
-                        )
+                if py >= wp.int32(0) and py < LIDAR_IMAGE_HEIGHT and px >= wp.int32(0) and px < LIDAR_IMAGE_WIDTH:
+                    fg = _lidar_feature_grid_coords(px, py)
+                    for feature_channel_offset in range(feature_channels_per_thread):
+                        feature_channel = base_feature_channel + feature_channel_offset
+                        if feature_channel < FEATURE_DIM:
+                            feature_acc[feature_channel_offset] = (
+                                feature_acc[feature_channel_offset]
+                                + wp.float32(
+                                    feature_grid[
+                                        lidar_i,
+                                        fg[1],
+                                        fg[0],
+                                        feature_channel,
+                                    ]
+                                )
+                            )
+                    total_w = total_w + wp.float32(1.0)
+
+        if total_w <= wp.float32(0.0):
+            return
 
         for feature_channel_offset in range(feature_channels_per_thread):
             feature_channel = base_feature_channel + feature_channel_offset
@@ -568,11 +1009,12 @@ def make_lidar_integrate_kernels(
                 wp.atomic_add(
                     block_features,
                     pool_idx,
+                    node_idx,
                     feature_channel,
                     wp.float16(feature_acc[feature_channel_offset]),
                 )
         if base_feature_channel == wp.int32(0):
-            wp.atomic_add(block_feature_weight, pool_idx, wp.float16(wp.float32(count)))
+            wp.atomic_add(block_feature_weight, pool_idx, node_idx, wp.float16(total_w))
 
     @warp_kernel(
         f"lidar_integrate_features_from_support_tiled_kernel_{suffix}_tile"
@@ -581,51 +1023,247 @@ def make_lidar_integrate_kernels(
     def lidar_integrate_features_from_support_tiled_kernel(
         visible_pool_indices: wp.array(dtype=wp.int32),
         n_visible: wp.int32,
+        lidar_positions: wp.array2d(dtype=wp.float32),
+        lidar_quaternions: wp.array2d(dtype=wp.float32),
+        range_images: wp.array3d(dtype=wp.float32),
+        valid_range_m: wp.array2d(dtype=wp.float32),
+        elevation_range_rad: wp.array2d(dtype=wp.float32),
+        block_coords: wp.array(dtype=wp.int32),
         support_counts: wp.array2d(dtype=wp.int32),
         support_pixels: wp.array3d(dtype=wp.int32),
         feature_grid: wp.array4d(dtype=wp.float16),
-        block_features: wp.array2d(dtype=wp.float16),
-        block_feature_weight: wp.array(dtype=wp.float16),
+        block_features: wp.array3d(dtype=wp.float16),
+        block_feature_weight: wp.array2d(dtype=wp.float16),
     ):
-        vis_idx, lidar_i, feature_tile_idx, lane = wp.tid()
         n_channel_tiles = (FEATURE_DIM + FEATURE_TILE_CHANNELS - wp.int32(1)) // FEATURE_TILE_CHANNELS
-        if vis_idx >= n_visible or feature_tile_idx >= n_channel_tiles:
+        vis_idx, lidar_i, node_tile_idx, lane = wp.tid()
+        node_idx = node_tile_idx // n_channel_tiles
+        feature_tile_idx = node_tile_idx - node_idx * n_channel_tiles
+        if (
+            vis_idx >= n_visible
+            or node_idx >= FEATURE_GRID_VOXELS
+            or feature_tile_idx >= n_channel_tiles
+        ):
             return
         pool_idx = visible_pool_indices[vis_idx]
         if pool_idx < wp.int32(0):
             return
-        count = support_counts[vis_idx, lidar_i]
-        if count > SUPPORT_CAPACITY:
-            count = SUPPORT_CAPACITY
-        if count <= wp.int32(0):
-            return
+
+        bx = block_coords[pool_idx * 3 + 0]
+        by = block_coords[pool_idx * 3 + 1]
+        bz = block_coords[pool_idx * 3 + 2]
+
+        gx_node = node_idx % FEATURE_BLOCK_GRID_SIZE
+        gy_node = (node_idx // FEATURE_BLOCK_GRID_SIZE) % FEATURE_BLOCK_GRID_SIZE
+        gz_node = node_idx // (FEATURE_BLOCK_GRID_SIZE * FEATURE_BLOCK_GRID_SIZE)
+
+        local_x = wp.float32(0.0)
+        local_y = wp.float32(0.0)
+        local_z = wp.float32(0.0)
+        if FEATURE_BLOCK_GRID_SIZE > wp.int32(1):
+            span = wp.float32(BLOCK_SIZE - wp.int32(1))
+            denom = wp.float32(FEATURE_BLOCK_GRID_SIZE - wp.int32(1))
+            local_x = wp.float32(0.5) + wp.float32(gx_node) * span / denom
+            local_y = wp.float32(0.5) + wp.float32(gy_node) * span / denom
+            local_z = wp.float32(0.5) + wp.float32(gz_node) * span / denom
+        else:
+            center = wp.float32(BLOCK_SIZE) * wp.float32(0.5)
+            local_x = center
+            local_y = center
+            local_z = center
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        center_offset_x = wp.float32(GRID_W) * wp.float32(0.5)
+        center_offset_y = wp.float32(GRID_H) * wp.float32(0.5)
+        center_offset_z = wp.float32(GRID_D) * wp.float32(0.5)
+        node_world = (
+            wp.vec3(ORIGIN_X, ORIGIN_Y, ORIGIN_Z)
+            + wp.vec3(
+                wp.float32(base[0]) + local_x - center_offset_x,
+                wp.float32(base[1]) + local_y - center_offset_y,
+                wp.float32(base[2]) + local_z - center_offset_z,
+            )
+            * VOXEL_SIZE
+        )
 
         base_feature_channel = feature_tile_idx * FEATURE_TILE_CHANNELS
         feature_acc = wp.tile_zeros(shape=feature_tile_channels, dtype=wp.float32)
-        for k in range(support_capacity):
-            if k < count:
-                pixel_idx = support_pixels[vis_idx, lidar_i, k]
+        total_w = wp.float32(0.0)
+
+        lidar_pos = wp.vec3(
+            lidar_positions[lidar_i, 0],
+            lidar_positions[lidar_i, 1],
+            lidar_positions[lidar_i, 2],
+        )
+        lidar_quat = wp.quaternion(
+            lidar_quaternions[lidar_i, 1],
+            lidar_quaternions[lidar_i, 2],
+            lidar_quaternions[lidar_i, 3],
+            lidar_quaternions[lidar_i, 0],
+        )
+        node_lidar = wp.quat_rotate(wp.quat_inverse(lidar_quat), node_world - lidar_pos)
+        node_range = wp.sqrt(wp.dot(node_lidar, node_lidar))
+        min_range = valid_range_m[lidar_i, 0]
+        max_range = valid_range_m[lidar_i, 1]
+
+        if _range_valid(node_range, min_range, max_range):
+            min_elev = elevation_range_rad[lidar_i, 0]
+            max_elev = elevation_range_rad[lidar_i, 1]
+            xy_norm = wp.sqrt(node_lidar[0] * node_lidar[0] + node_lidar[1] * node_lidar[1])
+            elevation = wp.atan2(node_lidar[2], xy_norm)
+            can_project = bool(True)
+            v_float = wp.float32(0.0)
+            if LIDAR_IMAGE_HEIGHT > wp.int32(1):
+                if elevation < min_elev or elevation > max_elev:
+                    can_project = False
+                else:
+                    v_float = (max_elev - elevation) * (
+                        wp.float32(LIDAR_IMAGE_HEIGHT - wp.int32(1))
+                        / (max_elev - min_elev)
+                    )
+
+            if can_project:
+                azimuth = wp.atan2(node_lidar[1], node_lidar[0])
+                u_float = (azimuth + PI) * (wp.float32(LIDAR_IMAGE_WIDTH) / TWO_PI)
+                if u_float >= wp.float32(LIDAR_IMAGE_WIDTH):
+                    u_float = u_float - wp.float32(LIDAR_IMAGE_WIDTH)
+                if u_float < wp.float32(0.0):
+                    u_float = u_float + wp.float32(LIDAR_IMAGE_WIDTH)
+
+                u0 = wp.int32(wp.floor(u_float))
+                if u0 < wp.int32(0):
+                    u0 = u0 + LIDAR_IMAGE_WIDTH
+                if u0 >= LIDAR_IMAGE_WIDTH:
+                    u0 = u0 - LIDAR_IMAGE_WIDTH
+                u1 = u0 + wp.int32(1)
+                if u1 >= LIDAR_IMAGE_WIDTH:
+                    u1 = wp.int32(0)
+                fu = u_float - wp.floor(u_float)
+
+                v0 = wp.int32(0)
+                v1 = wp.int32(0)
+                fv = wp.float32(0.0)
+                can_sample = bool(True)
+                if LIDAR_IMAGE_HEIGHT > wp.int32(1):
+                    v0 = wp.int32(wp.floor(v_float))
+                    if v0 < wp.int32(0) or v0 >= LIDAR_IMAGE_HEIGHT:
+                        can_sample = False
+                    else:
+                        v1 = wp.min(v0 + wp.int32(1), LIDAR_IMAGE_HEIGHT - wp.int32(1))
+                        fv = v_float - wp.float32(v0)
+
+                if can_sample:
+                    wx0 = wp.float32(1.0) - fu
+                    wy0 = wp.float32(1.0) - fv
+                    w00 = wx0 * wy0
+                    w10 = fu * wy0
+                    w01 = wx0 * fv
+                    w11 = fu * fv
+
+                    range00 = range_images[lidar_i, v0, u0]
+                    if _range_valid(range00, min_range, max_range):
+                        sdf00 = range00 - node_range
+                        if sdf00 >= -TRUNCATION_DIST and sdf00 <= TRUNCATION_DIST:
+                            sample_w = w00 * compute_tsdf_weight(range00, VOXEL_SIZE)
+                            fg = _lidar_feature_grid_coords(u0, v0)
+                            feature_vals_h = wp.tile_load(
+                                feature_grid[lidar_i, fg[1], fg[0]],
+                                shape=feature_tile_channels,
+                                offset=base_feature_channel,
+                                bounds_check=True,
+                            )
+                            feature_acc = feature_acc + wp.tile_astype(
+                                feature_vals_h,
+                                dtype=wp.float32,
+                            ) * sample_w
+                            total_w = total_w + sample_w
+
+                    range10 = range_images[lidar_i, v0, u1]
+                    if _range_valid(range10, min_range, max_range):
+                        sdf10 = range10 - node_range
+                        if sdf10 >= -TRUNCATION_DIST and sdf10 <= TRUNCATION_DIST:
+                            sample_w = w10 * compute_tsdf_weight(range10, VOXEL_SIZE)
+                            fg = _lidar_feature_grid_coords(u1, v0)
+                            feature_vals_h = wp.tile_load(
+                                feature_grid[lidar_i, fg[1], fg[0]],
+                                shape=feature_tile_channels,
+                                offset=base_feature_channel,
+                                bounds_check=True,
+                            )
+                            feature_acc = feature_acc + wp.tile_astype(
+                                feature_vals_h,
+                                dtype=wp.float32,
+                            ) * sample_w
+                            total_w = total_w + sample_w
+
+                    range01 = range_images[lidar_i, v1, u0]
+                    if _range_valid(range01, min_range, max_range):
+                        sdf01 = range01 - node_range
+                        if sdf01 >= -TRUNCATION_DIST and sdf01 <= TRUNCATION_DIST:
+                            sample_w = w01 * compute_tsdf_weight(range01, VOXEL_SIZE)
+                            fg = _lidar_feature_grid_coords(u0, v1)
+                            feature_vals_h = wp.tile_load(
+                                feature_grid[lidar_i, fg[1], fg[0]],
+                                shape=feature_tile_channels,
+                                offset=base_feature_channel,
+                                bounds_check=True,
+                            )
+                            feature_acc = feature_acc + wp.tile_astype(
+                                feature_vals_h,
+                                dtype=wp.float32,
+                            ) * sample_w
+                            total_w = total_w + sample_w
+
+                    range11 = range_images[lidar_i, v1, u1]
+                    if _range_valid(range11, min_range, max_range):
+                        sdf11 = range11 - node_range
+                        if sdf11 >= -TRUNCATION_DIST and sdf11 <= TRUNCATION_DIST:
+                            sample_w = w11 * compute_tsdf_weight(range11, VOXEL_SIZE)
+                            fg = _lidar_feature_grid_coords(u1, v1)
+                            feature_vals_h = wp.tile_load(
+                                feature_grid[lidar_i, fg[1], fg[0]],
+                                shape=feature_tile_channels,
+                                offset=base_feature_channel,
+                                bounds_check=True,
+                            )
+                            feature_acc = feature_acc + wp.tile_astype(
+                                feature_vals_h,
+                                dtype=wp.float32,
+                            ) * sample_w
+                            total_w = total_w + sample_w
+
+        if total_w <= wp.float32(0.0):
+            count = support_counts[vis_idx, lidar_i]
+            if count > wp.int32(0):
+                pixel_idx = support_pixels[vis_idx, lidar_i, 0]
                 px = pixel_idx % LIDAR_IMAGE_WIDTH
                 py = pixel_idx // LIDAR_IMAGE_WIDTH
-                gx = (px * LIDAR_FEATURE_GRID_WIDTH) // LIDAR_IMAGE_WIDTH
-                gy = (py * LIDAR_FEATURE_GRID_HEIGHT) // LIDAR_IMAGE_HEIGHT
-                feature_vals_h = wp.tile_load(
-                    feature_grid[lidar_i, gy, gx],
-                    shape=feature_tile_channels,
-                    offset=base_feature_channel,
-                    storage="global",
-                )
-                feature_acc = feature_acc + wp.tile_astype(feature_vals_h, dtype=wp.float32)
+                if py >= wp.int32(0) and py < LIDAR_IMAGE_HEIGHT and px >= wp.int32(0) and px < LIDAR_IMAGE_WIDTH:
+                    fg = _lidar_feature_grid_coords(px, py)
+                    feature_vals_h = wp.tile_load(
+                        feature_grid[lidar_i, fg[1], fg[0]],
+                        shape=feature_tile_channels,
+                        offset=base_feature_channel,
+                        bounds_check=True,
+                    )
+                    feature_acc = feature_acc + wp.tile_astype(
+                        feature_vals_h,
+                        dtype=wp.float32,
+                    )
+                    total_w = total_w + wp.float32(1.0)
+
+        if total_w <= wp.float32(0.0):
+            return
 
         feature_acc_h = wp.tile_astype(feature_acc, dtype=wp.float16)
         wp.tile_atomic_add(
-            block_features[pool_idx],
+            block_features[pool_idx, node_idx],
             feature_acc_h,
             offset=base_feature_channel,
-            storage="global",
+            bounds_check=True,
         )
         if feature_tile_idx == wp.int32(0) and lane == wp.int32(0):
-            wp.atomic_add(block_feature_weight, pool_idx, wp.float16(wp.float32(count)))
+            wp.atomic_add(block_feature_weight, pool_idx, node_idx, wp.float16(total_w))
 
     return {
         "lidar_compute_block_keys_only_kernel": lidar_compute_block_keys_only_kernel,
@@ -633,9 +1271,7 @@ def make_lidar_integrate_kernels(
             lidar_build_support_pixels_from_keys_kernel
         ),
         "lidar_integrate_voxels_kernel": lidar_integrate_voxels_kernel,
-        "lidar_integrate_block_grid_rgb_from_support_kernel": (
-            lidar_integrate_block_grid_rgb_from_support_kernel
-        ),
+        "lidar_integrate_block_grid_rgb_kernel": lidar_integrate_block_grid_rgb_kernel,
         "lidar_integrate_features_from_support_grouped_kernel": (
             lidar_integrate_features_from_support_grouped_kernel
         ),

--- a/curobo/_src/perception/mapper/kernel/builder/builder_lidar_integrate.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_lidar_integrate.py
@@ -31,6 +31,7 @@ def make_lidar_integrate_kernels(
     feature_channels_per_thread: int,
     max_feature_tile_channels: int,
     max_support_pixels_per_block_lidar: int,
+    color_grid_size: int,
     pack_key_only,
     unpack_block_key,
     hash_lookup,
@@ -54,6 +55,8 @@ def make_lidar_integrate_kernels(
     safe_step = (float(block_size) * float(voxel_size)) / 1.42
     STEP_SIZE = wp.constant(wp.float32(safe_step))
     FEATURE_DIM = wp.constant(wp.int32(feature_dim))
+    color_grid_voxels = int(color_grid_size) ** 3
+    COLOR_GRID_VOXELS = wp.constant(wp.int32(color_grid_voxels))
     if lidar_feature_grid_shape is None:
         lidar_feature_grid_height = 1
         lidar_feature_grid_width = 1
@@ -69,7 +72,7 @@ def make_lidar_integrate_kernels(
     SUPPORT_CAPACITY = wp.constant(support_capacity)
     suffix = (
         f"bs{block_size}_cfg"
-        f"{warp_constant_suffix(block_size, feature_dim, lidar_num_sensors, lidar_image_height, lidar_image_width, num_samples, grid_shape, origin_xyz, voxel_size, truncation_distance, lidar_feature_grid_shape, feature_channels_per_thread, max_feature_tile_channels, max_support_pixels_per_block_lidar)}"
+        f"{warp_constant_suffix(block_size, feature_dim, lidar_num_sensors, lidar_image_height, lidar_image_width, num_samples, grid_shape, origin_xyz, voxel_size, truncation_distance, lidar_feature_grid_shape, feature_channels_per_thread, max_feature_tile_channels, max_support_pixels_per_block_lidar, color_grid_size)}"
     )
 
     @wp.func
@@ -467,18 +470,18 @@ def make_lidar_integrate_kernels(
             block_data[pool_idx, local_idx, 1] = wp.float16(old_w + total_w)
 
     @warp_kernel(
-        f"lidar_integrate_block_rgb_from_support_kernel_{suffix}_sc{support_capacity}"
+        f"lidar_integrate_block_grid_rgb_from_support_kernel_{suffix}_sc{support_capacity}"
     )
-    def lidar_integrate_block_rgb_from_support_kernel(
+    def lidar_integrate_block_grid_rgb_from_support_kernel(
         visible_pool_indices: wp.array(dtype=wp.int32),
         n_visible: wp.int32,
         support_counts: wp.array2d(dtype=wp.int32),
         support_pixels: wp.array3d(dtype=wp.int32),
         rgb_images_flat: wp.array3d(dtype=wp.uint8),
-        block_rgb: wp.array2d(dtype=wp.float16),
+        block_grid_rgb: wp.array3d(dtype=wp.float16),
     ):
-        vis_idx, lidar_i = wp.tid()
-        if vis_idx >= n_visible:
+        vis_idx, lidar_i, node_idx = wp.tid()
+        if vis_idx >= n_visible or node_idx >= COLOR_GRID_VOXELS:
             return
         pool_idx = visible_pool_indices[vis_idx]
         if pool_idx < wp.int32(0):
@@ -504,14 +507,16 @@ def make_lidar_integrate_kernels(
                 total_g = total_g + wp.float32(rgb_images_flat[row, px, 1]) * inv_255
                 total_b = total_b + wp.float32(rgb_images_flat[row, px, 2]) * inv_255
 
-        old_r = wp.float32(block_rgb[pool_idx, 0])
-        old_g = wp.float32(block_rgb[pool_idx, 1])
-        old_b = wp.float32(block_rgb[pool_idx, 2])
-        old_w = wp.float32(block_rgb[pool_idx, 3])
-        block_rgb[pool_idx, 0] = wp.float16(old_r + total_r)
-        block_rgb[pool_idx, 1] = wp.float16(old_g + total_g)
-        block_rgb[pool_idx, 2] = wp.float16(old_b + total_b)
-        block_rgb[pool_idx, 3] = wp.float16(old_w + wp.float32(count))
+        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 0, wp.float16(total_r))
+        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 1, wp.float16(total_g))
+        wp.atomic_add(block_grid_rgb, pool_idx, node_idx, 2, wp.float16(total_b))
+        wp.atomic_add(
+            block_grid_rgb,
+            pool_idx,
+            node_idx,
+            3,
+            wp.float16(wp.float32(count)),
+        )
 
     @warp_kernel(
         f"lidar_integrate_features_from_support_grouped_kernel_{suffix}_fcpt"
@@ -628,8 +633,8 @@ def make_lidar_integrate_kernels(
             lidar_build_support_pixels_from_keys_kernel
         ),
         "lidar_integrate_voxels_kernel": lidar_integrate_voxels_kernel,
-        "lidar_integrate_block_rgb_from_support_kernel": (
-            lidar_integrate_block_rgb_from_support_kernel
+        "lidar_integrate_block_grid_rgb_from_support_kernel": (
+            lidar_integrate_block_grid_rgb_from_support_kernel
         ),
         "lidar_integrate_features_from_support_grouped_kernel": (
             lidar_integrate_features_from_support_grouped_kernel

--- a/curobo/_src/perception/mapper/kernel/builder/builder_mesh.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_mesh.py
@@ -20,6 +20,7 @@ import warp as wp
 from curobo._src.perception.mapper.kernel.warp_types import BlockSparseTSDFWarp
 from curobo._src.perception.mapper.marching_cubes.kernel.wp_mc_common import (
     binary_search_int64,
+    get_edge_vertex,
     interpolate_edge_vertex,
     local_edge_to_array_idx,
 )
@@ -29,17 +30,26 @@ from curobo._src.util.warp import warp_func, warp_kernel
 def make_mesh_kernels(
     block_size: int,
     *,
+    num_cameras: int = 1,
+    image_height: int = 1,
+    image_width: int = 1,
     hash_lookup,
     compute_avg_rgb_uint8_from_block,
+    sample_rgb,
     sample_voxel,
     sample_tsdf_trilinear,
     compute_gradient,
     compute_gradient_nearest,
     block_grid_to_key_coords,
     block_key_to_voxel_base,
+    use_color_grid: bool = False,
 ) -> dict[str, object]:
     """Build block-sparse marching-cubes kernels."""
     BS = wp.constant(block_size)
+    NUM_CAMERAS = wp.constant(num_cameras)
+    IMAGE_HEIGHT = wp.constant(image_height)
+    IMAGE_WIDTH = wp.constant(image_width)
+    USE_COLOR_GRID = wp.constant(bool(use_color_grid))
 
     # Cross-domain helpers are explicit parameters so Warp sees them as
     # local closure bindings when compiling dependent functions.
@@ -326,6 +336,70 @@ def make_mesh_kernels(
         ):
             wp.atomic_add(surface_count, 0, wp.int32(1))
 
+    @warp_kernel(f"append_active_blocks_kernel_bs{block_size}", enable_backward=False)
+    def append_active_blocks_kernel(
+        tsdf: BlockSparseTSDFWarp,
+        active_count: wp.array(dtype=wp.int32),
+        active_block_idx: wp.array(dtype=wp.int32),
+    ):
+        """Compact active pool indices into a dense block list."""
+        block_idx = wp.tid()
+
+        if block_idx >= tsdf.num_allocated[0]:
+            return
+        if tsdf.block_to_hash_slot[block_idx] < 0:
+            return
+
+        out_idx = wp.atomic_add(active_count, 0, wp.int32(1))
+        active_block_idx[out_idx] = block_idx
+
+    @warp_kernel(
+        f"count_surface_cubes_from_blocks_kernel_bs{block_size}", enable_backward=False
+    )
+    def count_surface_cubes_from_blocks_kernel(
+        tsdf: BlockSparseTSDFWarp,
+        active_block_idx: wp.array(dtype=wp.int32),
+        n_active_blocks: wp.int32,
+        level: float,
+        surface_band: float,
+        minimum_tsdf_weight: float,
+        surface_count: wp.array(dtype=wp.int32),
+    ):
+        """Count surface cubes from a compact active block list."""
+        active_idx, cube_idx = wp.tid()
+
+        if active_idx >= n_active_blocks:
+            return
+
+        block_idx = active_block_idx[active_idx]
+        if block_idx < 0 or block_idx >= tsdf.num_allocated[0]:
+            return
+        if tsdf.block_to_hash_slot[block_idx] < 0:
+            return
+
+        cx = cube_idx % BS
+        cy = (cube_idx // BS) % BS
+        cz = cube_idx // (BS * BS)
+
+        bx = tsdf.block_coords[block_idx * 3 + 0]
+        by = tsdf.block_coords[block_idx * 3 + 1]
+        bz = tsdf.block_coords[block_idx * 3 + 2]
+
+        if is_surface_cube_combined(
+            cx,
+            cy,
+            cz,
+            bx,
+            by,
+            bz,
+            block_idx,
+            tsdf,
+            level,
+            surface_band,
+            minimum_tsdf_weight,
+        ):
+            wp.atomic_add(surface_count, 0, wp.int32(1))
+
     @warp_kernel(f"append_surface_cubes_kernel_bs{block_size}", enable_backward=False)
     def append_surface_cubes_kernel(
         tsdf: BlockSparseTSDFWarp,
@@ -340,6 +414,57 @@ def make_mesh_kernels(
         block_idx, cube_idx = wp.tid()
 
         if block_idx >= tsdf.num_allocated[0]:
+            return
+        if tsdf.block_to_hash_slot[block_idx] < 0:
+            return
+
+        cx = cube_idx % BS
+        cy = (cube_idx // BS) % BS
+        cz = cube_idx // (BS * BS)
+
+        bx = tsdf.block_coords[block_idx * 3 + 0]
+        by = tsdf.block_coords[block_idx * 3 + 1]
+        bz = tsdf.block_coords[block_idx * 3 + 2]
+
+        if is_surface_cube_combined(
+            cx,
+            cy,
+            cz,
+            bx,
+            by,
+            bz,
+            block_idx,
+            tsdf,
+            level,
+            surface_band,
+            minimum_tsdf_weight,
+        ):
+            out_idx = wp.atomic_add(surface_count, 0, wp.int32(1))
+            surface_block_idx[out_idx] = block_idx
+            surface_cube_idx[out_idx] = cube_idx
+
+    @warp_kernel(
+        f"append_surface_cubes_from_blocks_kernel_bs{block_size}", enable_backward=False
+    )
+    def append_surface_cubes_from_blocks_kernel(
+        tsdf: BlockSparseTSDFWarp,
+        active_block_idx: wp.array(dtype=wp.int32),
+        n_active_blocks: wp.int32,
+        level: float,
+        surface_band: float,
+        minimum_tsdf_weight: float,
+        surface_count: wp.array(dtype=wp.int32),
+        surface_block_idx: wp.array(dtype=wp.int32),
+        surface_cube_idx: wp.array(dtype=wp.int32),
+    ):
+        """Append surface cubes from a compact active block list."""
+        active_idx, cube_idx = wp.tid()
+
+        if active_idx >= n_active_blocks:
+            return
+
+        block_idx = active_block_idx[active_idx]
+        if block_idx < 0 or block_idx >= tsdf.num_allocated[0]:
             return
         if tsdf.block_to_hash_slot[block_idx] < 0:
             return
@@ -746,6 +871,2216 @@ def make_mesh_kernels(
 
         tri_counts[tid] = num_tris_table[cube_config]
 
+    @warp_kernel(f"count_total_triangles_kernel_bs{block_size}", enable_backward=False)
+    def count_total_triangles_kernel(
+        tsdf: BlockSparseTSDFWarp,
+        level: float,
+        minimum_tsdf_weight: float,
+        surface_block_idx: wp.array(dtype=wp.int32),
+        surface_cube_idx: wp.array(dtype=wp.int32),
+        n_surfaces: wp.int32,
+        num_tris_table: wp.array(dtype=wp.int32),
+        triangle_count: wp.array(dtype=wp.int32),
+    ):
+        """Count approximate mesh triangles with one device-side total."""
+        tid = wp.tid()
+        if tid >= n_surfaces:
+            return
+
+        block_idx = surface_block_idx[tid]
+        cube_idx = surface_cube_idx[tid]
+
+        cx = cube_idx % BS
+        cy = (cube_idx // BS) % BS
+        cz = cube_idx // (BS * BS)
+
+        bx = tsdf.block_coords[block_idx * 3 + 0]
+        by = tsdf.block_coords[block_idx * 3 + 1]
+        bz = tsdf.block_coords[block_idx * 3 + 2]
+
+        s0 = sample_cube_corner(
+            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s1 = sample_cube_corner(
+            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s2 = sample_cube_corner(
+            cx + 1, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s3 = sample_cube_corner(
+            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s4 = sample_cube_corner(
+            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s5 = sample_cube_corner(
+            cx + 1, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s6 = sample_cube_corner(
+            cx + 1, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s7 = sample_cube_corner(
+            cx, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+
+        cube_config = wp.int32(0)
+        if s0[0] < 0.0:
+            cube_config = cube_config | wp.int32(1)
+        if s1[0] < 0.0:
+            cube_config = cube_config | wp.int32(2)
+        if s2[0] < 0.0:
+            cube_config = cube_config | wp.int32(4)
+        if s3[0] < 0.0:
+            cube_config = cube_config | wp.int32(8)
+        if s4[0] < 0.0:
+            cube_config = cube_config | wp.int32(16)
+        if s5[0] < 0.0:
+            cube_config = cube_config | wp.int32(32)
+        if s6[0] < 0.0:
+            cube_config = cube_config | wp.int32(64)
+        if s7[0] < 0.0:
+            cube_config = cube_config | wp.int32(128)
+
+        wp.atomic_add(triangle_count, 0, num_tris_table[cube_config])
+
+    @warp_kernel(f"generate_approximate_mesh_block_sparse_kernel_bs{block_size}")
+    def generate_approximate_mesh_block_sparse_kernel(
+        tsdf: BlockSparseTSDFWarp,
+        level: float,
+        minimum_tsdf_weight: float,
+        surface_block_idx: wp.array(dtype=wp.int32),
+        surface_cube_idx: wp.array(dtype=wp.int32),
+        tri_offsets: wp.array(dtype=wp.int32),
+        n_surfaces: wp.int32,
+        tri_table: wp.array(dtype=wp.int32),
+        vertices: wp.array(dtype=wp.vec3),
+        triangles: wp.array(dtype=wp.int32),
+        normals: wp.array(dtype=wp.vec3),
+        colors: wp.array(dtype=wp.vec3ub),
+    ):
+        """Generate a triangle-soup mesh without shared vertex ownership."""
+        tid = wp.tid()
+        if tid >= n_surfaces:
+            return
+
+        block_idx = surface_block_idx[tid]
+        cube_idx = surface_cube_idx[tid]
+
+        cx = cube_idx % BS
+        cy = (cube_idx // BS) % BS
+        cz = cube_idx // (BS * BS)
+
+        bx = tsdf.block_coords[block_idx * 3 + 0]
+        by = tsdf.block_coords[block_idx * 3 + 1]
+        bz = tsdf.block_coords[block_idx * 3 + 2]
+
+        s0 = sample_cube_corner(
+            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s1 = sample_cube_corner(
+            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s2 = sample_cube_corner(
+            cx + 1, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s3 = sample_cube_corner(
+            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s4 = sample_cube_corner(
+            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s5 = sample_cube_corner(
+            cx + 1, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s6 = sample_cube_corner(
+            cx + 1, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s7 = sample_cube_corner(
+            cx, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+
+        cube_config = wp.int32(0)
+        if s0[0] < 0.0:
+            cube_config = cube_config | wp.int32(1)
+        if s1[0] < 0.0:
+            cube_config = cube_config | wp.int32(2)
+        if s2[0] < 0.0:
+            cube_config = cube_config | wp.int32(4)
+        if s3[0] < 0.0:
+            cube_config = cube_config | wp.int32(8)
+        if s4[0] < 0.0:
+            cube_config = cube_config | wp.int32(16)
+        if s5[0] < 0.0:
+            cube_config = cube_config | wp.int32(32)
+        if s6[0] < 0.0:
+            cube_config = cube_config | wp.int32(64)
+        if s7[0] < 0.0:
+            cube_config = cube_config | wp.int32(128)
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        gx = base[0] + cx
+        gy = base[1] + cy
+        gz = base[2] + cz
+
+        center_offset_x = wp.float32(tsdf.grid_W) * 0.5
+        center_offset_y = wp.float32(tsdf.grid_H) * 0.5
+        center_offset_z = wp.float32(tsdf.grid_D) * 0.5
+
+        p0 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p1 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p2 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p3 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p4 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p5 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p6 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p7 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+
+        rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+        color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
+
+        tri_base = tri_offsets[tid]
+        table_offset = cube_config * 16
+
+        for t in range(5):
+            e0 = tri_table[table_offset + t * 3]
+            if e0 < 0:
+                break
+
+            e1 = tri_table[table_offset + t * 3 + 1]
+            e2 = tri_table[table_offset + t * 3 + 2]
+
+            out_base = (tri_base + t) * 3
+            for v_idx in range(3):
+                edge = e0
+                if v_idx == 1:
+                    edge = e1
+                elif v_idx == 2:
+                    edge = e2
+
+                vertex_id = out_base + v_idx
+                v = get_edge_vertex(
+                    edge,
+                    p0,
+                    p1,
+                    p2,
+                    p3,
+                    p4,
+                    p5,
+                    p6,
+                    p7,
+                    s0[0],
+                    s1[0],
+                    s2[0],
+                    s3[0],
+                    s4[0],
+                    s5[0],
+                    s6[0],
+                    s7[0],
+                )
+                n = compute_gradient_nearest(tsdf, v, minimum_tsdf_weight)
+                vertices[vertex_id] = v
+                normals[vertex_id] = wp.normalize(n)
+                colors[vertex_id] = color
+                triangles[vertex_id] = vertex_id
+
+    @warp_kernel(f"generate_approximate_mesh_atomic_kernel_bs{block_size}")
+    def generate_approximate_mesh_atomic_kernel(
+        tsdf: BlockSparseTSDFWarp,
+        level: float,
+        minimum_tsdf_weight: float,
+        surface_block_idx: wp.array(dtype=wp.int32),
+        surface_cube_idx: wp.array(dtype=wp.int32),
+        n_surfaces: wp.int32,
+        tri_table: wp.array(dtype=wp.int32),
+        vertices: wp.array(dtype=wp.vec3),
+        triangles: wp.array(dtype=wp.int32),
+        normals: wp.array(dtype=wp.vec3),
+        colors: wp.array(dtype=wp.vec3ub),
+        triangle_count: wp.array(dtype=wp.int32),
+        triangle_capacity: wp.int32,
+    ):
+        """Generate approximate triangle soup with atomic output allocation."""
+        tid = wp.tid()
+        if tid >= n_surfaces:
+            return
+
+        block_idx = surface_block_idx[tid]
+        cube_idx = surface_cube_idx[tid]
+
+        cx = cube_idx % BS
+        cy = (cube_idx // BS) % BS
+        cz = cube_idx // (BS * BS)
+
+        bx = tsdf.block_coords[block_idx * 3 + 0]
+        by = tsdf.block_coords[block_idx * 3 + 1]
+        bz = tsdf.block_coords[block_idx * 3 + 2]
+
+        s0 = sample_cube_corner(
+            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s1 = sample_cube_corner(
+            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s2 = sample_cube_corner(
+            cx + 1, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s3 = sample_cube_corner(
+            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s4 = sample_cube_corner(
+            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s5 = sample_cube_corner(
+            cx + 1, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s6 = sample_cube_corner(
+            cx + 1, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s7 = sample_cube_corner(
+            cx, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+
+        cube_config = wp.int32(0)
+        if s0[0] < 0.0:
+            cube_config = cube_config | wp.int32(1)
+        if s1[0] < 0.0:
+            cube_config = cube_config | wp.int32(2)
+        if s2[0] < 0.0:
+            cube_config = cube_config | wp.int32(4)
+        if s3[0] < 0.0:
+            cube_config = cube_config | wp.int32(8)
+        if s4[0] < 0.0:
+            cube_config = cube_config | wp.int32(16)
+        if s5[0] < 0.0:
+            cube_config = cube_config | wp.int32(32)
+        if s6[0] < 0.0:
+            cube_config = cube_config | wp.int32(64)
+        if s7[0] < 0.0:
+            cube_config = cube_config | wp.int32(128)
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        gx = base[0] + cx
+        gy = base[1] + cy
+        gz = base[2] + cz
+
+        center_offset_x = wp.float32(tsdf.grid_W) * 0.5
+        center_offset_y = wp.float32(tsdf.grid_H) * 0.5
+        center_offset_z = wp.float32(tsdf.grid_D) * 0.5
+
+        p0 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p1 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p2 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p3 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p4 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p5 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p6 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p7 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+
+        rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+        color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
+
+        table_offset = cube_config * 16
+
+        for t in range(5):
+            e0 = tri_table[table_offset + t * 3]
+            if e0 < 0:
+                break
+
+            tri_idx = wp.atomic_add(triangle_count, 0, wp.int32(1))
+            if tri_idx >= triangle_capacity:
+                continue
+
+            e1 = tri_table[table_offset + t * 3 + 1]
+            e2 = tri_table[table_offset + t * 3 + 2]
+
+            out_base = tri_idx * 3
+            for v_idx in range(3):
+                edge = e0
+                if v_idx == 1:
+                    edge = e1
+                elif v_idx == 2:
+                    edge = e2
+
+                vertex_id = out_base + v_idx
+                v = get_edge_vertex(
+                    edge,
+                    p0,
+                    p1,
+                    p2,
+                    p3,
+                    p4,
+                    p5,
+                    p6,
+                    p7,
+                    s0[0],
+                    s1[0],
+                    s2[0],
+                    s3[0],
+                    s4[0],
+                    s5[0],
+                    s6[0],
+                    s7[0],
+                )
+                n = compute_gradient_nearest(tsdf, v, minimum_tsdf_weight)
+                vertices[vertex_id] = v
+                normals[vertex_id] = wp.normalize(n)
+                colors[vertex_id] = color
+                triangles[vertex_id] = vertex_id
+
+    @warp_kernel(f"generate_approximate_mesh_current_state_kernel_bs{block_size}")
+    def generate_approximate_mesh_current_state_kernel(
+        tsdf: BlockSparseTSDFWarp,
+        level: float,
+        surface_band: float,
+        minimum_tsdf_weight: float,
+        n_blocks: wp.int32,
+        tri_table: wp.array(dtype=wp.int32),
+        vertices: wp.array(dtype=wp.vec3),
+        triangles: wp.array(dtype=wp.int32),
+        normals: wp.array(dtype=wp.vec3),
+        colors: wp.array(dtype=wp.vec3ub),
+        mesh_counts: wp.array(dtype=wp.int32),
+        output_flags: wp.int32,
+        triangle_capacity: wp.int32,
+    ):
+        """Generate approximate mesh directly from current active TSDF blocks.
+
+        ``mesh_counts`` layout:
+          0 required vertices, 1 required triangles, 2 written vertices,
+          3 written triangles, 4 surface cubes, 5 overflow triangles.
+        """
+        block_idx, cube_idx = wp.tid()
+
+        if block_idx >= n_blocks:
+            return
+        if block_idx >= tsdf.num_allocated[0]:
+            return
+        if tsdf.block_to_hash_slot[block_idx] < 0:
+            return
+
+        if BS == wp.int32(1) and (
+            (output_flags & wp.int32(4)) == wp.int32(0)
+            or (output_flags & wp.int32(16)) != wp.int32(0)
+        ):
+            bx1 = tsdf.block_coords[block_idx * 3 + 0]
+            by1 = tsdf.block_coords[block_idx * 3 + 1]
+            bz1 = tsdf.block_coords[block_idx * 3 + 2]
+
+            n100_idx = hash_lookup(tsdf.hash_table, bx1 + 1, by1, bz1, tsdf.hash_capacity)
+            n010_idx = hash_lookup(tsdf.hash_table, bx1, by1 + 1, bz1, tsdf.hash_capacity)
+            n110_idx = hash_lookup(
+                tsdf.hash_table, bx1 + 1, by1 + 1, bz1, tsdf.hash_capacity
+            )
+            n001_idx = hash_lookup(tsdf.hash_table, bx1, by1, bz1 + 1, tsdf.hash_capacity)
+            n101_idx = hash_lookup(
+                tsdf.hash_table, bx1 + 1, by1, bz1 + 1, tsdf.hash_capacity
+            )
+            n011_idx = hash_lookup(
+                tsdf.hash_table, bx1, by1 + 1, bz1 + 1, tsdf.hash_capacity
+            )
+            n111_idx = hash_lookup(
+                tsdf.hash_table, bx1 + 1, by1 + 1, bz1 + 1, tsdf.hash_capacity
+            )
+            if (
+                n100_idx < 0
+                or n010_idx < 0
+                or n110_idx < 0
+                or n001_idx < 0
+                or n101_idx < 0
+                or n011_idx < 0
+                or n111_idx < 0
+            ):
+                return
+
+            s0b = sample_voxel(tsdf, block_idx, wp.int32(0), minimum_tsdf_weight)
+            s1b = sample_voxel(tsdf, n100_idx, wp.int32(0), minimum_tsdf_weight)
+            s2b = sample_voxel(tsdf, n110_idx, wp.int32(0), minimum_tsdf_weight)
+            s3b = sample_voxel(tsdf, n010_idx, wp.int32(0), minimum_tsdf_weight)
+            s4b = sample_voxel(tsdf, n001_idx, wp.int32(0), minimum_tsdf_weight)
+            s5b = sample_voxel(tsdf, n101_idx, wp.int32(0), minimum_tsdf_weight)
+            s6b = sample_voxel(tsdf, n111_idx, wp.int32(0), minimum_tsdf_weight)
+            s7b = sample_voxel(tsdf, n011_idx, wp.int32(0), minimum_tsdf_weight)
+            if s0b[1] < 0.5 or s1b[1] < 0.5 or s2b[1] < 0.5 or s3b[1] < 0.5:
+                return
+            if s4b[1] < 0.5 or s5b[1] < 0.5 or s6b[1] < 0.5 or s7b[1] < 0.5:
+                return
+
+            d0 = s0b[0] - level
+            d1 = s1b[0] - level
+            d2 = s2b[0] - level
+            d3 = s3b[0] - level
+            d4 = s4b[0] - level
+            d5 = s5b[0] - level
+            d6 = s6b[0] - level
+            d7 = s7b[0] - level
+
+            has_positive_bs1 = (
+                d0 > 0.0
+                or d1 > 0.0
+                or d2 > 0.0
+                or d3 > 0.0
+                or d4 > 0.0
+                or d5 > 0.0
+                or d6 > 0.0
+                or d7 > 0.0
+            )
+            has_negative_bs1 = (
+                d0 < 0.0
+                or d1 < 0.0
+                or d2 < 0.0
+                or d3 < 0.0
+                or d4 < 0.0
+                or d5 < 0.0
+                or d6 < 0.0
+                or d7 < 0.0
+            )
+            if not (has_positive_bs1 and has_negative_bs1):
+                return
+
+            if surface_band > 0.0:
+                in_band_bs1 = (
+                    wp.abs(d0) < surface_band
+                    or wp.abs(d1) < surface_band
+                    or wp.abs(d2) < surface_band
+                    or wp.abs(d3) < surface_band
+                    or wp.abs(d4) < surface_band
+                    or wp.abs(d5) < surface_band
+                    or wp.abs(d6) < surface_band
+                    or wp.abs(d7) < surface_band
+                )
+                if not in_band_bs1:
+                    return
+
+            wp.atomic_add(mesh_counts, 4, wp.int32(1))
+
+            cube_config_bs1 = wp.int32(0)
+            if d0 < 0.0:
+                cube_config_bs1 = cube_config_bs1 | wp.int32(1)
+            if d1 < 0.0:
+                cube_config_bs1 = cube_config_bs1 | wp.int32(2)
+            if d2 < 0.0:
+                cube_config_bs1 = cube_config_bs1 | wp.int32(4)
+            if d3 < 0.0:
+                cube_config_bs1 = cube_config_bs1 | wp.int32(8)
+            if d4 < 0.0:
+                cube_config_bs1 = cube_config_bs1 | wp.int32(16)
+            if d5 < 0.0:
+                cube_config_bs1 = cube_config_bs1 | wp.int32(32)
+            if d6 < 0.0:
+                cube_config_bs1 = cube_config_bs1 | wp.int32(64)
+            if d7 < 0.0:
+                cube_config_bs1 = cube_config_bs1 | wp.int32(128)
+
+            table_offset_bs1 = cube_config_bs1 * 16
+            num_tris_bs1 = wp.int32(0)
+            for t in range(5):
+                e = tri_table[table_offset_bs1 + t * 3]
+                if e < 0:
+                    break
+                num_tris_bs1 = num_tris_bs1 + wp.int32(1)
+
+            if num_tris_bs1 <= wp.int32(0):
+                return
+
+            tri_base_bs1 = wp.atomic_add(mesh_counts, 1, num_tris_bs1)
+            wp.atomic_add(mesh_counts, 0, num_tris_bs1 * wp.int32(3))
+
+            write_tris_bs1 = num_tris_bs1
+            if tri_base_bs1 >= triangle_capacity:
+                wp.atomic_add(mesh_counts, 5, num_tris_bs1)
+                return
+            if tri_base_bs1 + write_tris_bs1 > triangle_capacity:
+                write_tris_bs1 = triangle_capacity - tri_base_bs1
+                wp.atomic_add(mesh_counts, 5, num_tris_bs1 - write_tris_bs1)
+
+            write_vertices_bs1 = (output_flags & wp.int32(1)) != wp.int32(0)
+            write_triangles_bs1 = (output_flags & wp.int32(2)) != wp.int32(0)
+            write_normals_bs1 = (output_flags & wp.int32(4)) != wp.int32(0)
+            write_colors_bs1 = (output_flags & wp.int32(8)) != wp.int32(0)
+
+            base_bs1 = block_key_to_voxel_base(bx1, by1, bz1)
+            gx1 = base_bs1[0]
+            gy1 = base_bs1[1]
+            gz1 = base_bs1[2]
+
+            center_offset_x_bs1 = wp.float32(tsdf.grid_W) * 0.5
+            center_offset_y_bs1 = wp.float32(tsdf.grid_H) * 0.5
+            center_offset_z_bs1 = wp.float32(tsdf.grid_D) * 0.5
+
+            p0_bs1 = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx1) - center_offset_x_bs1,
+                    wp.float32(gy1) - center_offset_y_bs1,
+                    wp.float32(gz1) - center_offset_z_bs1,
+                )
+                * tsdf.voxel_size
+            )
+            p1_bs1 = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx1 + 1) - center_offset_x_bs1,
+                    wp.float32(gy1) - center_offset_y_bs1,
+                    wp.float32(gz1) - center_offset_z_bs1,
+                )
+                * tsdf.voxel_size
+            )
+            p2_bs1 = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx1 + 1) - center_offset_x_bs1,
+                    wp.float32(gy1 + 1) - center_offset_y_bs1,
+                    wp.float32(gz1) - center_offset_z_bs1,
+                )
+                * tsdf.voxel_size
+            )
+            p3_bs1 = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx1) - center_offset_x_bs1,
+                    wp.float32(gy1 + 1) - center_offset_y_bs1,
+                    wp.float32(gz1) - center_offset_z_bs1,
+                )
+                * tsdf.voxel_size
+            )
+            p4_bs1 = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx1) - center_offset_x_bs1,
+                    wp.float32(gy1) - center_offset_y_bs1,
+                    wp.float32(gz1 + 1) - center_offset_z_bs1,
+                )
+                * tsdf.voxel_size
+            )
+            p5_bs1 = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx1 + 1) - center_offset_x_bs1,
+                    wp.float32(gy1) - center_offset_y_bs1,
+                    wp.float32(gz1 + 1) - center_offset_z_bs1,
+                )
+                * tsdf.voxel_size
+            )
+            p6_bs1 = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx1 + 1) - center_offset_x_bs1,
+                    wp.float32(gy1 + 1) - center_offset_y_bs1,
+                    wp.float32(gz1 + 1) - center_offset_z_bs1,
+                )
+                * tsdf.voxel_size
+            )
+            p7_bs1 = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx1) - center_offset_x_bs1,
+                    wp.float32(gy1 + 1) - center_offset_y_bs1,
+                    wp.float32(gz1 + 1) - center_offset_z_bs1,
+                )
+                * tsdf.voxel_size
+            )
+
+            color_bs1 = wp.vec3ub(wp.uint8(0), wp.uint8(0), wp.uint8(0))
+            if write_colors_bs1:
+                rgb_bs1 = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+                color_bs1 = wp.vec3ub(
+                    wp.uint8(rgb_bs1[0]), wp.uint8(rgb_bs1[1]), wp.uint8(rgb_bs1[2])
+                )
+
+            for t in range(5):
+                if wp.int32(t) >= write_tris_bs1:
+                    break
+
+                e0_bs1 = tri_table[table_offset_bs1 + t * 3]
+                if e0_bs1 < 0:
+                    break
+
+                e1_bs1 = tri_table[table_offset_bs1 + t * 3 + 1]
+                e2_bs1 = tri_table[table_offset_bs1 + t * 3 + 2]
+
+                tri_idx_bs1 = tri_base_bs1 + wp.int32(t)
+                out_base_bs1 = tri_idx_bs1 * 3
+                v0_bs1 = get_edge_vertex(
+                    e0_bs1,
+                    p0_bs1,
+                    p1_bs1,
+                    p2_bs1,
+                    p3_bs1,
+                    p4_bs1,
+                    p5_bs1,
+                    p6_bs1,
+                    p7_bs1,
+                    d0,
+                    d1,
+                    d2,
+                    d3,
+                    d4,
+                    d5,
+                    d6,
+                    d7,
+                )
+                v1_bs1 = get_edge_vertex(
+                    e1_bs1,
+                    p0_bs1,
+                    p1_bs1,
+                    p2_bs1,
+                    p3_bs1,
+                    p4_bs1,
+                    p5_bs1,
+                    p6_bs1,
+                    p7_bs1,
+                    d0,
+                    d1,
+                    d2,
+                    d3,
+                    d4,
+                    d5,
+                    d6,
+                    d7,
+                )
+                v2_bs1 = get_edge_vertex(
+                    e2_bs1,
+                    p0_bs1,
+                    p1_bs1,
+                    p2_bs1,
+                    p3_bs1,
+                    p4_bs1,
+                    p5_bs1,
+                    p6_bs1,
+                    p7_bs1,
+                    d0,
+                    d1,
+                    d2,
+                    d3,
+                    d4,
+                    d5,
+                    d6,
+                    d7,
+                )
+
+                vertex_id0_bs1 = out_base_bs1
+                vertex_id1_bs1 = out_base_bs1 + wp.int32(1)
+                vertex_id2_bs1 = out_base_bs1 + wp.int32(2)
+                if write_vertices_bs1:
+                    vertices[vertex_id0_bs1] = v0_bs1
+                    vertices[vertex_id1_bs1] = v1_bs1
+                    vertices[vertex_id2_bs1] = v2_bs1
+                if write_normals_bs1:
+                    face_normal_bs1 = wp.cross(v1_bs1 - v0_bs1, v2_bs1 - v0_bs1)
+                    face_normal_len_sq_bs1 = wp.dot(face_normal_bs1, face_normal_bs1)
+                    if face_normal_len_sq_bs1 > 1.0e-20:
+                        face_normal_bs1 = face_normal_bs1 / wp.sqrt(
+                            face_normal_len_sq_bs1
+                        )
+                    normals[vertex_id0_bs1] = face_normal_bs1
+                    normals[vertex_id1_bs1] = face_normal_bs1
+                    normals[vertex_id2_bs1] = face_normal_bs1
+                if write_colors_bs1:
+                    colors[vertex_id0_bs1] = color_bs1
+                    colors[vertex_id1_bs1] = color_bs1
+                    colors[vertex_id2_bs1] = color_bs1
+                if write_triangles_bs1:
+                    triangles[vertex_id0_bs1] = vertex_id0_bs1
+                    triangles[vertex_id1_bs1] = vertex_id1_bs1
+                    triangles[vertex_id2_bs1] = vertex_id2_bs1
+
+            wp.atomic_add(mesh_counts, 3, write_tris_bs1)
+            wp.atomic_add(mesh_counts, 2, write_tris_bs1 * wp.int32(3))
+            return
+
+        cx = cube_idx % BS
+        cy = (cube_idx // BS) % BS
+        cz = cube_idx // (BS * BS)
+
+        bx = tsdf.block_coords[block_idx * 3 + 0]
+        by = tsdf.block_coords[block_idx * 3 + 1]
+        bz = tsdf.block_coords[block_idx * 3 + 2]
+
+        s0 = sample_cube_corner(
+            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s1 = sample_cube_corner(
+            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s2 = sample_cube_corner(
+            cx + 1, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s3 = sample_cube_corner(
+            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s4 = sample_cube_corner(
+            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s5 = sample_cube_corner(
+            cx + 1, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s6 = sample_cube_corner(
+            cx + 1, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s7 = sample_cube_corner(
+            cx, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+
+        if s0[1] < 0.5 or s1[1] < 0.5 or s2[1] < 0.5 or s3[1] < 0.5:
+            return
+        if s4[1] < 0.5 or s5[1] < 0.5 or s6[1] < 0.5 or s7[1] < 0.5:
+            return
+
+        has_positive = (
+            s0[0] > 0.0
+            or s1[0] > 0.0
+            or s2[0] > 0.0
+            or s3[0] > 0.0
+            or s4[0] > 0.0
+            or s5[0] > 0.0
+            or s6[0] > 0.0
+            or s7[0] > 0.0
+        )
+        has_negative = (
+            s0[0] < 0.0
+            or s1[0] < 0.0
+            or s2[0] < 0.0
+            or s3[0] < 0.0
+            or s4[0] < 0.0
+            or s5[0] < 0.0
+            or s6[0] < 0.0
+            or s7[0] < 0.0
+        )
+        if not (has_positive and has_negative):
+            return
+
+        if surface_band > 0.0:
+            in_band = (
+                wp.abs(s0[0]) < surface_band
+                or wp.abs(s1[0]) < surface_band
+                or wp.abs(s2[0]) < surface_band
+                or wp.abs(s3[0]) < surface_band
+                or wp.abs(s4[0]) < surface_band
+                or wp.abs(s5[0]) < surface_band
+                or wp.abs(s6[0]) < surface_band
+                or wp.abs(s7[0]) < surface_band
+            )
+            if not in_band:
+                return
+
+        wp.atomic_add(mesh_counts, 4, wp.int32(1))
+
+        cube_config = wp.int32(0)
+        if s0[0] < 0.0:
+            cube_config = cube_config | wp.int32(1)
+        if s1[0] < 0.0:
+            cube_config = cube_config | wp.int32(2)
+        if s2[0] < 0.0:
+            cube_config = cube_config | wp.int32(4)
+        if s3[0] < 0.0:
+            cube_config = cube_config | wp.int32(8)
+        if s4[0] < 0.0:
+            cube_config = cube_config | wp.int32(16)
+        if s5[0] < 0.0:
+            cube_config = cube_config | wp.int32(32)
+        if s6[0] < 0.0:
+            cube_config = cube_config | wp.int32(64)
+        if s7[0] < 0.0:
+            cube_config = cube_config | wp.int32(128)
+
+        table_offset = cube_config * 16
+        num_tris = wp.int32(0)
+
+        for t in range(5):
+            e0 = tri_table[table_offset + t * 3]
+            if e0 < 0:
+                break
+            num_tris = num_tris + wp.int32(1)
+
+        if num_tris <= wp.int32(0):
+            return
+
+        tri_base = wp.atomic_add(mesh_counts, 1, num_tris)
+        wp.atomic_add(mesh_counts, 0, num_tris * wp.int32(3))
+
+        write_tris = num_tris
+        if tri_base >= triangle_capacity:
+            wp.atomic_add(mesh_counts, 5, num_tris)
+            return
+        if tri_base + write_tris > triangle_capacity:
+            write_tris = triangle_capacity - tri_base
+            wp.atomic_add(mesh_counts, 5, num_tris - write_tris)
+
+        write_vertices = (output_flags & wp.int32(1)) != wp.int32(0)
+        write_triangles = (output_flags & wp.int32(2)) != wp.int32(0)
+        write_normals = (output_flags & wp.int32(4)) != wp.int32(0)
+        write_colors = (output_flags & wp.int32(8)) != wp.int32(0)
+        use_face_normals = (output_flags & wp.int32(16)) != wp.int32(0)
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        gx = base[0] + cx
+        gy = base[1] + cy
+        gz = base[2] + cz
+
+        center_offset_x = wp.float32(tsdf.grid_W) * 0.5
+        center_offset_y = wp.float32(tsdf.grid_H) * 0.5
+        center_offset_z = wp.float32(tsdf.grid_D) * 0.5
+
+        p0 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p1 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p2 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p3 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p4 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p5 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p6 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p7 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+
+        color = wp.vec3ub(wp.uint8(0), wp.uint8(0), wp.uint8(0))
+        if write_colors:
+            rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+            color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
+
+        for t in range(5):
+            if wp.int32(t) >= write_tris:
+                break
+
+            e0 = tri_table[table_offset + t * 3]
+            if e0 < 0:
+                break
+
+            e1 = tri_table[table_offset + t * 3 + 1]
+            e2 = tri_table[table_offset + t * 3 + 2]
+
+            tri_idx = tri_base + wp.int32(t)
+            out_base = tri_idx * 3
+            v0 = get_edge_vertex(
+                e0,
+                p0,
+                p1,
+                p2,
+                p3,
+                p4,
+                p5,
+                p6,
+                p7,
+                s0[0],
+                s1[0],
+                s2[0],
+                s3[0],
+                s4[0],
+                s5[0],
+                s6[0],
+                s7[0],
+            )
+            v1 = get_edge_vertex(
+                e1,
+                p0,
+                p1,
+                p2,
+                p3,
+                p4,
+                p5,
+                p6,
+                p7,
+                s0[0],
+                s1[0],
+                s2[0],
+                s3[0],
+                s4[0],
+                s5[0],
+                s6[0],
+                s7[0],
+            )
+            v2 = get_edge_vertex(
+                e2,
+                p0,
+                p1,
+                p2,
+                p3,
+                p4,
+                p5,
+                p6,
+                p7,
+                s0[0],
+                s1[0],
+                s2[0],
+                s3[0],
+                s4[0],
+                s5[0],
+                s6[0],
+                s7[0],
+            )
+
+            vertex_id0 = out_base
+            vertex_id1 = out_base + wp.int32(1)
+            vertex_id2 = out_base + wp.int32(2)
+            if write_vertices:
+                vertices[vertex_id0] = v0
+                vertices[vertex_id1] = v1
+                vertices[vertex_id2] = v2
+            if write_normals:
+                if use_face_normals:
+                    face_normal = wp.cross(v1 - v0, v2 - v0)
+                    face_normal_len_sq = wp.dot(face_normal, face_normal)
+                    if face_normal_len_sq > 1.0e-20:
+                        face_normal = face_normal / wp.sqrt(face_normal_len_sq)
+                    normals[vertex_id0] = face_normal
+                    normals[vertex_id1] = face_normal
+                    normals[vertex_id2] = face_normal
+                else:
+                    n0 = compute_gradient_nearest(tsdf, v0, minimum_tsdf_weight)
+                    n1 = compute_gradient_nearest(tsdf, v1, minimum_tsdf_weight)
+                    n2 = compute_gradient_nearest(tsdf, v2, minimum_tsdf_weight)
+                    normals[vertex_id0] = wp.normalize(n0)
+                    normals[vertex_id1] = wp.normalize(n1)
+                    normals[vertex_id2] = wp.normalize(n2)
+            if write_colors:
+                colors[vertex_id0] = color
+                colors[vertex_id1] = color
+                colors[vertex_id2] = color
+            if write_triangles:
+                triangles[vertex_id0] = vertex_id0
+                triangles[vertex_id1] = vertex_id1
+                triangles[vertex_id2] = vertex_id2
+
+        wp.atomic_add(mesh_counts, 3, write_tris)
+        wp.atomic_add(mesh_counts, 2, write_tris * wp.int32(3))
+
+    @warp_kernel(f"count_fast_mesh_block_triangles_kernel_bs{block_size}", enable_backward=False)
+    def count_fast_mesh_block_triangles_kernel(
+        tsdf: BlockSparseTSDFWarp,
+        level: float,
+        surface_band: float,
+        minimum_tsdf_weight: float,
+        n_blocks: wp.int32,
+        num_tris_table: wp.array(dtype=wp.int32),
+        block_triangle_counts: wp.array(dtype=wp.int32),
+        block_surface_counts: wp.array(dtype=wp.int32),
+    ):
+        """Count full-scene fast mesh triangles per TSDF block."""
+        block_idx, cube_idx = wp.tid()
+
+        if block_idx >= n_blocks:
+            return
+        if block_idx >= tsdf.num_allocated[0]:
+            return
+        if tsdf.block_to_hash_slot[block_idx] < 0:
+            return
+
+        if BS == wp.int32(1):
+            return
+
+        cx = cube_idx % BS
+        cy = (cube_idx // BS) % BS
+        cz = cube_idx // (BS * BS)
+
+        bx = tsdf.block_coords[block_idx * 3 + 0]
+        by = tsdf.block_coords[block_idx * 3 + 1]
+        bz = tsdf.block_coords[block_idx * 3 + 2]
+
+        s0 = sample_cube_corner(
+            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s1 = sample_cube_corner(
+            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s2 = sample_cube_corner(
+            cx + 1, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s3 = sample_cube_corner(
+            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s4 = sample_cube_corner(
+            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s5 = sample_cube_corner(
+            cx + 1, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s6 = sample_cube_corner(
+            cx + 1, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+        s7 = sample_cube_corner(
+            cx, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
+        )
+
+        if s0[1] < 0.5 or s1[1] < 0.5 or s2[1] < 0.5 or s3[1] < 0.5:
+            return
+        if s4[1] < 0.5 or s5[1] < 0.5 or s6[1] < 0.5 or s7[1] < 0.5:
+            return
+
+        has_positive = (
+            s0[0] > 0.0
+            or s1[0] > 0.0
+            or s2[0] > 0.0
+            or s3[0] > 0.0
+            or s4[0] > 0.0
+            or s5[0] > 0.0
+            or s6[0] > 0.0
+            or s7[0] > 0.0
+        )
+        has_negative = (
+            s0[0] < 0.0
+            or s1[0] < 0.0
+            or s2[0] < 0.0
+            or s3[0] < 0.0
+            or s4[0] < 0.0
+            or s5[0] < 0.0
+            or s6[0] < 0.0
+            or s7[0] < 0.0
+        )
+        if not (has_positive and has_negative):
+            return
+
+        if surface_band > 0.0:
+            in_band = (
+                wp.abs(s0[0]) < surface_band
+                or wp.abs(s1[0]) < surface_band
+                or wp.abs(s2[0]) < surface_band
+                or wp.abs(s3[0]) < surface_band
+                or wp.abs(s4[0]) < surface_band
+                or wp.abs(s5[0]) < surface_band
+                or wp.abs(s6[0]) < surface_band
+                or wp.abs(s7[0]) < surface_band
+            )
+            if not in_band:
+                return
+
+        cube_config = wp.int32(0)
+        if s0[0] < 0.0:
+            cube_config = cube_config | wp.int32(1)
+        if s1[0] < 0.0:
+            cube_config = cube_config | wp.int32(2)
+        if s2[0] < 0.0:
+            cube_config = cube_config | wp.int32(4)
+        if s3[0] < 0.0:
+            cube_config = cube_config | wp.int32(8)
+        if s4[0] < 0.0:
+            cube_config = cube_config | wp.int32(16)
+        if s5[0] < 0.0:
+            cube_config = cube_config | wp.int32(32)
+        if s6[0] < 0.0:
+            cube_config = cube_config | wp.int32(64)
+        if s7[0] < 0.0:
+            cube_config = cube_config | wp.int32(128)
+
+        num_tris = num_tris_table[cube_config]
+        if num_tris <= wp.int32(0):
+            return
+
+        wp.atomic_add(block_surface_counts, block_idx, wp.int32(1))
+        wp.atomic_add(block_triangle_counts, block_idx, num_tris)
+
+    @warp_kernel(f"generate_fast_mesh_current_state_kernel_bs{block_size}")
+    def generate_fast_mesh_current_state_kernel(
+        tsdf: BlockSparseTSDFWarp,
+        level: float,
+        surface_band: float,
+        minimum_tsdf_weight: float,
+        n_blocks: wp.int32,
+        tri_table: wp.array(dtype=wp.int32),
+        vertices: wp.array(dtype=wp.vec3),
+        triangles: wp.array(dtype=wp.int32),
+        colors: wp.array(dtype=wp.vec3ub),
+        mesh_counts: wp.array(dtype=wp.int32),
+        block_triangle_offsets: wp.array(dtype=wp.int32),
+        block_write_counts: wp.array(dtype=wp.int32),
+        triangle_capacity: wp.int32,
+        write_triangles: wp.int32,
+        use_voxel_colors: wp.int32,
+        atomic_triangle_list: wp.int32,
+    ):
+        """Fast current-state mesh: vertices, triangles, colors; no normals."""
+        block_idx, cube_idx = wp.tid()
+
+        if block_idx >= n_blocks:
+            return
+        if block_idx >= tsdf.num_allocated[0]:
+            return
+        if tsdf.block_to_hash_slot[block_idx] < 0:
+            return
+
+        if BS != wp.int32(1):
+            cx_g = cube_idx % BS
+            cy_g = (cube_idx // BS) % BS
+            cz_g = cube_idx // (BS * BS)
+
+            bx_g = tsdf.block_coords[block_idx * 3 + 0]
+            by_g = tsdf.block_coords[block_idx * 3 + 1]
+            bz_g = tsdf.block_coords[block_idx * 3 + 2]
+
+            s0_g = sample_cube_corner(
+                cx_g, cy_g, cz_g, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
+            )
+            s1_g = sample_cube_corner(
+                cx_g + 1, cy_g, cz_g, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
+            )
+            s2_g = sample_cube_corner(
+                cx_g + 1, cy_g + 1, cz_g, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
+            )
+            s3_g = sample_cube_corner(
+                cx_g, cy_g + 1, cz_g, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
+            )
+            s4_g = sample_cube_corner(
+                cx_g, cy_g, cz_g + 1, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
+            )
+            s5_g = sample_cube_corner(
+                cx_g + 1, cy_g, cz_g + 1, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
+            )
+            s6_g = sample_cube_corner(
+                cx_g + 1, cy_g + 1, cz_g + 1, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
+            )
+            s7_g = sample_cube_corner(
+                cx_g, cy_g + 1, cz_g + 1, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
+            )
+
+            if s0_g[1] < 0.5 or s1_g[1] < 0.5 or s2_g[1] < 0.5 or s3_g[1] < 0.5:
+                return
+            if s4_g[1] < 0.5 or s5_g[1] < 0.5 or s6_g[1] < 0.5 or s7_g[1] < 0.5:
+                return
+
+            has_positive_g = (
+                s0_g[0] > 0.0
+                or s1_g[0] > 0.0
+                or s2_g[0] > 0.0
+                or s3_g[0] > 0.0
+                or s4_g[0] > 0.0
+                or s5_g[0] > 0.0
+                or s6_g[0] > 0.0
+                or s7_g[0] > 0.0
+            )
+            has_negative_g = (
+                s0_g[0] < 0.0
+                or s1_g[0] < 0.0
+                or s2_g[0] < 0.0
+                or s3_g[0] < 0.0
+                or s4_g[0] < 0.0
+                or s5_g[0] < 0.0
+                or s6_g[0] < 0.0
+                or s7_g[0] < 0.0
+            )
+            if not (has_positive_g and has_negative_g):
+                return
+
+            if surface_band > 0.0:
+                in_band_g = (
+                    wp.abs(s0_g[0]) < surface_band
+                    or wp.abs(s1_g[0]) < surface_band
+                    or wp.abs(s2_g[0]) < surface_band
+                    or wp.abs(s3_g[0]) < surface_band
+                    or wp.abs(s4_g[0]) < surface_band
+                    or wp.abs(s5_g[0]) < surface_band
+                    or wp.abs(s6_g[0]) < surface_band
+                    or wp.abs(s7_g[0]) < surface_band
+                )
+                if not in_band_g:
+                    return
+
+            cube_config_g = wp.int32(0)
+            if s0_g[0] < 0.0:
+                cube_config_g = cube_config_g | wp.int32(1)
+            if s1_g[0] < 0.0:
+                cube_config_g = cube_config_g | wp.int32(2)
+            if s2_g[0] < 0.0:
+                cube_config_g = cube_config_g | wp.int32(4)
+            if s3_g[0] < 0.0:
+                cube_config_g = cube_config_g | wp.int32(8)
+            if s4_g[0] < 0.0:
+                cube_config_g = cube_config_g | wp.int32(16)
+            if s5_g[0] < 0.0:
+                cube_config_g = cube_config_g | wp.int32(32)
+            if s6_g[0] < 0.0:
+                cube_config_g = cube_config_g | wp.int32(64)
+            if s7_g[0] < 0.0:
+                cube_config_g = cube_config_g | wp.int32(128)
+
+            table_offset_g = cube_config_g * 16
+            num_tris_g = wp.int32(0)
+            for t in range(5):
+                e_g = tri_table[table_offset_g + t * 3]
+                if e_g < 0:
+                    break
+                num_tris_g = num_tris_g + wp.int32(1)
+
+            if num_tris_g <= wp.int32(0):
+                return
+
+            if atomic_triangle_list != wp.int32(0):
+                tri_base_g = wp.atomic_add(mesh_counts, wp.int32(1), num_tris_g)
+                wp.atomic_add(mesh_counts, wp.int32(0), num_tris_g * wp.int32(3))
+            else:
+                local_tri_base_g = wp.atomic_add(block_write_counts, block_idx, num_tris_g)
+                tri_base_g = block_triangle_offsets[block_idx] + local_tri_base_g
+
+            write_tris_g = num_tris_g
+            if tri_base_g >= triangle_capacity:
+                if atomic_triangle_list != wp.int32(0):
+                    wp.atomic_add(mesh_counts, wp.int32(5), num_tris_g)
+                return
+            if tri_base_g + write_tris_g > triangle_capacity:
+                write_tris_g = triangle_capacity - tri_base_g
+                if atomic_triangle_list != wp.int32(0):
+                    wp.atomic_add(mesh_counts, wp.int32(5), num_tris_g - write_tris_g)
+
+            if atomic_triangle_list != wp.int32(0):
+                wp.atomic_add(mesh_counts, wp.int32(2), write_tris_g * wp.int32(3))
+                wp.atomic_add(mesh_counts, wp.int32(3), write_tris_g)
+
+            base_g = block_key_to_voxel_base(bx_g, by_g, bz_g)
+            gx_g = base_g[0] + cx_g
+            gy_g = base_g[1] + cy_g
+            gz_g = base_g[2] + cz_g
+
+            center_offset_x_g = wp.float32(tsdf.grid_W) * 0.5
+            center_offset_y_g = wp.float32(tsdf.grid_H) * 0.5
+            center_offset_z_g = wp.float32(tsdf.grid_D) * 0.5
+
+            p0_g = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx_g) - center_offset_x_g,
+                    wp.float32(gy_g) - center_offset_y_g,
+                    wp.float32(gz_g) - center_offset_z_g,
+                )
+                * tsdf.voxel_size
+            )
+            p1_g = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx_g + 1) - center_offset_x_g,
+                    wp.float32(gy_g) - center_offset_y_g,
+                    wp.float32(gz_g) - center_offset_z_g,
+                )
+                * tsdf.voxel_size
+            )
+            p2_g = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx_g + 1) - center_offset_x_g,
+                    wp.float32(gy_g + 1) - center_offset_y_g,
+                    wp.float32(gz_g) - center_offset_z_g,
+                )
+                * tsdf.voxel_size
+            )
+            p3_g = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx_g) - center_offset_x_g,
+                    wp.float32(gy_g + 1) - center_offset_y_g,
+                    wp.float32(gz_g) - center_offset_z_g,
+                )
+                * tsdf.voxel_size
+            )
+            p4_g = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx_g) - center_offset_x_g,
+                    wp.float32(gy_g) - center_offset_y_g,
+                    wp.float32(gz_g + 1) - center_offset_z_g,
+                )
+                * tsdf.voxel_size
+            )
+            p5_g = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx_g + 1) - center_offset_x_g,
+                    wp.float32(gy_g) - center_offset_y_g,
+                    wp.float32(gz_g + 1) - center_offset_z_g,
+                )
+                * tsdf.voxel_size
+            )
+            p6_g = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx_g + 1) - center_offset_x_g,
+                    wp.float32(gy_g + 1) - center_offset_y_g,
+                    wp.float32(gz_g + 1) - center_offset_z_g,
+                )
+                * tsdf.voxel_size
+            )
+            p7_g = (
+                tsdf.origin
+                + wp.vec3(
+                    wp.float32(gx_g) - center_offset_x_g,
+                    wp.float32(gy_g + 1) - center_offset_y_g,
+                    wp.float32(gz_g + 1) - center_offset_z_g,
+                )
+                * tsdf.voxel_size
+            )
+
+            color_g = wp.vec3ub(wp.uint8(128), wp.uint8(128), wp.uint8(128))
+            if use_voxel_colors != wp.int32(0):
+                if not USE_COLOR_GRID:
+                    rgb_g = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+                    color_g = wp.vec3ub(
+                        wp.uint8(rgb_g[0]), wp.uint8(rgb_g[1]), wp.uint8(rgb_g[2])
+                    )
+
+            for t in range(5):
+                if wp.int32(t) >= write_tris_g:
+                    break
+
+                e0_g = tri_table[table_offset_g + t * 3]
+                if e0_g < 0:
+                    break
+
+                e1_g = tri_table[table_offset_g + t * 3 + 1]
+                e2_g = tri_table[table_offset_g + t * 3 + 2]
+
+                tri_idx_g = tri_base_g + wp.int32(t)
+                out_base_g = tri_idx_g * 3
+                v0_g = get_edge_vertex(
+                    e0_g,
+                    p0_g,
+                    p1_g,
+                    p2_g,
+                    p3_g,
+                    p4_g,
+                    p5_g,
+                    p6_g,
+                    p7_g,
+                    s0_g[0],
+                    s1_g[0],
+                    s2_g[0],
+                    s3_g[0],
+                    s4_g[0],
+                    s5_g[0],
+                    s6_g[0],
+                    s7_g[0],
+                )
+                v1_g = get_edge_vertex(
+                    e1_g,
+                    p0_g,
+                    p1_g,
+                    p2_g,
+                    p3_g,
+                    p4_g,
+                    p5_g,
+                    p6_g,
+                    p7_g,
+                    s0_g[0],
+                    s1_g[0],
+                    s2_g[0],
+                    s3_g[0],
+                    s4_g[0],
+                    s5_g[0],
+                    s6_g[0],
+                    s7_g[0],
+                )
+                v2_g = get_edge_vertex(
+                    e2_g,
+                    p0_g,
+                    p1_g,
+                    p2_g,
+                    p3_g,
+                    p4_g,
+                    p5_g,
+                    p6_g,
+                    p7_g,
+                    s0_g[0],
+                    s1_g[0],
+                    s2_g[0],
+                    s3_g[0],
+                    s4_g[0],
+                    s5_g[0],
+                    s6_g[0],
+                    s7_g[0],
+                )
+
+                vertex_id0_g = out_base_g
+                vertex_id1_g = out_base_g + wp.int32(1)
+                vertex_id2_g = out_base_g + wp.int32(2)
+                vertices[vertex_id0_g] = v0_g
+                vertices[vertex_id1_g] = v1_g
+                vertices[vertex_id2_g] = v2_g
+                if write_triangles != wp.int32(0):
+                    triangles[vertex_id0_g] = vertex_id0_g
+                    triangles[vertex_id1_g] = vertex_id1_g
+                    triangles[vertex_id2_g] = vertex_id2_g
+                if USE_COLOR_GRID:
+                    if use_voxel_colors == wp.int32(0):
+                        colors[vertex_id0_g] = color_g
+                        colors[vertex_id1_g] = color_g
+                        colors[vertex_id2_g] = color_g
+                        continue
+                    c0_g = sample_rgb(tsdf, v0_g)
+                    c1_g = sample_rgb(tsdf, v1_g)
+                    c2_g = sample_rgb(tsdf, v2_g)
+                    colors[vertex_id0_g] = wp.vec3ub(
+                        wp.uint8(c0_g[0]), wp.uint8(c0_g[1]), wp.uint8(c0_g[2])
+                    )
+                    colors[vertex_id1_g] = wp.vec3ub(
+                        wp.uint8(c1_g[0]), wp.uint8(c1_g[1]), wp.uint8(c1_g[2])
+                    )
+                    colors[vertex_id2_g] = wp.vec3ub(
+                        wp.uint8(c2_g[0]), wp.uint8(c2_g[1]), wp.uint8(c2_g[2])
+                    )
+                else:
+                    colors[vertex_id0_g] = color_g
+                    colors[vertex_id1_g] = color_g
+                    colors[vertex_id2_g] = color_g
+
+            return
+
+        if cube_idx != wp.int32(0):
+            return
+
+        bx = tsdf.block_coords[block_idx * 3 + 0]
+        by = tsdf.block_coords[block_idx * 3 + 1]
+        bz = tsdf.block_coords[block_idx * 3 + 2]
+
+        n100_idx = hash_lookup(tsdf.hash_table, bx + 1, by, bz, tsdf.hash_capacity)
+        n010_idx = hash_lookup(tsdf.hash_table, bx, by + 1, bz, tsdf.hash_capacity)
+        n110_idx = hash_lookup(tsdf.hash_table, bx + 1, by + 1, bz, tsdf.hash_capacity)
+        n001_idx = hash_lookup(tsdf.hash_table, bx, by, bz + 1, tsdf.hash_capacity)
+        n101_idx = hash_lookup(tsdf.hash_table, bx + 1, by, bz + 1, tsdf.hash_capacity)
+        n011_idx = hash_lookup(tsdf.hash_table, bx, by + 1, bz + 1, tsdf.hash_capacity)
+        n111_idx = hash_lookup(
+            tsdf.hash_table, bx + 1, by + 1, bz + 1, tsdf.hash_capacity
+        )
+        if (
+            n100_idx < 0
+            or n010_idx < 0
+            or n110_idx < 0
+            or n001_idx < 0
+            or n101_idx < 0
+            or n011_idx < 0
+            or n111_idx < 0
+        ):
+            return
+
+        s0 = sample_voxel(tsdf, block_idx, wp.int32(0), minimum_tsdf_weight)
+        s1 = sample_voxel(tsdf, n100_idx, wp.int32(0), minimum_tsdf_weight)
+        s2 = sample_voxel(tsdf, n110_idx, wp.int32(0), minimum_tsdf_weight)
+        s3 = sample_voxel(tsdf, n010_idx, wp.int32(0), minimum_tsdf_weight)
+        s4 = sample_voxel(tsdf, n001_idx, wp.int32(0), minimum_tsdf_weight)
+        s5 = sample_voxel(tsdf, n101_idx, wp.int32(0), minimum_tsdf_weight)
+        s6 = sample_voxel(tsdf, n111_idx, wp.int32(0), minimum_tsdf_weight)
+        s7 = sample_voxel(tsdf, n011_idx, wp.int32(0), minimum_tsdf_weight)
+        if s0[1] < 0.5 or s1[1] < 0.5 or s2[1] < 0.5 or s3[1] < 0.5:
+            return
+        if s4[1] < 0.5 or s5[1] < 0.5 or s6[1] < 0.5 or s7[1] < 0.5:
+            return
+
+        d0 = s0[0] - level
+        d1 = s1[0] - level
+        d2 = s2[0] - level
+        d3 = s3[0] - level
+        d4 = s4[0] - level
+        d5 = s5[0] - level
+        d6 = s6[0] - level
+        d7 = s7[0] - level
+
+        has_positive = (
+            d0 > 0.0
+            or d1 > 0.0
+            or d2 > 0.0
+            or d3 > 0.0
+            or d4 > 0.0
+            or d5 > 0.0
+            or d6 > 0.0
+            or d7 > 0.0
+        )
+        has_negative = (
+            d0 < 0.0
+            or d1 < 0.0
+            or d2 < 0.0
+            or d3 < 0.0
+            or d4 < 0.0
+            or d5 < 0.0
+            or d6 < 0.0
+            or d7 < 0.0
+        )
+        if not (has_positive and has_negative):
+            return
+
+        if surface_band > 0.0:
+            in_band = (
+                wp.abs(d0) < surface_band
+                or wp.abs(d1) < surface_band
+                or wp.abs(d2) < surface_band
+                or wp.abs(d3) < surface_band
+                or wp.abs(d4) < surface_band
+                or wp.abs(d5) < surface_band
+                or wp.abs(d6) < surface_band
+                or wp.abs(d7) < surface_band
+            )
+            if not in_band:
+                return
+
+        cube_config = wp.int32(0)
+        if d0 < 0.0:
+            cube_config = cube_config | wp.int32(1)
+        if d1 < 0.0:
+            cube_config = cube_config | wp.int32(2)
+        if d2 < 0.0:
+            cube_config = cube_config | wp.int32(4)
+        if d3 < 0.0:
+            cube_config = cube_config | wp.int32(8)
+        if d4 < 0.0:
+            cube_config = cube_config | wp.int32(16)
+        if d5 < 0.0:
+            cube_config = cube_config | wp.int32(32)
+        if d6 < 0.0:
+            cube_config = cube_config | wp.int32(64)
+        if d7 < 0.0:
+            cube_config = cube_config | wp.int32(128)
+
+        table_offset = cube_config * 16
+        num_tris = wp.int32(0)
+        for t in range(5):
+            e = tri_table[table_offset + t * 3]
+            if e < 0:
+                break
+            num_tris = num_tris + wp.int32(1)
+
+        if num_tris <= wp.int32(0):
+            return
+
+        if atomic_triangle_list != wp.int32(0):
+            tri_base = wp.atomic_add(mesh_counts, wp.int32(1), num_tris)
+            wp.atomic_add(mesh_counts, wp.int32(0), num_tris * wp.int32(3))
+        else:
+            local_tri_base = wp.atomic_add(block_write_counts, block_idx, num_tris)
+            tri_base = block_triangle_offsets[block_idx] + local_tri_base
+
+        write_tris = num_tris
+        if tri_base >= triangle_capacity:
+            if atomic_triangle_list != wp.int32(0):
+                wp.atomic_add(mesh_counts, wp.int32(5), num_tris)
+            return
+        if tri_base + write_tris > triangle_capacity:
+            write_tris = triangle_capacity - tri_base
+            if atomic_triangle_list != wp.int32(0):
+                wp.atomic_add(mesh_counts, wp.int32(5), num_tris - write_tris)
+
+        if atomic_triangle_list != wp.int32(0):
+            wp.atomic_add(mesh_counts, wp.int32(2), write_tris * wp.int32(3))
+            wp.atomic_add(mesh_counts, wp.int32(3), write_tris)
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        gx = base[0]
+        gy = base[1]
+        gz = base[2]
+
+        center_offset_x = wp.float32(tsdf.grid_W) * 0.5
+        center_offset_y = wp.float32(tsdf.grid_H) * 0.5
+        center_offset_z = wp.float32(tsdf.grid_D) * 0.5
+
+        p0 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p1 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p2 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p3 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p4 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p5 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p6 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx + 1) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+        p7 = (
+            tsdf.origin
+            + wp.vec3(
+                wp.float32(gx) - center_offset_x,
+                wp.float32(gy + 1) - center_offset_y,
+                wp.float32(gz + 1) - center_offset_z,
+            )
+            * tsdf.voxel_size
+        )
+
+        color = wp.vec3ub(wp.uint8(128), wp.uint8(128), wp.uint8(128))
+        if use_voxel_colors != wp.int32(0):
+            if not USE_COLOR_GRID:
+                rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+                color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
+
+        for t in range(5):
+            if wp.int32(t) >= write_tris:
+                break
+
+            e0 = tri_table[table_offset + t * 3]
+            if e0 < 0:
+                break
+
+            e1 = tri_table[table_offset + t * 3 + 1]
+            e2 = tri_table[table_offset + t * 3 + 2]
+
+            tri_idx = tri_base + wp.int32(t)
+            out_base = tri_idx * 3
+            v0 = get_edge_vertex(
+                e0,
+                p0,
+                p1,
+                p2,
+                p3,
+                p4,
+                p5,
+                p6,
+                p7,
+                d0,
+                d1,
+                d2,
+                d3,
+                d4,
+                d5,
+                d6,
+                d7,
+            )
+            v1 = get_edge_vertex(
+                e1,
+                p0,
+                p1,
+                p2,
+                p3,
+                p4,
+                p5,
+                p6,
+                p7,
+                d0,
+                d1,
+                d2,
+                d3,
+                d4,
+                d5,
+                d6,
+                d7,
+            )
+            v2 = get_edge_vertex(
+                e2,
+                p0,
+                p1,
+                p2,
+                p3,
+                p4,
+                p5,
+                p6,
+                p7,
+                d0,
+                d1,
+                d2,
+                d3,
+                d4,
+                d5,
+                d6,
+                d7,
+            )
+
+            vertex_id0 = out_base
+            vertex_id1 = out_base + wp.int32(1)
+            vertex_id2 = out_base + wp.int32(2)
+            vertices[vertex_id0] = v0
+            vertices[vertex_id1] = v1
+            vertices[vertex_id2] = v2
+            if write_triangles != wp.int32(0):
+                triangles[vertex_id0] = vertex_id0
+                triangles[vertex_id1] = vertex_id1
+                triangles[vertex_id2] = vertex_id2
+            if USE_COLOR_GRID:
+                if use_voxel_colors == wp.int32(0):
+                    colors[vertex_id0] = color
+                    colors[vertex_id1] = color
+                    colors[vertex_id2] = color
+                    continue
+                c0 = sample_rgb(tsdf, v0)
+                c1 = sample_rgb(tsdf, v1)
+                c2 = sample_rgb(tsdf, v2)
+                colors[vertex_id0] = wp.vec3ub(
+                    wp.uint8(c0[0]), wp.uint8(c0[1]), wp.uint8(c0[2])
+                )
+                colors[vertex_id1] = wp.vec3ub(
+                    wp.uint8(c1[0]), wp.uint8(c1[1]), wp.uint8(c1[2])
+                )
+                colors[vertex_id2] = wp.vec3ub(
+                    wp.uint8(c2[0]), wp.uint8(c2[1]), wp.uint8(c2[2])
+                )
+            else:
+                colors[vertex_id0] = color
+                colors[vertex_id1] = color
+                colors[vertex_id2] = color
+
+    # =====================================================================
+    # Projective texture mapping for fast triangle-list meshes
+    # =====================================================================
+
+    @warp_kernel(f"copy_rgb_images_to_texture_atlas_kernel_bs{block_size}", enable_backward=False)
+    def copy_rgb_images_to_texture_atlas_kernel(
+        rgb_images: wp.array3d(dtype=wp.uint8),
+        texture_atlas: wp.array3d(dtype=wp.uint8),
+    ):
+        """Copy flattened camera RGB images into a horizontal texture atlas."""
+        tid = wp.tid()
+        image_pixels = IMAGE_HEIGHT * IMAGE_WIDTH
+        total_pixels = NUM_CAMERAS * image_pixels
+        if tid >= total_pixels:
+            return
+
+        cam_idx = tid // image_pixels
+        rem = tid - cam_idx * image_pixels
+        py = rem // IMAGE_WIDTH
+        px = rem - py * IMAGE_WIDTH
+
+        src_y = cam_idx * IMAGE_HEIGHT + py
+        atlas_x = cam_idx * IMAGE_WIDTH + px
+
+        texture_atlas[py, atlas_x, 0] = rgb_images[src_y, px, 0]
+        texture_atlas[py, atlas_x, 1] = rgb_images[src_y, px, 1]
+        texture_atlas[py, atlas_x, 2] = rgb_images[src_y, px, 2]
+
+    @warp_kernel(f"project_fast_mesh_uvs_kernel_bs{block_size}", enable_backward=False)
+    def project_fast_mesh_uvs_kernel(
+        vertices: wp.array(dtype=wp.vec3),
+        vertex_count: wp.int32,
+        intrinsics: wp.array3d(dtype=wp.float32),
+        cam_positions: wp.array2d(dtype=wp.float32),
+        cam_quaternions: wp.array2d(dtype=wp.float32),
+        depth_images: wp.array3d(dtype=wp.float32),
+        depth_min: float,
+        depth_max: float,
+        occlusion_tolerance_m: float,
+        vertex_uvs: wp.array(dtype=wp.vec2),
+        colors: wp.array(dtype=wp.vec3ub),
+        fill_missing_colors: wp.int32,
+        tsdf: BlockSparseTSDFWarp,
+    ):
+        """Project fast-mesh triangle vertices into the current camera atlas."""
+        tri_idx = wp.tid()
+        base = tri_idx * wp.int32(3)
+        if base + wp.int32(2) >= vertex_count:
+            return
+
+        invalid_uv = wp.vec2(-1.0, -1.0)
+        v0 = vertices[base]
+        v1 = vertices[base + wp.int32(1)]
+        v2 = vertices[base + wp.int32(2)]
+
+        center = (v0 + v1 + v2) / wp.float32(3.0)
+        face_normal = wp.cross(v1 - v0, v2 - v0)
+
+        uv0 = invalid_uv
+        uv1 = invalid_uv
+        uv2 = invalid_uv
+        projected = bool(False)
+        score_limit = wp.float32(1.0e20)
+
+        for _attempt in range(num_cameras):
+            best_cam = wp.int32(-1)
+            best_score = wp.float32(-1.0e20)
+
+            for cam_i in range(num_cameras):
+                cam_pos_i = wp.vec3(
+                    cam_positions[cam_i, 0],
+                    cam_positions[cam_i, 1],
+                    cam_positions[cam_i, 2],
+                )
+                cam_quat_i = wp.quaternion(
+                    cam_quaternions[cam_i, 1],
+                    cam_quaternions[cam_i, 2],
+                    cam_quaternions[cam_i, 3],
+                    cam_quaternions[cam_i, 0],
+                )
+                center_cam_i = wp.quat_rotate(wp.quat_inverse(cam_quat_i), center - cam_pos_i)
+                z_center_i = center_cam_i[2]
+
+                if z_center_i > depth_min and z_center_i <= depth_max:
+                    fx_i = intrinsics[cam_i, 0, 0]
+                    fy_i = intrinsics[cam_i, 1, 1]
+                    cx_i = intrinsics[cam_i, 0, 2]
+                    cy_i = intrinsics[cam_i, 1, 2]
+
+                    u_center_i = fx_i * center_cam_i[0] / z_center_i + cx_i
+                    v_center_i = fy_i * center_cam_i[1] / z_center_i + cy_i
+                    if (
+                        u_center_i >= 0.0
+                        and u_center_i < wp.float32(IMAGE_WIDTH)
+                        and v_center_i >= 0.0
+                        and v_center_i < wp.float32(IMAGE_HEIGHT)
+                    ):
+                        viewing_dir = cam_pos_i - center
+                        viewing_len_sq = wp.dot(viewing_dir, viewing_dir)
+                        if viewing_len_sq > 1.0e-20:
+                            viewing_dir = viewing_dir / wp.sqrt(viewing_len_sq)
+                            score = wp.dot(face_normal, viewing_dir)
+                            if score < score_limit and score > best_score:
+                                best_score = score
+                                best_cam = wp.int32(cam_i)
+
+            if best_cam < 0:
+                break
+
+            cam_pos = wp.vec3(
+                cam_positions[best_cam, 0],
+                cam_positions[best_cam, 1],
+                cam_positions[best_cam, 2],
+            )
+            cam_quat = wp.quaternion(
+                cam_quaternions[best_cam, 1],
+                cam_quaternions[best_cam, 2],
+                cam_quaternions[best_cam, 3],
+                cam_quaternions[best_cam, 0],
+            )
+            cam_quat_inv = wp.quat_inverse(cam_quat)
+            fx = intrinsics[best_cam, 0, 0]
+            fy = intrinsics[best_cam, 1, 1]
+            cx = intrinsics[best_cam, 0, 2]
+            cy = intrinsics[best_cam, 1, 2]
+            atlas_width = wp.float32(NUM_CAMERAS * IMAGE_WIDTH)
+            atlas_x_offset = wp.float32(best_cam * IMAGE_WIDTH)
+
+            all_valid = bool(True)
+
+            p0_cam = wp.quat_rotate(cam_quat_inv, v0 - cam_pos)
+            z0 = p0_cam[2]
+            if z0 > depth_min and z0 <= depth_max:
+                u0 = fx * p0_cam[0] / z0 + cx
+                vv0 = fy * p0_cam[1] / z0 + cy
+                if (
+                    u0 >= 0.0
+                    and u0 < wp.float32(IMAGE_WIDTH)
+                    and vv0 >= 0.0
+                    and vv0 < wp.float32(IMAGE_HEIGHT)
+                ):
+                    px0 = wp.int32(u0 + 0.5)
+                    py0 = wp.int32(vv0 + 0.5)
+                    if px0 >= IMAGE_WIDTH:
+                        px0 = IMAGE_WIDTH - wp.int32(1)
+                    if py0 >= IMAGE_HEIGHT:
+                        py0 = IMAGE_HEIGHT - wp.int32(1)
+                    observed0 = depth_images[best_cam, py0, px0]
+                    if observed0 > 0.0 and z0 > observed0 + occlusion_tolerance_m:
+                        all_valid = False
+                    else:
+                        uv0 = wp.vec2(
+                            (atlas_x_offset + u0) / atlas_width,
+                            vv0 / wp.float32(IMAGE_HEIGHT),
+                        )
+                else:
+                    all_valid = False
+            else:
+                all_valid = False
+
+            p1_cam = wp.quat_rotate(cam_quat_inv, v1 - cam_pos)
+            z1 = p1_cam[2]
+            if all_valid and z1 > depth_min and z1 <= depth_max:
+                u1 = fx * p1_cam[0] / z1 + cx
+                vv1 = fy * p1_cam[1] / z1 + cy
+                if (
+                    u1 >= 0.0
+                    and u1 < wp.float32(IMAGE_WIDTH)
+                    and vv1 >= 0.0
+                    and vv1 < wp.float32(IMAGE_HEIGHT)
+                ):
+                    px1 = wp.int32(u1 + 0.5)
+                    py1 = wp.int32(vv1 + 0.5)
+                    if px1 >= IMAGE_WIDTH:
+                        px1 = IMAGE_WIDTH - wp.int32(1)
+                    if py1 >= IMAGE_HEIGHT:
+                        py1 = IMAGE_HEIGHT - wp.int32(1)
+                    observed1 = depth_images[best_cam, py1, px1]
+                    if observed1 > 0.0 and z1 > observed1 + occlusion_tolerance_m:
+                        all_valid = False
+                    else:
+                        uv1 = wp.vec2(
+                            (atlas_x_offset + u1) / atlas_width,
+                            vv1 / wp.float32(IMAGE_HEIGHT),
+                        )
+                else:
+                    all_valid = False
+            else:
+                all_valid = False
+
+            p2_cam = wp.quat_rotate(cam_quat_inv, v2 - cam_pos)
+            z2 = p2_cam[2]
+            if all_valid and z2 > depth_min and z2 <= depth_max:
+                u2 = fx * p2_cam[0] / z2 + cx
+                vv2 = fy * p2_cam[1] / z2 + cy
+                if (
+                    u2 >= 0.0
+                    and u2 < wp.float32(IMAGE_WIDTH)
+                    and vv2 >= 0.0
+                    and vv2 < wp.float32(IMAGE_HEIGHT)
+                ):
+                    px2 = wp.int32(u2 + 0.5)
+                    py2 = wp.int32(vv2 + 0.5)
+                    if px2 >= IMAGE_WIDTH:
+                        px2 = IMAGE_WIDTH - wp.int32(1)
+                    if py2 >= IMAGE_HEIGHT:
+                        py2 = IMAGE_HEIGHT - wp.int32(1)
+                    observed2 = depth_images[best_cam, py2, px2]
+                    if observed2 > 0.0 and z2 > observed2 + occlusion_tolerance_m:
+                        all_valid = False
+                    else:
+                        uv2 = wp.vec2(
+                            (atlas_x_offset + u2) / atlas_width,
+                            vv2 / wp.float32(IMAGE_HEIGHT),
+                        )
+                else:
+                    all_valid = False
+            else:
+                all_valid = False
+
+            if all_valid:
+                vertex_uvs[base] = uv0
+                vertex_uvs[base + wp.int32(1)] = uv1
+                vertex_uvs[base + wp.int32(2)] = uv2
+                projected = True
+                break
+
+            score_limit = best_score - wp.float32(1.0e-6)
+
+        if not projected:
+            vertex_uvs[base] = invalid_uv
+            vertex_uvs[base + wp.int32(1)] = invalid_uv
+            vertex_uvs[base + wp.int32(2)] = invalid_uv
+            if fill_missing_colors != wp.int32(0):
+                c0 = sample_rgb(tsdf, v0)
+                c1 = sample_rgb(tsdf, v1)
+                c2 = sample_rgb(tsdf, v2)
+                colors[base] = wp.vec3ub(wp.uint8(c0[0]), wp.uint8(c0[1]), wp.uint8(c0[2]))
+                colors[base + wp.int32(1)] = wp.vec3ub(
+                    wp.uint8(c1[0]), wp.uint8(c1[1]), wp.uint8(c1[2])
+                )
+                colors[base + wp.int32(2)] = wp.vec3ub(
+                    wp.uint8(c2[0]), wp.uint8(c2[1]), wp.uint8(c2[2])
+                )
+
     # =====================================================================
     # Color sampling
     # =====================================================================
@@ -784,16 +3119,35 @@ def make_mesh_kernels(
             colors[tid] = wp.vec3ub(wp.uint8(128), wp.uint8(128), wp.uint8(128))
             return
 
-        rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, pool_idx)
-        colors[tid] = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
+        if USE_COLOR_GRID:
+            rgb_grid = sample_rgb(tsdf, pos)
+            colors[tid] = wp.vec3ub(
+                wp.uint8(rgb_grid[0]), wp.uint8(rgb_grid[1]), wp.uint8(rgb_grid[2])
+            )
+        else:
+            rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, pool_idx)
+            colors[tid] = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
 
     # Expose kernels on the instance.
     return {
         "count_surface_cubes_kernel": count_surface_cubes_kernel,
+        "append_active_blocks_kernel": append_active_blocks_kernel,
+        "count_surface_cubes_from_blocks_kernel": count_surface_cubes_from_blocks_kernel,
         "append_surface_cubes_kernel": append_surface_cubes_kernel,
+        "append_surface_cubes_from_blocks_kernel": append_surface_cubes_from_blocks_kernel,
         "count_edges_block_sparse_kernel": count_edges_block_sparse_kernel,
         "generate_vertices_block_sparse_kernel": generate_vertices_block_sparse_kernel,
         "generate_triangles_shared_kernel": generate_triangles_shared_kernel,
         "count_triangles_kernel": count_triangles_kernel,
+        "count_total_triangles_kernel": count_total_triangles_kernel,
+        "generate_approximate_mesh_block_sparse_kernel": generate_approximate_mesh_block_sparse_kernel,
+        "generate_approximate_mesh_atomic_kernel": generate_approximate_mesh_atomic_kernel,
+        "generate_approximate_mesh_current_state_kernel": (
+            generate_approximate_mesh_current_state_kernel
+        ),
+        "count_fast_mesh_block_triangles_kernel": count_fast_mesh_block_triangles_kernel,
+        "generate_fast_mesh_current_state_kernel": generate_fast_mesh_current_state_kernel,
+        "copy_rgb_images_to_texture_atlas_kernel": copy_rgb_images_to_texture_atlas_kernel,
+        "project_fast_mesh_uvs_kernel": project_fast_mesh_uvs_kernel,
         "sample_vertex_colors_kernel": sample_vertex_colors_kernel,
     }

--- a/curobo/_src/perception/mapper/kernel/builder/builder_mesh.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_mesh.py
@@ -7,10 +7,10 @@
 Moved from :mod:`curobo._src.perception.mapper.mesh_extractor` in the
 block-size builder refactor.
 
-All 7 kernels and 5 ``@wp.func`` helpers are BS-sensitive: cube and
-edge indexing uses ``BS``-based packing (``local_idx = lz*BS^2 +
-ly*BS + lx``), and block-boundary crossing logic tests against ``BS``
-directly. Every kernel closure-captures ``BS = wp.constant(block_size)``.
+The kernels and ``@wp.func`` helpers are BS-sensitive: cube indexing uses
+``BS``-based packing (``local_idx = lz*BS^2 + ly*BS + lx``), and
+block-boundary crossing logic tests against ``BS`` directly. Every kernel
+closure-captures ``BS = wp.constant(block_size)``.
 """
 
 from __future__ import annotations
@@ -19,10 +19,7 @@ import warp as wp
 
 from curobo._src.perception.mapper.kernel.warp_types import BlockSparseTSDFWarp
 from curobo._src.perception.mapper.marching_cubes.kernel.wp_mc_common import (
-    binary_search_int64,
     get_edge_vertex,
-    interpolate_edge_vertex,
-    local_edge_to_array_idx,
 )
 from curobo._src.util.warp import warp_func, warp_kernel
 
@@ -44,7 +41,6 @@ def make_mesh_kernels(
 ) -> dict[str, object]:
     """Build block-sparse marching-cubes kernels."""
     BS = wp.constant(block_size)
-    NUM_CAMERAS = wp.constant(num_cameras)
     IMAGE_HEIGHT = wp.constant(image_height)
     IMAGE_WIDTH = wp.constant(image_width)
 
@@ -236,102 +232,8 @@ def make_mesh_kernels(
         return True
 
     # =====================================================================
-    # Edge ownership
-    # =====================================================================
-
-    @warp_func(f"get_edge_owner_combined_bs{block_size}")
-    def get_edge_owner_combined(
-        edge: wp.int32,
-        block_idx: wp.int32,
-        cx: wp.int32,
-        cy: wp.int32,
-        cz: wp.int32,
-        bx: wp.int32,
-        by: wp.int32,
-        bz: wp.int32,
-        tsdf: BlockSparseTSDFWarp,
-        edge_owner: wp.array(dtype=wp.int32),
-    ) -> wp.vec3i:
-        """Find which cube owns an edge, handling block boundaries."""
-        owner_dx = edge_owner[edge * 4 + 2]
-        owner_dy = edge_owner[edge * 4 + 1]
-        owner_dz = edge_owner[edge * 4 + 0]
-        local_edge = edge_owner[edge * 4 + 3]
-
-        new_cx = cx + owner_dx
-        new_cy = cy + owner_dy
-        new_cz = cz + owner_dz
-
-        if new_cx < BS and new_cy < BS and new_cz < BS:
-            owner_cube = new_cz * BS * BS + new_cy * BS + new_cx
-            return wp.vec3i(block_idx, owner_cube, local_edge)
-
-        new_bx = bx
-        new_by = by
-        new_bz = bz
-
-        if new_cx >= BS:
-            new_bx = bx + 1
-            new_cx = 0
-        if new_cy >= BS:
-            new_by = by + 1
-            new_cy = 0
-        if new_cz >= BS:
-            new_bz = bz + 1
-            new_cz = 0
-
-        neighbor_idx = hash_lookup(tsdf.hash_table, new_bx, new_by, new_bz, tsdf.hash_capacity)
-        if neighbor_idx < 0:
-            return wp.vec3i(-1, -1, local_edge)
-
-        owner_cube = new_cz * BS * BS + new_cy * BS + new_cx
-        return wp.vec3i(neighbor_idx, owner_cube, local_edge)
-
-    # =====================================================================
     # Surface detection kernels
     # =====================================================================
-
-    @warp_kernel(f"count_surface_cubes_kernel_bs{block_size}", enable_backward=False)
-    def count_surface_cubes_kernel(
-        tsdf: BlockSparseTSDFWarp,
-        level: float,
-        surface_band: float,
-        minimum_tsdf_weight: float,
-        surface_count: wp.array(dtype=wp.int32),
-    ):
-        """Count cubes that contain a surface (pass 1).
-
-        Launch with ``dim = (num_allocated, BS ** 3)``.
-        """
-        block_idx, cube_idx = wp.tid()
-
-        if block_idx >= tsdf.num_allocated[0]:
-            return
-        if tsdf.block_to_hash_slot[block_idx] < 0:
-            return
-
-        cx = cube_idx % BS
-        cy = (cube_idx // BS) % BS
-        cz = cube_idx // (BS * BS)
-
-        bx = tsdf.block_coords[block_idx * 3 + 0]
-        by = tsdf.block_coords[block_idx * 3 + 1]
-        bz = tsdf.block_coords[block_idx * 3 + 2]
-
-        if is_surface_cube_combined(
-            cx,
-            cy,
-            cz,
-            bx,
-            by,
-            bz,
-            block_idx,
-            tsdf,
-            level,
-            surface_band,
-            minimum_tsdf_weight,
-        ):
-            wp.atomic_add(surface_count, 0, wp.int32(1))
 
     @warp_kernel(f"append_active_blocks_kernel_bs{block_size}", enable_backward=False)
     def append_active_blocks_kernel(
@@ -397,49 +299,6 @@ def make_mesh_kernels(
         ):
             wp.atomic_add(surface_count, 0, wp.int32(1))
 
-    @warp_kernel(f"append_surface_cubes_kernel_bs{block_size}", enable_backward=False)
-    def append_surface_cubes_kernel(
-        tsdf: BlockSparseTSDFWarp,
-        level: float,
-        surface_band: float,
-        minimum_tsdf_weight: float,
-        surface_count: wp.array(dtype=wp.int32),
-        surface_block_idx: wp.array(dtype=wp.int32),
-        surface_cube_idx: wp.array(dtype=wp.int32),
-    ):
-        """Append surface cubes to output arrays (pass 2)."""
-        block_idx, cube_idx = wp.tid()
-
-        if block_idx >= tsdf.num_allocated[0]:
-            return
-        if tsdf.block_to_hash_slot[block_idx] < 0:
-            return
-
-        cx = cube_idx % BS
-        cy = (cube_idx // BS) % BS
-        cz = cube_idx // (BS * BS)
-
-        bx = tsdf.block_coords[block_idx * 3 + 0]
-        by = tsdf.block_coords[block_idx * 3 + 1]
-        bz = tsdf.block_coords[block_idx * 3 + 2]
-
-        if is_surface_cube_combined(
-            cx,
-            cy,
-            cz,
-            bx,
-            by,
-            bz,
-            block_idx,
-            tsdf,
-            level,
-            surface_band,
-            minimum_tsdf_weight,
-        ):
-            out_idx = wp.atomic_add(surface_count, 0, wp.int32(1))
-            surface_block_idx[out_idx] = block_idx
-            surface_cube_idx[out_idx] = cube_idx
-
     @warp_kernel(
         f"append_surface_cubes_from_blocks_kernel_bs{block_size}", enable_backward=False
     )
@@ -491,383 +350,6 @@ def make_mesh_kernels(
             surface_block_idx[out_idx] = block_idx
             surface_cube_idx[out_idx] = cube_idx
 
-    # =====================================================================
-    # Edge counting + vertex generation
-    # =====================================================================
-
-    @warp_kernel(f"count_edges_block_sparse_kernel_bs{block_size}", enable_backward=False)
-    def count_edges_block_sparse_kernel(
-        tsdf: BlockSparseTSDFWarp,
-        level: float,
-        minimum_tsdf_weight: float,
-        surface_block_idx: wp.array(dtype=wp.int32),
-        surface_cube_idx: wp.array(dtype=wp.int32),
-        n_surfaces: wp.int32,
-        edge_counts: wp.array(dtype=wp.int32),
-    ):
-        """Count owned edges (0, 3, 8) for each surface cube."""
-        tid = wp.tid()
-        if tid >= n_surfaces:
-            return
-
-        block_idx = surface_block_idx[tid]
-        cube_idx = surface_cube_idx[tid]
-
-        cx = cube_idx % BS
-        cy = (cube_idx // BS) % BS
-        cz = cube_idx // (BS * BS)
-
-        bx = tsdf.block_coords[block_idx * 3 + 0]
-        by = tsdf.block_coords[block_idx * 3 + 1]
-        bz = tsdf.block_coords[block_idx * 3 + 2]
-
-        s0 = sample_cube_corner(
-            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s1 = sample_cube_corner(
-            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s3 = sample_cube_corner(
-            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s4 = sample_cube_corner(
-            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-
-        count = wp.int32(0)
-        if s0[0] * s1[0] < 0.0:
-            count += wp.int32(1)
-        if s0[0] * s3[0] < 0.0:
-            count += wp.int32(1)
-        if s0[0] * s4[0] < 0.0:
-            count += wp.int32(1)
-
-        edge_counts[tid] = count
-
-    @warp_kernel(f"generate_vertices_block_sparse_kernel_bs{block_size}", enable_backward=False)
-    def generate_vertices_block_sparse_kernel(
-        tsdf: BlockSparseTSDFWarp,
-        level: float,
-        minimum_tsdf_weight: float,
-        surface_block_idx: wp.array(dtype=wp.int32),
-        surface_cube_idx: wp.array(dtype=wp.int32),
-        edge_offsets: wp.array(dtype=wp.int32),
-        n_surfaces: wp.int32,
-        refine_iterations: wp.int32,
-        vertices: wp.array(dtype=wp.vec3),
-        normals: wp.array(dtype=wp.vec3),
-        edge_vertex_indices: wp.array(dtype=wp.int32),
-    ):
-        """Generate vertices + normals for owned edges."""
-        tid = wp.tid()
-        if tid >= n_surfaces:
-            return
-
-        block_idx = surface_block_idx[tid]
-        cube_idx = surface_cube_idx[tid]
-
-        cx = cube_idx % BS
-        cy = (cube_idx // BS) % BS
-        cz = cube_idx // (BS * BS)
-
-        bx = tsdf.block_coords[block_idx * 3 + 0]
-        by = tsdf.block_coords[block_idx * 3 + 1]
-        bz = tsdf.block_coords[block_idx * 3 + 2]
-
-        s0 = sample_cube_corner(
-            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s1 = sample_cube_corner(
-            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s3 = sample_cube_corner(
-            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s4 = sample_cube_corner(
-            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-
-        base = block_key_to_voxel_base(bx, by, bz)
-        gx = base[0] + cx
-        gy = base[1] + cy
-        gz = base[2] + cz
-
-        center_offset_x = wp.float32(tsdf.grid_W) * 0.5
-        center_offset_y = wp.float32(tsdf.grid_H) * 0.5
-        center_offset_z = wp.float32(tsdf.grid_D) * 0.5
-
-        p0 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p1 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p3 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p4 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-
-        vertex_idx = edge_offsets[tid]
-
-        edge_vertex_indices[tid * 3 + 0] = wp.int32(-1)
-        edge_vertex_indices[tid * 3 + 1] = wp.int32(-1)
-        edge_vertex_indices[tid * 3 + 2] = wp.int32(-1)
-
-        if s0[0] * s1[0] < 0.0:
-            v = interpolate_edge_vertex(p0, p1, s0[0], s1[0])
-            if refine_iterations > 0:
-                v = refine_vertex_mesh(tsdf, v, level, refine_iterations, minimum_tsdf_weight)
-            n = compute_gradient_nearest(tsdf, v, minimum_tsdf_weight)
-            vertices[vertex_idx] = v
-            normals[vertex_idx] = wp.normalize(n)
-            edge_vertex_indices[tid * 3 + 0] = vertex_idx
-            vertex_idx += wp.int32(1)
-
-        if s0[0] * s3[0] < 0.0:
-            v = interpolate_edge_vertex(p0, p3, s0[0], s3[0])
-            if refine_iterations > 0:
-                v = refine_vertex_mesh(tsdf, v, level, refine_iterations, minimum_tsdf_weight)
-            n = compute_gradient_nearest(tsdf, v, minimum_tsdf_weight)
-            vertices[vertex_idx] = v
-            normals[vertex_idx] = wp.normalize(n)
-            edge_vertex_indices[tid * 3 + 1] = vertex_idx
-            vertex_idx += wp.int32(1)
-
-        if s0[0] * s4[0] < 0.0:
-            v = interpolate_edge_vertex(p0, p4, s0[0], s4[0])
-            if refine_iterations > 0:
-                v = refine_vertex_mesh(tsdf, v, level, refine_iterations, minimum_tsdf_weight)
-            n = compute_gradient_nearest(tsdf, v, minimum_tsdf_weight)
-            vertices[vertex_idx] = v
-            normals[vertex_idx] = wp.normalize(n)
-            edge_vertex_indices[tid * 3 + 2] = vertex_idx
-
-    # =====================================================================
-    # Triangle generation / counting
-    # =====================================================================
-
-    @warp_kernel(f"generate_triangles_shared_kernel_bs{block_size}")
-    def generate_triangles_shared_kernel(
-        tsdf: BlockSparseTSDFWarp,
-        level: float,
-        minimum_tsdf_weight: float,
-        surface_block_idx: wp.array(dtype=wp.int32),
-        surface_cube_idx: wp.array(dtype=wp.int32),
-        tri_offsets: wp.array(dtype=wp.int32),
-        n_surfaces: wp.int32,
-        tri_table: wp.array(dtype=wp.int32),
-        edge_owner: wp.array(dtype=wp.int32),
-        sorted_global_ids: wp.array(dtype=wp.int64),
-        sparse_indices_sorted: wp.array(dtype=wp.int32),
-        edge_vertex_indices: wp.array(dtype=wp.int32),
-        triangles: wp.array(dtype=wp.int32),
-    ):
-        """Generate triangles with shared vertex lookup."""
-        tid = wp.tid()
-        if tid >= n_surfaces:
-            return
-
-        block_idx = surface_block_idx[tid]
-        cube_idx = surface_cube_idx[tid]
-
-        cx = cube_idx % BS
-        cy = (cube_idx // BS) % BS
-        cz = cube_idx // (BS * BS)
-
-        bx = tsdf.block_coords[block_idx * 3 + 0]
-        by = tsdf.block_coords[block_idx * 3 + 1]
-        bz = tsdf.block_coords[block_idx * 3 + 2]
-
-        s0 = sample_cube_corner(
-            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s1 = sample_cube_corner(
-            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s2 = sample_cube_corner(
-            cx + 1, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s3 = sample_cube_corner(
-            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s4 = sample_cube_corner(
-            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s5 = sample_cube_corner(
-            cx + 1, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s6 = sample_cube_corner(
-            cx + 1, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s7 = sample_cube_corner(
-            cx, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-
-        cube_config = wp.int32(0)
-        if s0[0] < 0.0:
-            cube_config = cube_config | wp.int32(1)
-        if s1[0] < 0.0:
-            cube_config = cube_config | wp.int32(2)
-        if s2[0] < 0.0:
-            cube_config = cube_config | wp.int32(4)
-        if s3[0] < 0.0:
-            cube_config = cube_config | wp.int32(8)
-        if s4[0] < 0.0:
-            cube_config = cube_config | wp.int32(16)
-        if s5[0] < 0.0:
-            cube_config = cube_config | wp.int32(32)
-        if s6[0] < 0.0:
-            cube_config = cube_config | wp.int32(64)
-        if s7[0] < 0.0:
-            cube_config = cube_config | wp.int32(128)
-
-        tri_base = tri_offsets[tid]
-        table_offset = cube_config * 16
-
-        for t in range(5):
-            e0 = tri_table[table_offset + t * 3]
-            if e0 < 0:
-                break
-
-            e1 = tri_table[table_offset + t * 3 + 1]
-            e2 = tri_table[table_offset + t * 3 + 2]
-
-            for v_idx in range(3):
-                edge = e0
-                if v_idx == 1:
-                    edge = e1
-                elif v_idx == 2:
-                    edge = e2
-
-                owner = get_edge_owner_combined(
-                    edge,
-                    block_idx,
-                    cx,
-                    cy,
-                    cz,
-                    bx,
-                    by,
-                    bz,
-                    tsdf,
-                    edge_owner,
-                )
-
-                vertex_id = wp.int32(-1)
-
-                if owner[0] >= 0:
-                    owner_global_id = wp.int64(owner[0]) * wp.int64(BS * BS * BS) + wp.int64(
-                        owner[1]
-                    )
-                    search_idx = binary_search_int64(
-                        sorted_global_ids,
-                        n_surfaces,
-                        owner_global_id,
-                    )
-                    if search_idx >= 0:
-                        owner_sparse = sparse_indices_sorted[search_idx]
-                        edge_array_idx = local_edge_to_array_idx(owner[2])
-                        vertex_id = edge_vertex_indices[owner_sparse * 3 + edge_array_idx]
-
-                triangles[(tri_base + t) * 3 + v_idx] = vertex_id
-
-    @warp_kernel(f"count_triangles_kernel_bs{block_size}", enable_backward=False)
-    def count_triangles_kernel(
-        tsdf: BlockSparseTSDFWarp,
-        level: float,
-        minimum_tsdf_weight: float,
-        surface_block_idx: wp.array(dtype=wp.int32),
-        surface_cube_idx: wp.array(dtype=wp.int32),
-        n_surfaces: wp.int32,
-        num_tris_table: wp.array(dtype=wp.int32),
-        tri_counts: wp.array(dtype=wp.int32),
-    ):
-        """Count triangles for each surface cube (combined SDF)."""
-        tid = wp.tid()
-        if tid >= n_surfaces:
-            return
-
-        block_idx = surface_block_idx[tid]
-        cube_idx = surface_cube_idx[tid]
-
-        cx = cube_idx % BS
-        cy = (cube_idx // BS) % BS
-        cz = cube_idx // (BS * BS)
-
-        bx = tsdf.block_coords[block_idx * 3 + 0]
-        by = tsdf.block_coords[block_idx * 3 + 1]
-        bz = tsdf.block_coords[block_idx * 3 + 2]
-
-        s0 = sample_cube_corner(
-            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s1 = sample_cube_corner(
-            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s2 = sample_cube_corner(
-            cx + 1, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s3 = sample_cube_corner(
-            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s4 = sample_cube_corner(
-            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s5 = sample_cube_corner(
-            cx + 1, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s6 = sample_cube_corner(
-            cx + 1, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s7 = sample_cube_corner(
-            cx, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-
-        cube_config = wp.int32(0)
-        if s0[0] < 0.0:
-            cube_config = cube_config | wp.int32(1)
-        if s1[0] < 0.0:
-            cube_config = cube_config | wp.int32(2)
-        if s2[0] < 0.0:
-            cube_config = cube_config | wp.int32(4)
-        if s3[0] < 0.0:
-            cube_config = cube_config | wp.int32(8)
-        if s4[0] < 0.0:
-            cube_config = cube_config | wp.int32(16)
-        if s5[0] < 0.0:
-            cube_config = cube_config | wp.int32(32)
-        if s6[0] < 0.0:
-            cube_config = cube_config | wp.int32(64)
-        if s7[0] < 0.0:
-            cube_config = cube_config | wp.int32(128)
-
-        tri_counts[tid] = num_tris_table[cube_config]
-
     @warp_kernel(f"count_total_triangles_kernel_bs{block_size}", enable_backward=False)
     def count_total_triangles_kernel(
         tsdf: BlockSparseTSDFWarp,
@@ -879,7 +361,7 @@ def make_mesh_kernels(
         num_tris_table: wp.array(dtype=wp.int32),
         triangle_count: wp.array(dtype=wp.int32),
     ):
-        """Count approximate mesh triangles with one device-side total."""
+        """Count triangle-soup mesh triangles with one device-side total."""
         tid = wp.tid()
         if tid >= n_surfaces:
             return
@@ -940,227 +422,23 @@ def make_mesh_kernels(
 
         wp.atomic_add(triangle_count, 0, num_tris_table[cube_config])
 
-    @warp_kernel(f"generate_approximate_mesh_block_sparse_kernel_bs{block_size}")
-    def generate_approximate_mesh_block_sparse_kernel(
+    @warp_kernel(f"generate_mesh_kernel_bs{block_size}")
+    def generate_mesh_kernel(
         tsdf: BlockSparseTSDFWarp,
         level: float,
         minimum_tsdf_weight: float,
-        surface_block_idx: wp.array(dtype=wp.int32),
-        surface_cube_idx: wp.array(dtype=wp.int32),
-        tri_offsets: wp.array(dtype=wp.int32),
-        n_surfaces: wp.int32,
-        tri_table: wp.array(dtype=wp.int32),
-        vertices: wp.array(dtype=wp.vec3),
-        triangles: wp.array(dtype=wp.int32),
-        normals: wp.array(dtype=wp.vec3),
-        colors: wp.array(dtype=wp.vec3ub),
-    ):
-        """Generate a triangle-soup mesh without shared vertex ownership."""
-        tid = wp.tid()
-        if tid >= n_surfaces:
-            return
-
-        block_idx = surface_block_idx[tid]
-        cube_idx = surface_cube_idx[tid]
-
-        cx = cube_idx % BS
-        cy = (cube_idx // BS) % BS
-        cz = cube_idx // (BS * BS)
-
-        bx = tsdf.block_coords[block_idx * 3 + 0]
-        by = tsdf.block_coords[block_idx * 3 + 1]
-        bz = tsdf.block_coords[block_idx * 3 + 2]
-
-        s0 = sample_cube_corner(
-            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s1 = sample_cube_corner(
-            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s2 = sample_cube_corner(
-            cx + 1, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s3 = sample_cube_corner(
-            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s4 = sample_cube_corner(
-            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s5 = sample_cube_corner(
-            cx + 1, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s6 = sample_cube_corner(
-            cx + 1, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s7 = sample_cube_corner(
-            cx, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-
-        cube_config = wp.int32(0)
-        if s0[0] < 0.0:
-            cube_config = cube_config | wp.int32(1)
-        if s1[0] < 0.0:
-            cube_config = cube_config | wp.int32(2)
-        if s2[0] < 0.0:
-            cube_config = cube_config | wp.int32(4)
-        if s3[0] < 0.0:
-            cube_config = cube_config | wp.int32(8)
-        if s4[0] < 0.0:
-            cube_config = cube_config | wp.int32(16)
-        if s5[0] < 0.0:
-            cube_config = cube_config | wp.int32(32)
-        if s6[0] < 0.0:
-            cube_config = cube_config | wp.int32(64)
-        if s7[0] < 0.0:
-            cube_config = cube_config | wp.int32(128)
-
-        base = block_key_to_voxel_base(bx, by, bz)
-        gx = base[0] + cx
-        gy = base[1] + cy
-        gz = base[2] + cz
-
-        center_offset_x = wp.float32(tsdf.grid_W) * 0.5
-        center_offset_y = wp.float32(tsdf.grid_H) * 0.5
-        center_offset_z = wp.float32(tsdf.grid_D) * 0.5
-
-        p0 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p1 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p2 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p3 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p4 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p5 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p6 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p7 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-
-        rgb = sample_rgb(tsdf, (p0 + p6) * wp.float32(0.5))
-        color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
-
-        tri_base = tri_offsets[tid]
-        table_offset = cube_config * 16
-
-        for t in range(5):
-            e0 = tri_table[table_offset + t * 3]
-            if e0 < 0:
-                break
-
-            e1 = tri_table[table_offset + t * 3 + 1]
-            e2 = tri_table[table_offset + t * 3 + 2]
-
-            out_base = (tri_base + t) * 3
-            for v_idx in range(3):
-                edge = e0
-                if v_idx == 1:
-                    edge = e1
-                elif v_idx == 2:
-                    edge = e2
-
-                vertex_id = out_base + v_idx
-                v = get_edge_vertex(
-                    edge,
-                    p0,
-                    p1,
-                    p2,
-                    p3,
-                    p4,
-                    p5,
-                    p6,
-                    p7,
-                    s0[0],
-                    s1[0],
-                    s2[0],
-                    s3[0],
-                    s4[0],
-                    s5[0],
-                    s6[0],
-                    s7[0],
-                )
-                n = compute_gradient_nearest(tsdf, v, minimum_tsdf_weight)
-                vertices[vertex_id] = v
-                normals[vertex_id] = wp.normalize(n)
-                colors[vertex_id] = color
-                triangles[vertex_id] = vertex_id
-
-    @warp_kernel(f"generate_approximate_mesh_atomic_kernel_bs{block_size}")
-    def generate_approximate_mesh_atomic_kernel(
-        tsdf: BlockSparseTSDFWarp,
-        level: float,
-        minimum_tsdf_weight: float,
+        refine_iterations: wp.int32,
         surface_block_idx: wp.array(dtype=wp.int32),
         surface_cube_idx: wp.array(dtype=wp.int32),
         n_surfaces: wp.int32,
         tri_table: wp.array(dtype=wp.int32),
         vertices: wp.array(dtype=wp.vec3),
-        triangles: wp.array(dtype=wp.int32),
         normals: wp.array(dtype=wp.vec3),
         colors: wp.array(dtype=wp.vec3ub),
         triangle_count: wp.array(dtype=wp.int32),
         triangle_capacity: wp.int32,
     ):
-        """Generate approximate triangle soup with atomic output allocation."""
+        """Generate a triangle-soup mesh with atomic output allocation."""
         tid = wp.tid()
         if tid >= n_surfaces:
             return
@@ -1322,9 +600,9 @@ def make_mesh_kernels(
             for v_idx in range(3):
                 edge = e0
                 if v_idx == 1:
-                    edge = e1
-                elif v_idx == 2:
                     edge = e2
+                elif v_idx == 2:
+                    edge = e1
 
                 vertex_id = out_base + v_idx
                 v = get_edge_vertex(
@@ -1346,1526 +624,63 @@ def make_mesh_kernels(
                     s6[0],
                     s7[0],
                 )
+                if refine_iterations > 0:
+                    v = refine_vertex_mesh(
+                        tsdf, v, level, refine_iterations, minimum_tsdf_weight
+                    )
                 n = compute_gradient_nearest(tsdf, v, minimum_tsdf_weight)
                 vertices[vertex_id] = v
                 normals[vertex_id] = wp.normalize(n)
                 colors[vertex_id] = color
-                triangles[vertex_id] = vertex_id
-
-    @warp_kernel(f"generate_approximate_mesh_current_state_kernel_bs{block_size}")
-    def generate_approximate_mesh_current_state_kernel(
-        tsdf: BlockSparseTSDFWarp,
-        level: float,
-        surface_band: float,
-        minimum_tsdf_weight: float,
-        n_blocks: wp.int32,
-        tri_table: wp.array(dtype=wp.int32),
-        vertices: wp.array(dtype=wp.vec3),
-        triangles: wp.array(dtype=wp.int32),
-        normals: wp.array(dtype=wp.vec3),
-        colors: wp.array(dtype=wp.vec3ub),
-        mesh_counts: wp.array(dtype=wp.int32),
-        output_flags: wp.int32,
-        triangle_capacity: wp.int32,
-    ):
-        """Generate approximate mesh directly from current active TSDF blocks.
-
-        ``mesh_counts`` layout:
-          0 required vertices, 1 required triangles, 2 written vertices,
-          3 written triangles, 4 surface cubes, 5 overflow triangles.
-        """
-        block_idx, cube_idx = wp.tid()
-
-        if block_idx >= n_blocks:
-            return
-        if block_idx >= tsdf.num_allocated[0]:
-            return
-        if tsdf.block_to_hash_slot[block_idx] < 0:
-            return
-
-        if BS == wp.int32(1) and (
-            (output_flags & wp.int32(4)) == wp.int32(0)
-            or (output_flags & wp.int32(16)) != wp.int32(0)
-        ):
-            bx1 = tsdf.block_coords[block_idx * 3 + 0]
-            by1 = tsdf.block_coords[block_idx * 3 + 1]
-            bz1 = tsdf.block_coords[block_idx * 3 + 2]
-
-            n100_idx = hash_lookup(tsdf.hash_table, bx1 + 1, by1, bz1, tsdf.hash_capacity)
-            n010_idx = hash_lookup(tsdf.hash_table, bx1, by1 + 1, bz1, tsdf.hash_capacity)
-            n110_idx = hash_lookup(
-                tsdf.hash_table, bx1 + 1, by1 + 1, bz1, tsdf.hash_capacity
-            )
-            n001_idx = hash_lookup(tsdf.hash_table, bx1, by1, bz1 + 1, tsdf.hash_capacity)
-            n101_idx = hash_lookup(
-                tsdf.hash_table, bx1 + 1, by1, bz1 + 1, tsdf.hash_capacity
-            )
-            n011_idx = hash_lookup(
-                tsdf.hash_table, bx1, by1 + 1, bz1 + 1, tsdf.hash_capacity
-            )
-            n111_idx = hash_lookup(
-                tsdf.hash_table, bx1 + 1, by1 + 1, bz1 + 1, tsdf.hash_capacity
-            )
-            if (
-                n100_idx < 0
-                or n010_idx < 0
-                or n110_idx < 0
-                or n001_idx < 0
-                or n101_idx < 0
-                or n011_idx < 0
-                or n111_idx < 0
-            ):
-                return
-
-            s0b = sample_voxel(tsdf, block_idx, wp.int32(0), minimum_tsdf_weight)
-            s1b = sample_voxel(tsdf, n100_idx, wp.int32(0), minimum_tsdf_weight)
-            s2b = sample_voxel(tsdf, n110_idx, wp.int32(0), minimum_tsdf_weight)
-            s3b = sample_voxel(tsdf, n010_idx, wp.int32(0), minimum_tsdf_weight)
-            s4b = sample_voxel(tsdf, n001_idx, wp.int32(0), minimum_tsdf_weight)
-            s5b = sample_voxel(tsdf, n101_idx, wp.int32(0), minimum_tsdf_weight)
-            s6b = sample_voxel(tsdf, n111_idx, wp.int32(0), minimum_tsdf_weight)
-            s7b = sample_voxel(tsdf, n011_idx, wp.int32(0), minimum_tsdf_weight)
-            if s0b[1] < 0.5 or s1b[1] < 0.5 or s2b[1] < 0.5 or s3b[1] < 0.5:
-                return
-            if s4b[1] < 0.5 or s5b[1] < 0.5 or s6b[1] < 0.5 or s7b[1] < 0.5:
-                return
-
-            d0 = s0b[0] - level
-            d1 = s1b[0] - level
-            d2 = s2b[0] - level
-            d3 = s3b[0] - level
-            d4 = s4b[0] - level
-            d5 = s5b[0] - level
-            d6 = s6b[0] - level
-            d7 = s7b[0] - level
-
-            has_positive_bs1 = (
-                d0 > 0.0
-                or d1 > 0.0
-                or d2 > 0.0
-                or d3 > 0.0
-                or d4 > 0.0
-                or d5 > 0.0
-                or d6 > 0.0
-                or d7 > 0.0
-            )
-            has_negative_bs1 = (
-                d0 < 0.0
-                or d1 < 0.0
-                or d2 < 0.0
-                or d3 < 0.0
-                or d4 < 0.0
-                or d5 < 0.0
-                or d6 < 0.0
-                or d7 < 0.0
-            )
-            if not (has_positive_bs1 and has_negative_bs1):
-                return
-
-            if surface_band > 0.0:
-                in_band_bs1 = (
-                    wp.abs(d0) < surface_band
-                    or wp.abs(d1) < surface_band
-                    or wp.abs(d2) < surface_band
-                    or wp.abs(d3) < surface_band
-                    or wp.abs(d4) < surface_band
-                    or wp.abs(d5) < surface_band
-                    or wp.abs(d6) < surface_band
-                    or wp.abs(d7) < surface_band
-                )
-                if not in_band_bs1:
-                    return
-
-            wp.atomic_add(mesh_counts, 4, wp.int32(1))
-
-            cube_config_bs1 = wp.int32(0)
-            if d0 < 0.0:
-                cube_config_bs1 = cube_config_bs1 | wp.int32(1)
-            if d1 < 0.0:
-                cube_config_bs1 = cube_config_bs1 | wp.int32(2)
-            if d2 < 0.0:
-                cube_config_bs1 = cube_config_bs1 | wp.int32(4)
-            if d3 < 0.0:
-                cube_config_bs1 = cube_config_bs1 | wp.int32(8)
-            if d4 < 0.0:
-                cube_config_bs1 = cube_config_bs1 | wp.int32(16)
-            if d5 < 0.0:
-                cube_config_bs1 = cube_config_bs1 | wp.int32(32)
-            if d6 < 0.0:
-                cube_config_bs1 = cube_config_bs1 | wp.int32(64)
-            if d7 < 0.0:
-                cube_config_bs1 = cube_config_bs1 | wp.int32(128)
-
-            table_offset_bs1 = cube_config_bs1 * 16
-            num_tris_bs1 = wp.int32(0)
-            for t in range(5):
-                e = tri_table[table_offset_bs1 + t * 3]
-                if e < 0:
-                    break
-                num_tris_bs1 = num_tris_bs1 + wp.int32(1)
-
-            if num_tris_bs1 <= wp.int32(0):
-                return
-
-            tri_base_bs1 = wp.atomic_add(mesh_counts, 1, num_tris_bs1)
-            wp.atomic_add(mesh_counts, 0, num_tris_bs1 * wp.int32(3))
-
-            write_tris_bs1 = num_tris_bs1
-            if tri_base_bs1 >= triangle_capacity:
-                wp.atomic_add(mesh_counts, 5, num_tris_bs1)
-                return
-            if tri_base_bs1 + write_tris_bs1 > triangle_capacity:
-                write_tris_bs1 = triangle_capacity - tri_base_bs1
-                wp.atomic_add(mesh_counts, 5, num_tris_bs1 - write_tris_bs1)
-
-            write_vertices_bs1 = (output_flags & wp.int32(1)) != wp.int32(0)
-            write_triangles_bs1 = (output_flags & wp.int32(2)) != wp.int32(0)
-            write_normals_bs1 = (output_flags & wp.int32(4)) != wp.int32(0)
-            write_colors_bs1 = (output_flags & wp.int32(8)) != wp.int32(0)
-
-            base_bs1 = block_key_to_voxel_base(bx1, by1, bz1)
-            gx1 = base_bs1[0]
-            gy1 = base_bs1[1]
-            gz1 = base_bs1[2]
-
-            center_offset_x_bs1 = wp.float32(tsdf.grid_W) * 0.5
-            center_offset_y_bs1 = wp.float32(tsdf.grid_H) * 0.5
-            center_offset_z_bs1 = wp.float32(tsdf.grid_D) * 0.5
-
-            p0_bs1 = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx1) - center_offset_x_bs1,
-                    wp.float32(gy1) - center_offset_y_bs1,
-                    wp.float32(gz1) - center_offset_z_bs1,
-                )
-                * tsdf.voxel_size
-            )
-            p1_bs1 = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx1 + 1) - center_offset_x_bs1,
-                    wp.float32(gy1) - center_offset_y_bs1,
-                    wp.float32(gz1) - center_offset_z_bs1,
-                )
-                * tsdf.voxel_size
-            )
-            p2_bs1 = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx1 + 1) - center_offset_x_bs1,
-                    wp.float32(gy1 + 1) - center_offset_y_bs1,
-                    wp.float32(gz1) - center_offset_z_bs1,
-                )
-                * tsdf.voxel_size
-            )
-            p3_bs1 = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx1) - center_offset_x_bs1,
-                    wp.float32(gy1 + 1) - center_offset_y_bs1,
-                    wp.float32(gz1) - center_offset_z_bs1,
-                )
-                * tsdf.voxel_size
-            )
-            p4_bs1 = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx1) - center_offset_x_bs1,
-                    wp.float32(gy1) - center_offset_y_bs1,
-                    wp.float32(gz1 + 1) - center_offset_z_bs1,
-                )
-                * tsdf.voxel_size
-            )
-            p5_bs1 = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx1 + 1) - center_offset_x_bs1,
-                    wp.float32(gy1) - center_offset_y_bs1,
-                    wp.float32(gz1 + 1) - center_offset_z_bs1,
-                )
-                * tsdf.voxel_size
-            )
-            p6_bs1 = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx1 + 1) - center_offset_x_bs1,
-                    wp.float32(gy1 + 1) - center_offset_y_bs1,
-                    wp.float32(gz1 + 1) - center_offset_z_bs1,
-                )
-                * tsdf.voxel_size
-            )
-            p7_bs1 = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx1) - center_offset_x_bs1,
-                    wp.float32(gy1 + 1) - center_offset_y_bs1,
-                    wp.float32(gz1 + 1) - center_offset_z_bs1,
-                )
-                * tsdf.voxel_size
-            )
-
-            color_bs1 = wp.vec3ub(wp.uint8(0), wp.uint8(0), wp.uint8(0))
-            if write_colors_bs1:
-                rgb_bs1 = sample_rgb(tsdf, (p0_bs1 + p6_bs1) * wp.float32(0.5))
-                color_bs1 = wp.vec3ub(
-                    wp.uint8(rgb_bs1[0]), wp.uint8(rgb_bs1[1]), wp.uint8(rgb_bs1[2])
-                )
-
-            for t in range(5):
-                if wp.int32(t) >= write_tris_bs1:
-                    break
-
-                e0_bs1 = tri_table[table_offset_bs1 + t * 3]
-                if e0_bs1 < 0:
-                    break
-
-                e1_bs1 = tri_table[table_offset_bs1 + t * 3 + 1]
-                e2_bs1 = tri_table[table_offset_bs1 + t * 3 + 2]
-
-                tri_idx_bs1 = tri_base_bs1 + wp.int32(t)
-                out_base_bs1 = tri_idx_bs1 * 3
-                v0_bs1 = get_edge_vertex(
-                    e0_bs1,
-                    p0_bs1,
-                    p1_bs1,
-                    p2_bs1,
-                    p3_bs1,
-                    p4_bs1,
-                    p5_bs1,
-                    p6_bs1,
-                    p7_bs1,
-                    d0,
-                    d1,
-                    d2,
-                    d3,
-                    d4,
-                    d5,
-                    d6,
-                    d7,
-                )
-                v1_bs1 = get_edge_vertex(
-                    e1_bs1,
-                    p0_bs1,
-                    p1_bs1,
-                    p2_bs1,
-                    p3_bs1,
-                    p4_bs1,
-                    p5_bs1,
-                    p6_bs1,
-                    p7_bs1,
-                    d0,
-                    d1,
-                    d2,
-                    d3,
-                    d4,
-                    d5,
-                    d6,
-                    d7,
-                )
-                v2_bs1 = get_edge_vertex(
-                    e2_bs1,
-                    p0_bs1,
-                    p1_bs1,
-                    p2_bs1,
-                    p3_bs1,
-                    p4_bs1,
-                    p5_bs1,
-                    p6_bs1,
-                    p7_bs1,
-                    d0,
-                    d1,
-                    d2,
-                    d3,
-                    d4,
-                    d5,
-                    d6,
-                    d7,
-                )
-
-                vertex_id0_bs1 = out_base_bs1
-                vertex_id1_bs1 = out_base_bs1 + wp.int32(1)
-                vertex_id2_bs1 = out_base_bs1 + wp.int32(2)
-                if write_vertices_bs1:
-                    vertices[vertex_id0_bs1] = v0_bs1
-                    vertices[vertex_id1_bs1] = v1_bs1
-                    vertices[vertex_id2_bs1] = v2_bs1
-                if write_normals_bs1:
-                    face_normal_bs1 = wp.cross(v1_bs1 - v0_bs1, v2_bs1 - v0_bs1)
-                    face_normal_len_sq_bs1 = wp.dot(face_normal_bs1, face_normal_bs1)
-                    if face_normal_len_sq_bs1 > 1.0e-20:
-                        face_normal_bs1 = face_normal_bs1 / wp.sqrt(
-                            face_normal_len_sq_bs1
-                        )
-                    normals[vertex_id0_bs1] = face_normal_bs1
-                    normals[vertex_id1_bs1] = face_normal_bs1
-                    normals[vertex_id2_bs1] = face_normal_bs1
-                if write_colors_bs1:
-                    colors[vertex_id0_bs1] = color_bs1
-                    colors[vertex_id1_bs1] = color_bs1
-                    colors[vertex_id2_bs1] = color_bs1
-                if write_triangles_bs1:
-                    triangles[vertex_id0_bs1] = vertex_id0_bs1
-                    triangles[vertex_id1_bs1] = vertex_id1_bs1
-                    triangles[vertex_id2_bs1] = vertex_id2_bs1
-
-            wp.atomic_add(mesh_counts, 3, write_tris_bs1)
-            wp.atomic_add(mesh_counts, 2, write_tris_bs1 * wp.int32(3))
-            return
-
-        cx = cube_idx % BS
-        cy = (cube_idx // BS) % BS
-        cz = cube_idx // (BS * BS)
-
-        bx = tsdf.block_coords[block_idx * 3 + 0]
-        by = tsdf.block_coords[block_idx * 3 + 1]
-        bz = tsdf.block_coords[block_idx * 3 + 2]
-
-        s0 = sample_cube_corner(
-            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s1 = sample_cube_corner(
-            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s2 = sample_cube_corner(
-            cx + 1, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s3 = sample_cube_corner(
-            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s4 = sample_cube_corner(
-            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s5 = sample_cube_corner(
-            cx + 1, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s6 = sample_cube_corner(
-            cx + 1, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s7 = sample_cube_corner(
-            cx, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-
-        if s0[1] < 0.5 or s1[1] < 0.5 or s2[1] < 0.5 or s3[1] < 0.5:
-            return
-        if s4[1] < 0.5 or s5[1] < 0.5 or s6[1] < 0.5 or s7[1] < 0.5:
-            return
-
-        has_positive = (
-            s0[0] > 0.0
-            or s1[0] > 0.0
-            or s2[0] > 0.0
-            or s3[0] > 0.0
-            or s4[0] > 0.0
-            or s5[0] > 0.0
-            or s6[0] > 0.0
-            or s7[0] > 0.0
-        )
-        has_negative = (
-            s0[0] < 0.0
-            or s1[0] < 0.0
-            or s2[0] < 0.0
-            or s3[0] < 0.0
-            or s4[0] < 0.0
-            or s5[0] < 0.0
-            or s6[0] < 0.0
-            or s7[0] < 0.0
-        )
-        if not (has_positive and has_negative):
-            return
-
-        if surface_band > 0.0:
-            in_band = (
-                wp.abs(s0[0]) < surface_band
-                or wp.abs(s1[0]) < surface_band
-                or wp.abs(s2[0]) < surface_band
-                or wp.abs(s3[0]) < surface_band
-                or wp.abs(s4[0]) < surface_band
-                or wp.abs(s5[0]) < surface_band
-                or wp.abs(s6[0]) < surface_band
-                or wp.abs(s7[0]) < surface_band
-            )
-            if not in_band:
-                return
-
-        wp.atomic_add(mesh_counts, 4, wp.int32(1))
-
-        cube_config = wp.int32(0)
-        if s0[0] < 0.0:
-            cube_config = cube_config | wp.int32(1)
-        if s1[0] < 0.0:
-            cube_config = cube_config | wp.int32(2)
-        if s2[0] < 0.0:
-            cube_config = cube_config | wp.int32(4)
-        if s3[0] < 0.0:
-            cube_config = cube_config | wp.int32(8)
-        if s4[0] < 0.0:
-            cube_config = cube_config | wp.int32(16)
-        if s5[0] < 0.0:
-            cube_config = cube_config | wp.int32(32)
-        if s6[0] < 0.0:
-            cube_config = cube_config | wp.int32(64)
-        if s7[0] < 0.0:
-            cube_config = cube_config | wp.int32(128)
-
-        table_offset = cube_config * 16
-        num_tris = wp.int32(0)
-
-        for t in range(5):
-            e0 = tri_table[table_offset + t * 3]
-            if e0 < 0:
-                break
-            num_tris = num_tris + wp.int32(1)
-
-        if num_tris <= wp.int32(0):
-            return
-
-        tri_base = wp.atomic_add(mesh_counts, 1, num_tris)
-        wp.atomic_add(mesh_counts, 0, num_tris * wp.int32(3))
-
-        write_tris = num_tris
-        if tri_base >= triangle_capacity:
-            wp.atomic_add(mesh_counts, 5, num_tris)
-            return
-        if tri_base + write_tris > triangle_capacity:
-            write_tris = triangle_capacity - tri_base
-            wp.atomic_add(mesh_counts, 5, num_tris - write_tris)
-
-        write_vertices = (output_flags & wp.int32(1)) != wp.int32(0)
-        write_triangles = (output_flags & wp.int32(2)) != wp.int32(0)
-        write_normals = (output_flags & wp.int32(4)) != wp.int32(0)
-        write_colors = (output_flags & wp.int32(8)) != wp.int32(0)
-        use_face_normals = (output_flags & wp.int32(16)) != wp.int32(0)
-
-        base = block_key_to_voxel_base(bx, by, bz)
-        gx = base[0] + cx
-        gy = base[1] + cy
-        gz = base[2] + cz
-
-        center_offset_x = wp.float32(tsdf.grid_W) * 0.5
-        center_offset_y = wp.float32(tsdf.grid_H) * 0.5
-        center_offset_z = wp.float32(tsdf.grid_D) * 0.5
-
-        p0 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p1 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p2 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p3 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p4 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p5 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p6 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p7 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-
-        color = wp.vec3ub(wp.uint8(0), wp.uint8(0), wp.uint8(0))
-        if write_colors:
-            rgb = sample_rgb(tsdf, (p0 + p6) * wp.float32(0.5))
-            color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
-
-        for t in range(5):
-            if wp.int32(t) >= write_tris:
-                break
-
-            e0 = tri_table[table_offset + t * 3]
-            if e0 < 0:
-                break
-
-            e1 = tri_table[table_offset + t * 3 + 1]
-            e2 = tri_table[table_offset + t * 3 + 2]
-
-            tri_idx = tri_base + wp.int32(t)
-            out_base = tri_idx * 3
-            v0 = get_edge_vertex(
-                e0,
-                p0,
-                p1,
-                p2,
-                p3,
-                p4,
-                p5,
-                p6,
-                p7,
-                s0[0],
-                s1[0],
-                s2[0],
-                s3[0],
-                s4[0],
-                s5[0],
-                s6[0],
-                s7[0],
-            )
-            v1 = get_edge_vertex(
-                e1,
-                p0,
-                p1,
-                p2,
-                p3,
-                p4,
-                p5,
-                p6,
-                p7,
-                s0[0],
-                s1[0],
-                s2[0],
-                s3[0],
-                s4[0],
-                s5[0],
-                s6[0],
-                s7[0],
-            )
-            v2 = get_edge_vertex(
-                e2,
-                p0,
-                p1,
-                p2,
-                p3,
-                p4,
-                p5,
-                p6,
-                p7,
-                s0[0],
-                s1[0],
-                s2[0],
-                s3[0],
-                s4[0],
-                s5[0],
-                s6[0],
-                s7[0],
-            )
-
-            vertex_id0 = out_base
-            vertex_id1 = out_base + wp.int32(1)
-            vertex_id2 = out_base + wp.int32(2)
-            if write_vertices:
-                vertices[vertex_id0] = v0
-                vertices[vertex_id1] = v1
-                vertices[vertex_id2] = v2
-            if write_normals:
-                if use_face_normals:
-                    face_normal = wp.cross(v1 - v0, v2 - v0)
-                    face_normal_len_sq = wp.dot(face_normal, face_normal)
-                    if face_normal_len_sq > 1.0e-20:
-                        face_normal = face_normal / wp.sqrt(face_normal_len_sq)
-                    normals[vertex_id0] = face_normal
-                    normals[vertex_id1] = face_normal
-                    normals[vertex_id2] = face_normal
-                else:
-                    n0 = compute_gradient_nearest(tsdf, v0, minimum_tsdf_weight)
-                    n1 = compute_gradient_nearest(tsdf, v1, minimum_tsdf_weight)
-                    n2 = compute_gradient_nearest(tsdf, v2, minimum_tsdf_weight)
-                    normals[vertex_id0] = wp.normalize(n0)
-                    normals[vertex_id1] = wp.normalize(n1)
-                    normals[vertex_id2] = wp.normalize(n2)
-            if write_colors:
-                colors[vertex_id0] = color
-                colors[vertex_id1] = color
-                colors[vertex_id2] = color
-            if write_triangles:
-                triangles[vertex_id0] = vertex_id0
-                triangles[vertex_id1] = vertex_id1
-                triangles[vertex_id2] = vertex_id2
-
-        wp.atomic_add(mesh_counts, 3, write_tris)
-        wp.atomic_add(mesh_counts, 2, write_tris * wp.int32(3))
-
-    @warp_kernel(f"count_fast_mesh_block_triangles_kernel_bs{block_size}", enable_backward=False)
-    def count_fast_mesh_block_triangles_kernel(
-        tsdf: BlockSparseTSDFWarp,
-        level: float,
-        surface_band: float,
-        minimum_tsdf_weight: float,
-        n_blocks: wp.int32,
-        num_tris_table: wp.array(dtype=wp.int32),
-        block_triangle_counts: wp.array(dtype=wp.int32),
-        block_surface_counts: wp.array(dtype=wp.int32),
-    ):
-        """Count full-scene fast mesh triangles per TSDF block."""
-        block_idx, cube_idx = wp.tid()
-
-        if block_idx >= n_blocks:
-            return
-        if block_idx >= tsdf.num_allocated[0]:
-            return
-        if tsdf.block_to_hash_slot[block_idx] < 0:
-            return
-
-        if BS == wp.int32(1):
-            return
-
-        cx = cube_idx % BS
-        cy = (cube_idx // BS) % BS
-        cz = cube_idx // (BS * BS)
-
-        bx = tsdf.block_coords[block_idx * 3 + 0]
-        by = tsdf.block_coords[block_idx * 3 + 1]
-        bz = tsdf.block_coords[block_idx * 3 + 2]
-
-        s0 = sample_cube_corner(
-            cx, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s1 = sample_cube_corner(
-            cx + 1, cy, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s2 = sample_cube_corner(
-            cx + 1, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s3 = sample_cube_corner(
-            cx, cy + 1, cz, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s4 = sample_cube_corner(
-            cx, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s5 = sample_cube_corner(
-            cx + 1, cy, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s6 = sample_cube_corner(
-            cx + 1, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-        s7 = sample_cube_corner(
-            cx, cy + 1, cz + 1, bx, by, bz, block_idx, tsdf, level, minimum_tsdf_weight
-        )
-
-        if s0[1] < 0.5 or s1[1] < 0.5 or s2[1] < 0.5 or s3[1] < 0.5:
-            return
-        if s4[1] < 0.5 or s5[1] < 0.5 or s6[1] < 0.5 or s7[1] < 0.5:
-            return
-
-        has_positive = (
-            s0[0] > 0.0
-            or s1[0] > 0.0
-            or s2[0] > 0.0
-            or s3[0] > 0.0
-            or s4[0] > 0.0
-            or s5[0] > 0.0
-            or s6[0] > 0.0
-            or s7[0] > 0.0
-        )
-        has_negative = (
-            s0[0] < 0.0
-            or s1[0] < 0.0
-            or s2[0] < 0.0
-            or s3[0] < 0.0
-            or s4[0] < 0.0
-            or s5[0] < 0.0
-            or s6[0] < 0.0
-            or s7[0] < 0.0
-        )
-        if not (has_positive and has_negative):
-            return
-
-        if surface_band > 0.0:
-            in_band = (
-                wp.abs(s0[0]) < surface_band
-                or wp.abs(s1[0]) < surface_band
-                or wp.abs(s2[0]) < surface_band
-                or wp.abs(s3[0]) < surface_band
-                or wp.abs(s4[0]) < surface_band
-                or wp.abs(s5[0]) < surface_band
-                or wp.abs(s6[0]) < surface_band
-                or wp.abs(s7[0]) < surface_band
-            )
-            if not in_band:
-                return
-
-        cube_config = wp.int32(0)
-        if s0[0] < 0.0:
-            cube_config = cube_config | wp.int32(1)
-        if s1[0] < 0.0:
-            cube_config = cube_config | wp.int32(2)
-        if s2[0] < 0.0:
-            cube_config = cube_config | wp.int32(4)
-        if s3[0] < 0.0:
-            cube_config = cube_config | wp.int32(8)
-        if s4[0] < 0.0:
-            cube_config = cube_config | wp.int32(16)
-        if s5[0] < 0.0:
-            cube_config = cube_config | wp.int32(32)
-        if s6[0] < 0.0:
-            cube_config = cube_config | wp.int32(64)
-        if s7[0] < 0.0:
-            cube_config = cube_config | wp.int32(128)
-
-        num_tris = num_tris_table[cube_config]
-        if num_tris <= wp.int32(0):
-            return
-
-        wp.atomic_add(block_surface_counts, block_idx, wp.int32(1))
-        wp.atomic_add(block_triangle_counts, block_idx, num_tris)
-
-    @warp_kernel(f"generate_fast_mesh_current_state_kernel_bs{block_size}")
-    def generate_fast_mesh_current_state_kernel(
-        tsdf: BlockSparseTSDFWarp,
-        level: float,
-        surface_band: float,
-        minimum_tsdf_weight: float,
-        n_blocks: wp.int32,
-        tri_table: wp.array(dtype=wp.int32),
-        vertices: wp.array(dtype=wp.vec3),
-        triangles: wp.array(dtype=wp.int32),
-        colors: wp.array(dtype=wp.vec3ub),
-        mesh_counts: wp.array(dtype=wp.int32),
-        block_triangle_offsets: wp.array(dtype=wp.int32),
-        block_write_counts: wp.array(dtype=wp.int32),
-        triangle_capacity: wp.int32,
-        write_triangles: wp.int32,
-        use_voxel_colors: wp.int32,
-        atomic_triangle_list: wp.int32,
-    ):
-        """Fast current-state mesh: vertices, triangles, colors; no normals."""
-        block_idx, cube_idx = wp.tid()
-
-        if block_idx >= n_blocks:
-            return
-        if block_idx >= tsdf.num_allocated[0]:
-            return
-        if tsdf.block_to_hash_slot[block_idx] < 0:
-            return
-
-        if BS != wp.int32(1):
-            cx_g = cube_idx % BS
-            cy_g = (cube_idx // BS) % BS
-            cz_g = cube_idx // (BS * BS)
-
-            bx_g = tsdf.block_coords[block_idx * 3 + 0]
-            by_g = tsdf.block_coords[block_idx * 3 + 1]
-            bz_g = tsdf.block_coords[block_idx * 3 + 2]
-
-            s0_g = sample_cube_corner(
-                cx_g, cy_g, cz_g, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
-            )
-            s1_g = sample_cube_corner(
-                cx_g + 1, cy_g, cz_g, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
-            )
-            s2_g = sample_cube_corner(
-                cx_g + 1, cy_g + 1, cz_g, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
-            )
-            s3_g = sample_cube_corner(
-                cx_g, cy_g + 1, cz_g, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
-            )
-            s4_g = sample_cube_corner(
-                cx_g, cy_g, cz_g + 1, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
-            )
-            s5_g = sample_cube_corner(
-                cx_g + 1, cy_g, cz_g + 1, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
-            )
-            s6_g = sample_cube_corner(
-                cx_g + 1, cy_g + 1, cz_g + 1, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
-            )
-            s7_g = sample_cube_corner(
-                cx_g, cy_g + 1, cz_g + 1, bx_g, by_g, bz_g, block_idx, tsdf, level, minimum_tsdf_weight
-            )
-
-            if s0_g[1] < 0.5 or s1_g[1] < 0.5 or s2_g[1] < 0.5 or s3_g[1] < 0.5:
-                return
-            if s4_g[1] < 0.5 or s5_g[1] < 0.5 or s6_g[1] < 0.5 or s7_g[1] < 0.5:
-                return
-
-            has_positive_g = (
-                s0_g[0] > 0.0
-                or s1_g[0] > 0.0
-                or s2_g[0] > 0.0
-                or s3_g[0] > 0.0
-                or s4_g[0] > 0.0
-                or s5_g[0] > 0.0
-                or s6_g[0] > 0.0
-                or s7_g[0] > 0.0
-            )
-            has_negative_g = (
-                s0_g[0] < 0.0
-                or s1_g[0] < 0.0
-                or s2_g[0] < 0.0
-                or s3_g[0] < 0.0
-                or s4_g[0] < 0.0
-                or s5_g[0] < 0.0
-                or s6_g[0] < 0.0
-                or s7_g[0] < 0.0
-            )
-            if not (has_positive_g and has_negative_g):
-                return
-
-            if surface_band > 0.0:
-                in_band_g = (
-                    wp.abs(s0_g[0]) < surface_band
-                    or wp.abs(s1_g[0]) < surface_band
-                    or wp.abs(s2_g[0]) < surface_band
-                    or wp.abs(s3_g[0]) < surface_band
-                    or wp.abs(s4_g[0]) < surface_band
-                    or wp.abs(s5_g[0]) < surface_band
-                    or wp.abs(s6_g[0]) < surface_band
-                    or wp.abs(s7_g[0]) < surface_band
-                )
-                if not in_band_g:
-                    return
-
-            cube_config_g = wp.int32(0)
-            if s0_g[0] < 0.0:
-                cube_config_g = cube_config_g | wp.int32(1)
-            if s1_g[0] < 0.0:
-                cube_config_g = cube_config_g | wp.int32(2)
-            if s2_g[0] < 0.0:
-                cube_config_g = cube_config_g | wp.int32(4)
-            if s3_g[0] < 0.0:
-                cube_config_g = cube_config_g | wp.int32(8)
-            if s4_g[0] < 0.0:
-                cube_config_g = cube_config_g | wp.int32(16)
-            if s5_g[0] < 0.0:
-                cube_config_g = cube_config_g | wp.int32(32)
-            if s6_g[0] < 0.0:
-                cube_config_g = cube_config_g | wp.int32(64)
-            if s7_g[0] < 0.0:
-                cube_config_g = cube_config_g | wp.int32(128)
-
-            table_offset_g = cube_config_g * 16
-            num_tris_g = wp.int32(0)
-            for t in range(5):
-                e_g = tri_table[table_offset_g + t * 3]
-                if e_g < 0:
-                    break
-                num_tris_g = num_tris_g + wp.int32(1)
-
-            if num_tris_g <= wp.int32(0):
-                return
-
-            if atomic_triangle_list != wp.int32(0):
-                tri_base_g = wp.atomic_add(mesh_counts, wp.int32(1), num_tris_g)
-                wp.atomic_add(mesh_counts, wp.int32(0), num_tris_g * wp.int32(3))
-            else:
-                local_tri_base_g = wp.atomic_add(block_write_counts, block_idx, num_tris_g)
-                tri_base_g = block_triangle_offsets[block_idx] + local_tri_base_g
-
-            write_tris_g = num_tris_g
-            if tri_base_g >= triangle_capacity:
-                if atomic_triangle_list != wp.int32(0):
-                    wp.atomic_add(mesh_counts, wp.int32(5), num_tris_g)
-                return
-            if tri_base_g + write_tris_g > triangle_capacity:
-                write_tris_g = triangle_capacity - tri_base_g
-                if atomic_triangle_list != wp.int32(0):
-                    wp.atomic_add(mesh_counts, wp.int32(5), num_tris_g - write_tris_g)
-
-            if atomic_triangle_list != wp.int32(0):
-                wp.atomic_add(mesh_counts, wp.int32(2), write_tris_g * wp.int32(3))
-                wp.atomic_add(mesh_counts, wp.int32(3), write_tris_g)
-
-            base_g = block_key_to_voxel_base(bx_g, by_g, bz_g)
-            gx_g = base_g[0] + cx_g
-            gy_g = base_g[1] + cy_g
-            gz_g = base_g[2] + cz_g
-
-            center_offset_x_g = wp.float32(tsdf.grid_W) * 0.5
-            center_offset_y_g = wp.float32(tsdf.grid_H) * 0.5
-            center_offset_z_g = wp.float32(tsdf.grid_D) * 0.5
-
-            p0_g = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx_g) - center_offset_x_g,
-                    wp.float32(gy_g) - center_offset_y_g,
-                    wp.float32(gz_g) - center_offset_z_g,
-                )
-                * tsdf.voxel_size
-            )
-            p1_g = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx_g + 1) - center_offset_x_g,
-                    wp.float32(gy_g) - center_offset_y_g,
-                    wp.float32(gz_g) - center_offset_z_g,
-                )
-                * tsdf.voxel_size
-            )
-            p2_g = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx_g + 1) - center_offset_x_g,
-                    wp.float32(gy_g + 1) - center_offset_y_g,
-                    wp.float32(gz_g) - center_offset_z_g,
-                )
-                * tsdf.voxel_size
-            )
-            p3_g = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx_g) - center_offset_x_g,
-                    wp.float32(gy_g + 1) - center_offset_y_g,
-                    wp.float32(gz_g) - center_offset_z_g,
-                )
-                * tsdf.voxel_size
-            )
-            p4_g = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx_g) - center_offset_x_g,
-                    wp.float32(gy_g) - center_offset_y_g,
-                    wp.float32(gz_g + 1) - center_offset_z_g,
-                )
-                * tsdf.voxel_size
-            )
-            p5_g = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx_g + 1) - center_offset_x_g,
-                    wp.float32(gy_g) - center_offset_y_g,
-                    wp.float32(gz_g + 1) - center_offset_z_g,
-                )
-                * tsdf.voxel_size
-            )
-            p6_g = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx_g + 1) - center_offset_x_g,
-                    wp.float32(gy_g + 1) - center_offset_y_g,
-                    wp.float32(gz_g + 1) - center_offset_z_g,
-                )
-                * tsdf.voxel_size
-            )
-            p7_g = (
-                tsdf.origin
-                + wp.vec3(
-                    wp.float32(gx_g) - center_offset_x_g,
-                    wp.float32(gy_g + 1) - center_offset_y_g,
-                    wp.float32(gz_g + 1) - center_offset_z_g,
-                )
-                * tsdf.voxel_size
-            )
-
-            color_g = wp.vec3ub(wp.uint8(128), wp.uint8(128), wp.uint8(128))
-            if use_voxel_colors != wp.int32(0):
-                rgb_g = sample_rgb(tsdf, (p0_g + p6_g) * wp.float32(0.5))
-                color_g = wp.vec3ub(
-                    wp.uint8(rgb_g[0]), wp.uint8(rgb_g[1]), wp.uint8(rgb_g[2])
-                )
-
-            for t in range(5):
-                if wp.int32(t) >= write_tris_g:
-                    break
-
-                e0_g = tri_table[table_offset_g + t * 3]
-                if e0_g < 0:
-                    break
-
-                e1_g = tri_table[table_offset_g + t * 3 + 1]
-                e2_g = tri_table[table_offset_g + t * 3 + 2]
-
-                tri_idx_g = tri_base_g + wp.int32(t)
-                out_base_g = tri_idx_g * 3
-                v0_g = get_edge_vertex(
-                    e0_g,
-                    p0_g,
-                    p1_g,
-                    p2_g,
-                    p3_g,
-                    p4_g,
-                    p5_g,
-                    p6_g,
-                    p7_g,
-                    s0_g[0],
-                    s1_g[0],
-                    s2_g[0],
-                    s3_g[0],
-                    s4_g[0],
-                    s5_g[0],
-                    s6_g[0],
-                    s7_g[0],
-                )
-                v1_g = get_edge_vertex(
-                    e1_g,
-                    p0_g,
-                    p1_g,
-                    p2_g,
-                    p3_g,
-                    p4_g,
-                    p5_g,
-                    p6_g,
-                    p7_g,
-                    s0_g[0],
-                    s1_g[0],
-                    s2_g[0],
-                    s3_g[0],
-                    s4_g[0],
-                    s5_g[0],
-                    s6_g[0],
-                    s7_g[0],
-                )
-                v2_g = get_edge_vertex(
-                    e2_g,
-                    p0_g,
-                    p1_g,
-                    p2_g,
-                    p3_g,
-                    p4_g,
-                    p5_g,
-                    p6_g,
-                    p7_g,
-                    s0_g[0],
-                    s1_g[0],
-                    s2_g[0],
-                    s3_g[0],
-                    s4_g[0],
-                    s5_g[0],
-                    s6_g[0],
-                    s7_g[0],
-                )
-
-                vertex_id0_g = out_base_g
-                vertex_id1_g = out_base_g + wp.int32(1)
-                vertex_id2_g = out_base_g + wp.int32(2)
-                vertices[vertex_id0_g] = v0_g
-                vertices[vertex_id1_g] = v1_g
-                vertices[vertex_id2_g] = v2_g
-                if write_triangles != wp.int32(0):
-                    triangles[vertex_id0_g] = vertex_id0_g
-                    triangles[vertex_id1_g] = vertex_id1_g
-                    triangles[vertex_id2_g] = vertex_id2_g
-                if use_voxel_colors == wp.int32(0):
-                    colors[vertex_id0_g] = color_g
-                    colors[vertex_id1_g] = color_g
-                    colors[vertex_id2_g] = color_g
-                    continue
-                c0_g = sample_rgb(tsdf, v0_g)
-                c1_g = sample_rgb(tsdf, v1_g)
-                c2_g = sample_rgb(tsdf, v2_g)
-                colors[vertex_id0_g] = wp.vec3ub(
-                    wp.uint8(c0_g[0]), wp.uint8(c0_g[1]), wp.uint8(c0_g[2])
-                )
-                colors[vertex_id1_g] = wp.vec3ub(
-                    wp.uint8(c1_g[0]), wp.uint8(c1_g[1]), wp.uint8(c1_g[2])
-                )
-                colors[vertex_id2_g] = wp.vec3ub(
-                    wp.uint8(c2_g[0]), wp.uint8(c2_g[1]), wp.uint8(c2_g[2])
-                )
-
-            return
-
-        if cube_idx != wp.int32(0):
-            return
-
-        bx = tsdf.block_coords[block_idx * 3 + 0]
-        by = tsdf.block_coords[block_idx * 3 + 1]
-        bz = tsdf.block_coords[block_idx * 3 + 2]
-
-        n100_idx = hash_lookup(tsdf.hash_table, bx + 1, by, bz, tsdf.hash_capacity)
-        n010_idx = hash_lookup(tsdf.hash_table, bx, by + 1, bz, tsdf.hash_capacity)
-        n110_idx = hash_lookup(tsdf.hash_table, bx + 1, by + 1, bz, tsdf.hash_capacity)
-        n001_idx = hash_lookup(tsdf.hash_table, bx, by, bz + 1, tsdf.hash_capacity)
-        n101_idx = hash_lookup(tsdf.hash_table, bx + 1, by, bz + 1, tsdf.hash_capacity)
-        n011_idx = hash_lookup(tsdf.hash_table, bx, by + 1, bz + 1, tsdf.hash_capacity)
-        n111_idx = hash_lookup(
-            tsdf.hash_table, bx + 1, by + 1, bz + 1, tsdf.hash_capacity
-        )
-        if (
-            n100_idx < 0
-            or n010_idx < 0
-            or n110_idx < 0
-            or n001_idx < 0
-            or n101_idx < 0
-            or n011_idx < 0
-            or n111_idx < 0
-        ):
-            return
-
-        s0 = sample_voxel(tsdf, block_idx, wp.int32(0), minimum_tsdf_weight)
-        s1 = sample_voxel(tsdf, n100_idx, wp.int32(0), minimum_tsdf_weight)
-        s2 = sample_voxel(tsdf, n110_idx, wp.int32(0), minimum_tsdf_weight)
-        s3 = sample_voxel(tsdf, n010_idx, wp.int32(0), minimum_tsdf_weight)
-        s4 = sample_voxel(tsdf, n001_idx, wp.int32(0), minimum_tsdf_weight)
-        s5 = sample_voxel(tsdf, n101_idx, wp.int32(0), minimum_tsdf_weight)
-        s6 = sample_voxel(tsdf, n111_idx, wp.int32(0), minimum_tsdf_weight)
-        s7 = sample_voxel(tsdf, n011_idx, wp.int32(0), minimum_tsdf_weight)
-        if s0[1] < 0.5 or s1[1] < 0.5 or s2[1] < 0.5 or s3[1] < 0.5:
-            return
-        if s4[1] < 0.5 or s5[1] < 0.5 or s6[1] < 0.5 or s7[1] < 0.5:
-            return
-
-        d0 = s0[0] - level
-        d1 = s1[0] - level
-        d2 = s2[0] - level
-        d3 = s3[0] - level
-        d4 = s4[0] - level
-        d5 = s5[0] - level
-        d6 = s6[0] - level
-        d7 = s7[0] - level
-
-        has_positive = (
-            d0 > 0.0
-            or d1 > 0.0
-            or d2 > 0.0
-            or d3 > 0.0
-            or d4 > 0.0
-            or d5 > 0.0
-            or d6 > 0.0
-            or d7 > 0.0
-        )
-        has_negative = (
-            d0 < 0.0
-            or d1 < 0.0
-            or d2 < 0.0
-            or d3 < 0.0
-            or d4 < 0.0
-            or d5 < 0.0
-            or d6 < 0.0
-            or d7 < 0.0
-        )
-        if not (has_positive and has_negative):
-            return
-
-        if surface_band > 0.0:
-            in_band = (
-                wp.abs(d0) < surface_band
-                or wp.abs(d1) < surface_band
-                or wp.abs(d2) < surface_band
-                or wp.abs(d3) < surface_band
-                or wp.abs(d4) < surface_band
-                or wp.abs(d5) < surface_band
-                or wp.abs(d6) < surface_band
-                or wp.abs(d7) < surface_band
-            )
-            if not in_band:
-                return
-
-        cube_config = wp.int32(0)
-        if d0 < 0.0:
-            cube_config = cube_config | wp.int32(1)
-        if d1 < 0.0:
-            cube_config = cube_config | wp.int32(2)
-        if d2 < 0.0:
-            cube_config = cube_config | wp.int32(4)
-        if d3 < 0.0:
-            cube_config = cube_config | wp.int32(8)
-        if d4 < 0.0:
-            cube_config = cube_config | wp.int32(16)
-        if d5 < 0.0:
-            cube_config = cube_config | wp.int32(32)
-        if d6 < 0.0:
-            cube_config = cube_config | wp.int32(64)
-        if d7 < 0.0:
-            cube_config = cube_config | wp.int32(128)
-
-        table_offset = cube_config * 16
-        num_tris = wp.int32(0)
-        for t in range(5):
-            e = tri_table[table_offset + t * 3]
-            if e < 0:
-                break
-            num_tris = num_tris + wp.int32(1)
-
-        if num_tris <= wp.int32(0):
-            return
-
-        if atomic_triangle_list != wp.int32(0):
-            tri_base = wp.atomic_add(mesh_counts, wp.int32(1), num_tris)
-            wp.atomic_add(mesh_counts, wp.int32(0), num_tris * wp.int32(3))
-        else:
-            local_tri_base = wp.atomic_add(block_write_counts, block_idx, num_tris)
-            tri_base = block_triangle_offsets[block_idx] + local_tri_base
-
-        write_tris = num_tris
-        if tri_base >= triangle_capacity:
-            if atomic_triangle_list != wp.int32(0):
-                wp.atomic_add(mesh_counts, wp.int32(5), num_tris)
-            return
-        if tri_base + write_tris > triangle_capacity:
-            write_tris = triangle_capacity - tri_base
-            if atomic_triangle_list != wp.int32(0):
-                wp.atomic_add(mesh_counts, wp.int32(5), num_tris - write_tris)
-
-        if atomic_triangle_list != wp.int32(0):
-            wp.atomic_add(mesh_counts, wp.int32(2), write_tris * wp.int32(3))
-            wp.atomic_add(mesh_counts, wp.int32(3), write_tris)
-
-        base = block_key_to_voxel_base(bx, by, bz)
-        gx = base[0]
-        gy = base[1]
-        gz = base[2]
-
-        center_offset_x = wp.float32(tsdf.grid_W) * 0.5
-        center_offset_y = wp.float32(tsdf.grid_H) * 0.5
-        center_offset_z = wp.float32(tsdf.grid_D) * 0.5
-
-        p0 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p1 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p2 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p3 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p4 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p5 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p6 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx + 1) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-        p7 = (
-            tsdf.origin
-            + wp.vec3(
-                wp.float32(gx) - center_offset_x,
-                wp.float32(gy + 1) - center_offset_y,
-                wp.float32(gz + 1) - center_offset_z,
-            )
-            * tsdf.voxel_size
-        )
-
-        color = wp.vec3ub(wp.uint8(128), wp.uint8(128), wp.uint8(128))
-        if use_voxel_colors != wp.int32(0):
-            rgb = sample_rgb(tsdf, (p0 + p6) * wp.float32(0.5))
-            color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
-
-        for t in range(5):
-            if wp.int32(t) >= write_tris:
-                break
-
-            e0 = tri_table[table_offset + t * 3]
-            if e0 < 0:
-                break
-
-            e1 = tri_table[table_offset + t * 3 + 1]
-            e2 = tri_table[table_offset + t * 3 + 2]
-
-            tri_idx = tri_base + wp.int32(t)
-            out_base = tri_idx * 3
-            v0 = get_edge_vertex(
-                e0,
-                p0,
-                p1,
-                p2,
-                p3,
-                p4,
-                p5,
-                p6,
-                p7,
-                d0,
-                d1,
-                d2,
-                d3,
-                d4,
-                d5,
-                d6,
-                d7,
-            )
-            v1 = get_edge_vertex(
-                e1,
-                p0,
-                p1,
-                p2,
-                p3,
-                p4,
-                p5,
-                p6,
-                p7,
-                d0,
-                d1,
-                d2,
-                d3,
-                d4,
-                d5,
-                d6,
-                d7,
-            )
-            v2 = get_edge_vertex(
-                e2,
-                p0,
-                p1,
-                p2,
-                p3,
-                p4,
-                p5,
-                p6,
-                p7,
-                d0,
-                d1,
-                d2,
-                d3,
-                d4,
-                d5,
-                d6,
-                d7,
-            )
-
-            vertex_id0 = out_base
-            vertex_id1 = out_base + wp.int32(1)
-            vertex_id2 = out_base + wp.int32(2)
-            vertices[vertex_id0] = v0
-            vertices[vertex_id1] = v1
-            vertices[vertex_id2] = v2
-            if write_triangles != wp.int32(0):
-                triangles[vertex_id0] = vertex_id0
-                triangles[vertex_id1] = vertex_id1
-                triangles[vertex_id2] = vertex_id2
-            if use_voxel_colors == wp.int32(0):
-                colors[vertex_id0] = color
-                colors[vertex_id1] = color
-                colors[vertex_id2] = color
-                continue
-            c0 = sample_rgb(tsdf, v0)
-            c1 = sample_rgb(tsdf, v1)
-            c2 = sample_rgb(tsdf, v2)
-            colors[vertex_id0] = wp.vec3ub(
-                wp.uint8(c0[0]), wp.uint8(c0[1]), wp.uint8(c0[2])
-            )
-            colors[vertex_id1] = wp.vec3ub(
-                wp.uint8(c1[0]), wp.uint8(c1[1]), wp.uint8(c1[2])
-            )
-            colors[vertex_id2] = wp.vec3ub(
-                wp.uint8(c2[0]), wp.uint8(c2[1]), wp.uint8(c2[2])
-            )
 
     # =====================================================================
-    # Projective texture mapping for fast triangle-list meshes
+    # Projective texture mapping for triangle-list meshes
     # =====================================================================
 
-    @warp_kernel(f"copy_rgb_images_to_texture_atlas_kernel_bs{block_size}", enable_backward=False)
-    def copy_rgb_images_to_texture_atlas_kernel(
-        rgb_images: wp.array3d(dtype=wp.uint8),
-        texture_atlas: wp.array3d(dtype=wp.uint8),
-    ):
-        """Copy flattened camera RGB images into a horizontal texture atlas."""
-        tid = wp.tid()
-        image_pixels = IMAGE_HEIGHT * IMAGE_WIDTH
-        total_pixels = NUM_CAMERAS * image_pixels
-        if tid >= total_pixels:
-            return
+    @warp_func(f"texture_depth_z_visible_bs{block_size}")
+    def texture_depth_z_visible(
+        visibility_depth: wp.float32,
+        projected_z: wp.float32,
+        texture_depth_tolerance_m: wp.float32,
+        voxel_size: wp.float32,
+    ) -> bool:
+        """Check camera-frame z against a sampled visibility depth."""
+        if projected_z <= 0.0 or not wp.isfinite(projected_z):
+            return False
+        if visibility_depth <= 0.0 or not wp.isfinite(visibility_depth):
+            return False
 
-        cam_idx = tid // image_pixels
-        rem = tid - cam_idx * image_pixels
-        py = rem // IMAGE_WIDTH
-        px = rem - py * IMAGE_WIDTH
+        tolerance = texture_depth_tolerance_m
+        if tolerance < 0.0:
+            voxel_tolerance = wp.float32(2.0) * voxel_size
+            range_tolerance = wp.float32(0.01) * projected_z
+            tolerance = voxel_tolerance
+            if range_tolerance > tolerance:
+                tolerance = range_tolerance
 
-        src_y = cam_idx * IMAGE_HEIGHT + py
-        atlas_x = cam_idx * IMAGE_WIDTH + px
+        return wp.abs(projected_z - visibility_depth) <= tolerance
 
-        texture_atlas[py, atlas_x, 0] = rgb_images[src_y, px, 0]
-        texture_atlas[py, atlas_x, 1] = rgb_images[src_y, px, 1]
-        texture_atlas[py, atlas_x, 2] = rgb_images[src_y, px, 2]
-
-    @warp_kernel(f"project_fast_mesh_uvs_kernel_bs{block_size}", enable_backward=False)
-    def project_fast_mesh_uvs_kernel(
+    @warp_kernel(f"project_mesh_uvs_kernel_bs{block_size}", enable_backward=False)
+    def project_mesh_uvs_kernel(
         vertices: wp.array(dtype=wp.vec3),
         vertex_count: wp.int32,
+        visibility_depths: wp.array3d(dtype=wp.float32),
         intrinsics: wp.array3d(dtype=wp.float32),
         cam_positions: wp.array2d(dtype=wp.float32),
         cam_quaternions: wp.array2d(dtype=wp.float32),
-        depth_images: wp.array3d(dtype=wp.float32),
-        depth_min: float,
-        depth_max: float,
-        occlusion_tolerance_m: float,
+        camera_min_distance: float,
+        camera_max_distance: float,
+        texture_depth_tolerance_m: float,
+        camera_offset: wp.int32,
+        atlas_camera_count: wp.int32,
+        atlas_columns: wp.int32,
         vertex_uvs: wp.array(dtype=wp.vec2),
+        projection_scores: wp.array(dtype=wp.float32),
         colors: wp.array(dtype=wp.vec3ub),
         fill_missing_colors: wp.int32,
         tsdf: BlockSparseTSDFWarp,
     ):
-        """Project fast-mesh triangle vertices into the current camera atlas."""
+        """Project triangle-soup mesh vertices into a horizontal camera atlas."""
         tri_idx = wp.tid()
         base = tri_idx * wp.int32(3)
         if base + wp.int32(2) >= vertex_count:
@@ -2904,7 +719,7 @@ def make_mesh_kernels(
                 center_cam_i = wp.quat_rotate(wp.quat_inverse(cam_quat_i), center - cam_pos_i)
                 z_center_i = center_cam_i[2]
 
-                if z_center_i > depth_min and z_center_i <= depth_max:
+                if z_center_i > camera_min_distance and z_center_i <= camera_max_distance:
                     fx_i = intrinsics[cam_i, 0, 0]
                     fy_i = intrinsics[cam_i, 1, 1]
                     cx_i = intrinsics[cam_i, 0, 2]
@@ -2918,14 +733,27 @@ def make_mesh_kernels(
                         and v_center_i >= 0.0
                         and v_center_i < wp.float32(IMAGE_HEIGHT)
                     ):
-                        viewing_dir = cam_pos_i - center
-                        viewing_len_sq = wp.dot(viewing_dir, viewing_dir)
-                        if viewing_len_sq > 1.0e-20:
-                            viewing_dir = viewing_dir / wp.sqrt(viewing_len_sq)
-                            score = wp.dot(face_normal, viewing_dir)
-                            if score < score_limit and score > best_score:
-                                best_score = score
-                                best_cam = wp.int32(cam_i)
+                        px_center_i = wp.int32(wp.floor(u_center_i))
+                        py_center_i = wp.int32(wp.floor(v_center_i))
+                        center_depth_i = visibility_depths[cam_i, py_center_i, px_center_i]
+                        if texture_depth_z_visible(
+                            center_depth_i,
+                            z_center_i,
+                            texture_depth_tolerance_m,
+                            tsdf.voxel_size,
+                        ):
+                            viewing_dir = cam_pos_i - center
+                            viewing_len_sq = wp.dot(viewing_dir, viewing_dir)
+                            if viewing_len_sq > 1.0e-20:
+                                viewing_dir = viewing_dir / wp.sqrt(viewing_len_sq)
+                                score = wp.dot(face_normal, viewing_dir)
+                                if (
+                                    score > 0.0
+                                    and score < score_limit
+                                    and score > best_score
+                                ):
+                                    best_score = score
+                                    best_cam = wp.int32(cam_i)
 
             if best_cam < 0:
                 break
@@ -2946,14 +774,22 @@ def make_mesh_kernels(
             fy = intrinsics[best_cam, 1, 1]
             cx = intrinsics[best_cam, 0, 2]
             cy = intrinsics[best_cam, 1, 2]
-            atlas_width = wp.float32(NUM_CAMERAS * IMAGE_WIDTH)
-            atlas_x_offset = wp.float32(best_cam * IMAGE_WIDTH)
+            atlas_rows = (
+                atlas_camera_count + atlas_columns - wp.int32(1)
+            ) // atlas_columns
+            atlas_camera_idx = camera_offset + best_cam
+            atlas_col = atlas_camera_idx % atlas_columns
+            atlas_row = atlas_camera_idx // atlas_columns
+            atlas_width = wp.float32(atlas_columns * IMAGE_WIDTH)
+            atlas_height = wp.float32(atlas_rows * IMAGE_HEIGHT)
+            atlas_x_offset = wp.float32(atlas_col * IMAGE_WIDTH)
+            atlas_y_offset = wp.float32(atlas_row * IMAGE_HEIGHT)
 
             all_valid = bool(True)
 
             p0_cam = wp.quat_rotate(cam_quat_inv, v0 - cam_pos)
             z0 = p0_cam[2]
-            if z0 > depth_min and z0 <= depth_max:
+            if z0 > camera_min_distance and z0 <= camera_max_distance:
                 u0 = fx * p0_cam[0] / z0 + cx
                 vv0 = fy * p0_cam[1] / z0 + cy
                 if (
@@ -2962,20 +798,21 @@ def make_mesh_kernels(
                     and vv0 >= 0.0
                     and vv0 < wp.float32(IMAGE_HEIGHT)
                 ):
-                    px0 = wp.int32(u0 + 0.5)
-                    py0 = wp.int32(vv0 + 0.5)
-                    if px0 >= IMAGE_WIDTH:
-                        px0 = IMAGE_WIDTH - wp.int32(1)
-                    if py0 >= IMAGE_HEIGHT:
-                        py0 = IMAGE_HEIGHT - wp.int32(1)
-                    observed0 = depth_images[best_cam, py0, px0]
-                    if observed0 > 0.0 and z0 > observed0 + occlusion_tolerance_m:
-                        all_valid = False
-                    else:
+                    px0 = wp.int32(wp.floor(u0))
+                    py0 = wp.int32(wp.floor(vv0))
+                    depth0 = visibility_depths[best_cam, py0, px0]
+                    if texture_depth_z_visible(
+                        depth0,
+                        z0,
+                        texture_depth_tolerance_m,
+                        tsdf.voxel_size,
+                    ):
                         uv0 = wp.vec2(
                             (atlas_x_offset + u0) / atlas_width,
-                            vv0 / wp.float32(IMAGE_HEIGHT),
+                            (atlas_y_offset + vv0) / atlas_height,
                         )
+                    else:
+                        all_valid = False
                 else:
                     all_valid = False
             else:
@@ -2983,7 +820,7 @@ def make_mesh_kernels(
 
             p1_cam = wp.quat_rotate(cam_quat_inv, v1 - cam_pos)
             z1 = p1_cam[2]
-            if all_valid and z1 > depth_min and z1 <= depth_max:
+            if all_valid and z1 > camera_min_distance and z1 <= camera_max_distance:
                 u1 = fx * p1_cam[0] / z1 + cx
                 vv1 = fy * p1_cam[1] / z1 + cy
                 if (
@@ -2992,20 +829,21 @@ def make_mesh_kernels(
                     and vv1 >= 0.0
                     and vv1 < wp.float32(IMAGE_HEIGHT)
                 ):
-                    px1 = wp.int32(u1 + 0.5)
-                    py1 = wp.int32(vv1 + 0.5)
-                    if px1 >= IMAGE_WIDTH:
-                        px1 = IMAGE_WIDTH - wp.int32(1)
-                    if py1 >= IMAGE_HEIGHT:
-                        py1 = IMAGE_HEIGHT - wp.int32(1)
-                    observed1 = depth_images[best_cam, py1, px1]
-                    if observed1 > 0.0 and z1 > observed1 + occlusion_tolerance_m:
-                        all_valid = False
-                    else:
+                    px1 = wp.int32(wp.floor(u1))
+                    py1 = wp.int32(wp.floor(vv1))
+                    depth1 = visibility_depths[best_cam, py1, px1]
+                    if texture_depth_z_visible(
+                        depth1,
+                        z1,
+                        texture_depth_tolerance_m,
+                        tsdf.voxel_size,
+                    ):
                         uv1 = wp.vec2(
                             (atlas_x_offset + u1) / atlas_width,
-                            vv1 / wp.float32(IMAGE_HEIGHT),
+                            (atlas_y_offset + vv1) / atlas_height,
                         )
+                    else:
+                        all_valid = False
                 else:
                     all_valid = False
             else:
@@ -3013,7 +851,7 @@ def make_mesh_kernels(
 
             p2_cam = wp.quat_rotate(cam_quat_inv, v2 - cam_pos)
             z2 = p2_cam[2]
-            if all_valid and z2 > depth_min and z2 <= depth_max:
+            if all_valid and z2 > camera_min_distance and z2 <= camera_max_distance:
                 u2 = fx * p2_cam[0] / z2 + cx
                 vv2 = fy * p2_cam[1] / z2 + cy
                 if (
@@ -3022,38 +860,42 @@ def make_mesh_kernels(
                     and vv2 >= 0.0
                     and vv2 < wp.float32(IMAGE_HEIGHT)
                 ):
-                    px2 = wp.int32(u2 + 0.5)
-                    py2 = wp.int32(vv2 + 0.5)
-                    if px2 >= IMAGE_WIDTH:
-                        px2 = IMAGE_WIDTH - wp.int32(1)
-                    if py2 >= IMAGE_HEIGHT:
-                        py2 = IMAGE_HEIGHT - wp.int32(1)
-                    observed2 = depth_images[best_cam, py2, px2]
-                    if observed2 > 0.0 and z2 > observed2 + occlusion_tolerance_m:
-                        all_valid = False
-                    else:
+                    px2 = wp.int32(wp.floor(u2))
+                    py2 = wp.int32(wp.floor(vv2))
+                    depth2 = visibility_depths[best_cam, py2, px2]
+                    if texture_depth_z_visible(
+                        depth2,
+                        z2,
+                        texture_depth_tolerance_m,
+                        tsdf.voxel_size,
+                    ):
                         uv2 = wp.vec2(
                             (atlas_x_offset + u2) / atlas_width,
-                            vv2 / wp.float32(IMAGE_HEIGHT),
+                            (atlas_y_offset + vv2) / atlas_height,
                         )
+                    else:
+                        all_valid = False
                 else:
                     all_valid = False
             else:
                 all_valid = False
 
             if all_valid:
-                vertex_uvs[base] = uv0
-                vertex_uvs[base + wp.int32(1)] = uv1
-                vertex_uvs[base + wp.int32(2)] = uv2
+                if best_score > projection_scores[tri_idx]:
+                    vertex_uvs[base] = uv0
+                    vertex_uvs[base + wp.int32(1)] = uv1
+                    vertex_uvs[base + wp.int32(2)] = uv2
+                    projection_scores[tri_idx] = best_score
                 projected = True
                 break
 
             score_limit = best_score - wp.float32(1.0e-6)
 
         if not projected:
-            vertex_uvs[base] = invalid_uv
-            vertex_uvs[base + wp.int32(1)] = invalid_uv
-            vertex_uvs[base + wp.int32(2)] = invalid_uv
+            if projection_scores[tri_idx] < wp.float32(-1.0e19):
+                vertex_uvs[base] = invalid_uv
+                vertex_uvs[base + wp.int32(1)] = invalid_uv
+                vertex_uvs[base + wp.int32(2)] = invalid_uv
             if fill_missing_colors != wp.int32(0):
                 c0 = sample_rgb(tsdf, v0)
                 c1 = sample_rgb(tsdf, v1)
@@ -3111,24 +953,11 @@ def make_mesh_kernels(
 
     # Expose kernels on the instance.
     return {
-        "count_surface_cubes_kernel": count_surface_cubes_kernel,
         "append_active_blocks_kernel": append_active_blocks_kernel,
         "count_surface_cubes_from_blocks_kernel": count_surface_cubes_from_blocks_kernel,
-        "append_surface_cubes_kernel": append_surface_cubes_kernel,
         "append_surface_cubes_from_blocks_kernel": append_surface_cubes_from_blocks_kernel,
-        "count_edges_block_sparse_kernel": count_edges_block_sparse_kernel,
-        "generate_vertices_block_sparse_kernel": generate_vertices_block_sparse_kernel,
-        "generate_triangles_shared_kernel": generate_triangles_shared_kernel,
-        "count_triangles_kernel": count_triangles_kernel,
         "count_total_triangles_kernel": count_total_triangles_kernel,
-        "generate_approximate_mesh_block_sparse_kernel": generate_approximate_mesh_block_sparse_kernel,
-        "generate_approximate_mesh_atomic_kernel": generate_approximate_mesh_atomic_kernel,
-        "generate_approximate_mesh_current_state_kernel": (
-            generate_approximate_mesh_current_state_kernel
-        ),
-        "count_fast_mesh_block_triangles_kernel": count_fast_mesh_block_triangles_kernel,
-        "generate_fast_mesh_current_state_kernel": generate_fast_mesh_current_state_kernel,
-        "copy_rgb_images_to_texture_atlas_kernel": copy_rgb_images_to_texture_atlas_kernel,
-        "project_fast_mesh_uvs_kernel": project_fast_mesh_uvs_kernel,
+        "generate_mesh_kernel": generate_mesh_kernel,
+        "project_mesh_uvs_kernel": project_mesh_uvs_kernel,
         "sample_vertex_colors_kernel": sample_vertex_colors_kernel,
     }

--- a/curobo/_src/perception/mapper/kernel/builder/builder_mesh.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_mesh.py
@@ -34,7 +34,6 @@ def make_mesh_kernels(
     image_height: int = 1,
     image_width: int = 1,
     hash_lookup,
-    compute_avg_rgb_uint8_from_block,
     sample_rgb,
     sample_voxel,
     sample_tsdf_trilinear,
@@ -42,14 +41,12 @@ def make_mesh_kernels(
     compute_gradient_nearest,
     block_grid_to_key_coords,
     block_key_to_voxel_base,
-    use_color_grid: bool = False,
 ) -> dict[str, object]:
     """Build block-sparse marching-cubes kernels."""
     BS = wp.constant(block_size)
     NUM_CAMERAS = wp.constant(num_cameras)
     IMAGE_HEIGHT = wp.constant(image_height)
     IMAGE_WIDTH = wp.constant(image_width)
-    USE_COLOR_GRID = wp.constant(bool(use_color_grid))
 
     # Cross-domain helpers are explicit parameters so Warp sees them as
     # local closure bindings when compiling dependent functions.
@@ -1099,7 +1096,7 @@ def make_mesh_kernels(
             * tsdf.voxel_size
         )
 
-        rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+        rgb = sample_rgb(tsdf, (p0 + p6) * wp.float32(0.5))
         color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
 
         tri_base = tri_offsets[tid]
@@ -1304,7 +1301,7 @@ def make_mesh_kernels(
             * tsdf.voxel_size
         )
 
-        rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+        rgb = sample_rgb(tsdf, (p0 + p6) * wp.float32(0.5))
         color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
 
         table_offset = cube_config * 16
@@ -1610,7 +1607,7 @@ def make_mesh_kernels(
 
             color_bs1 = wp.vec3ub(wp.uint8(0), wp.uint8(0), wp.uint8(0))
             if write_colors_bs1:
-                rgb_bs1 = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+                rgb_bs1 = sample_rgb(tsdf, (p0_bs1 + p6_bs1) * wp.float32(0.5))
                 color_bs1 = wp.vec3ub(
                     wp.uint8(rgb_bs1[0]), wp.uint8(rgb_bs1[1]), wp.uint8(rgb_bs1[2])
                 )
@@ -1924,7 +1921,7 @@ def make_mesh_kernels(
 
         color = wp.vec3ub(wp.uint8(0), wp.uint8(0), wp.uint8(0))
         if write_colors:
-            rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+            rgb = sample_rgb(tsdf, (p0 + p6) * wp.float32(0.5))
             color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
 
         for t in range(5):
@@ -2396,11 +2393,10 @@ def make_mesh_kernels(
 
             color_g = wp.vec3ub(wp.uint8(128), wp.uint8(128), wp.uint8(128))
             if use_voxel_colors != wp.int32(0):
-                if not USE_COLOR_GRID:
-                    rgb_g = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
-                    color_g = wp.vec3ub(
-                        wp.uint8(rgb_g[0]), wp.uint8(rgb_g[1]), wp.uint8(rgb_g[2])
-                    )
+                rgb_g = sample_rgb(tsdf, (p0_g + p6_g) * wp.float32(0.5))
+                color_g = wp.vec3ub(
+                    wp.uint8(rgb_g[0]), wp.uint8(rgb_g[1]), wp.uint8(rgb_g[2])
+                )
 
             for t in range(5):
                 if wp.int32(t) >= write_tris_g:
@@ -2483,28 +2479,23 @@ def make_mesh_kernels(
                     triangles[vertex_id0_g] = vertex_id0_g
                     triangles[vertex_id1_g] = vertex_id1_g
                     triangles[vertex_id2_g] = vertex_id2_g
-                if USE_COLOR_GRID:
-                    if use_voxel_colors == wp.int32(0):
-                        colors[vertex_id0_g] = color_g
-                        colors[vertex_id1_g] = color_g
-                        colors[vertex_id2_g] = color_g
-                        continue
-                    c0_g = sample_rgb(tsdf, v0_g)
-                    c1_g = sample_rgb(tsdf, v1_g)
-                    c2_g = sample_rgb(tsdf, v2_g)
-                    colors[vertex_id0_g] = wp.vec3ub(
-                        wp.uint8(c0_g[0]), wp.uint8(c0_g[1]), wp.uint8(c0_g[2])
-                    )
-                    colors[vertex_id1_g] = wp.vec3ub(
-                        wp.uint8(c1_g[0]), wp.uint8(c1_g[1]), wp.uint8(c1_g[2])
-                    )
-                    colors[vertex_id2_g] = wp.vec3ub(
-                        wp.uint8(c2_g[0]), wp.uint8(c2_g[1]), wp.uint8(c2_g[2])
-                    )
-                else:
+                if use_voxel_colors == wp.int32(0):
                     colors[vertex_id0_g] = color_g
                     colors[vertex_id1_g] = color_g
                     colors[vertex_id2_g] = color_g
+                    continue
+                c0_g = sample_rgb(tsdf, v0_g)
+                c1_g = sample_rgb(tsdf, v1_g)
+                c2_g = sample_rgb(tsdf, v2_g)
+                colors[vertex_id0_g] = wp.vec3ub(
+                    wp.uint8(c0_g[0]), wp.uint8(c0_g[1]), wp.uint8(c0_g[2])
+                )
+                colors[vertex_id1_g] = wp.vec3ub(
+                    wp.uint8(c1_g[0]), wp.uint8(c1_g[1]), wp.uint8(c1_g[2])
+                )
+                colors[vertex_id2_g] = wp.vec3ub(
+                    wp.uint8(c2_g[0]), wp.uint8(c2_g[1]), wp.uint8(c2_g[2])
+                )
 
             return
 
@@ -2728,9 +2719,8 @@ def make_mesh_kernels(
 
         color = wp.vec3ub(wp.uint8(128), wp.uint8(128), wp.uint8(128))
         if use_voxel_colors != wp.int32(0):
-            if not USE_COLOR_GRID:
-                rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
-                color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
+            rgb = sample_rgb(tsdf, (p0 + p6) * wp.float32(0.5))
+            color = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
 
         for t in range(5):
             if wp.int32(t) >= write_tris:
@@ -2813,28 +2803,23 @@ def make_mesh_kernels(
                 triangles[vertex_id0] = vertex_id0
                 triangles[vertex_id1] = vertex_id1
                 triangles[vertex_id2] = vertex_id2
-            if USE_COLOR_GRID:
-                if use_voxel_colors == wp.int32(0):
-                    colors[vertex_id0] = color
-                    colors[vertex_id1] = color
-                    colors[vertex_id2] = color
-                    continue
-                c0 = sample_rgb(tsdf, v0)
-                c1 = sample_rgb(tsdf, v1)
-                c2 = sample_rgb(tsdf, v2)
-                colors[vertex_id0] = wp.vec3ub(
-                    wp.uint8(c0[0]), wp.uint8(c0[1]), wp.uint8(c0[2])
-                )
-                colors[vertex_id1] = wp.vec3ub(
-                    wp.uint8(c1[0]), wp.uint8(c1[1]), wp.uint8(c1[2])
-                )
-                colors[vertex_id2] = wp.vec3ub(
-                    wp.uint8(c2[0]), wp.uint8(c2[1]), wp.uint8(c2[2])
-                )
-            else:
+            if use_voxel_colors == wp.int32(0):
                 colors[vertex_id0] = color
                 colors[vertex_id1] = color
                 colors[vertex_id2] = color
+                continue
+            c0 = sample_rgb(tsdf, v0)
+            c1 = sample_rgb(tsdf, v1)
+            c2 = sample_rgb(tsdf, v2)
+            colors[vertex_id0] = wp.vec3ub(
+                wp.uint8(c0[0]), wp.uint8(c0[1]), wp.uint8(c0[2])
+            )
+            colors[vertex_id1] = wp.vec3ub(
+                wp.uint8(c1[0]), wp.uint8(c1[1]), wp.uint8(c1[2])
+            )
+            colors[vertex_id2] = wp.vec3ub(
+                wp.uint8(c2[0]), wp.uint8(c2[1]), wp.uint8(c2[2])
+            )
 
     # =====================================================================
     # Projective texture mapping for fast triangle-list meshes
@@ -3119,14 +3104,10 @@ def make_mesh_kernels(
             colors[tid] = wp.vec3ub(wp.uint8(128), wp.uint8(128), wp.uint8(128))
             return
 
-        if USE_COLOR_GRID:
-            rgb_grid = sample_rgb(tsdf, pos)
-            colors[tid] = wp.vec3ub(
-                wp.uint8(rgb_grid[0]), wp.uint8(rgb_grid[1]), wp.uint8(rgb_grid[2])
-            )
-        else:
-            rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, pool_idx)
-            colors[tid] = wp.vec3ub(wp.uint8(rgb[0]), wp.uint8(rgb[1]), wp.uint8(rgb[2]))
+        rgb_grid = sample_rgb(tsdf, pos)
+        colors[tid] = wp.vec3ub(
+            wp.uint8(rgb_grid[0]), wp.uint8(rgb_grid[1]), wp.uint8(rgb_grid[2])
+        )
 
     # Expose kernels on the instance.
     return {

--- a/curobo/_src/perception/mapper/kernel/builder/builder_raycast.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_raycast.py
@@ -23,10 +23,6 @@ from __future__ import annotations
 import warp as wp
 
 from curobo._src.perception.mapper.kernel.warp_types import BlockSparseTSDFWarp
-from curobo._src.perception.mapper.kernel.wp_integrate_common import (
-    quat_from_wxyz_array,
-    vec3_from_array,
-)
 from curobo._src.util.warp import warp_func, warp_kernel
 
 _SDF_INFINITY = wp.constant(wp.float32(1e10))
@@ -320,7 +316,7 @@ def make_raycast_kernels(
         grid_rgbw = sample_block_grid_rgb(tsdf, world_pos, pool_idx, bx, by, bz)
         grid_w = grid_rgbw[3]
         if grid_w <= wp.float32(1.0e-6):
-            return wp.vec3(0.0, 0.0, 0.0)
+            return wp.vec3(128.0, 128.0, 128.0)
         inv_w = wp.float32(255.0) / grid_w
         return wp.vec3(
             wp.clamp(grid_rgbw[0] * inv_w, wp.float32(0.0), wp.float32(255.0)),
@@ -514,75 +510,67 @@ def make_raycast_kernels(
 
         return wp.min(wp.min(t_max_x, t_max_y), t_max_z)
 
-    # =====================================================================
-    # Raycast kernels (4)
-    # =====================================================================
-
-    @warp_kernel(f"raycast_block_sparse_kernel_bs{block_size}")
-    def raycast_block_sparse_kernel(
-        intrinsics: wp.array2d(dtype=wp.float32),
-        cam_position: wp.array(dtype=wp.float32),
-        cam_quaternion: wp.array(dtype=wp.float32),
+    @warp_func(f"raycast_hit_t_bs{block_size}")
+    def raycast_hit_t(
         tsdf: BlockSparseTSDFWarp,
-        depth_minimum_distance: float,
-        depth_maximum_distance: float,
-        minimum_tsdf_weight: float,
-        hit_points: wp.array2d(dtype=wp.float32),
-        hit_normals: wp.array2d(dtype=wp.float32),
-        hit_depths: wp.array(dtype=wp.float32),
-        hit_mask: wp.array(dtype=wp.uint8),
-        img_H: int,
-        img_W: int,
-    ):
-        """Raycast block-sparse TSDF (depth + normals)."""
-        tid = wp.tid()
-
-        hit_points[tid, 0] = 0.0
-        hit_points[tid, 1] = 0.0
-        hit_points[tid, 2] = 0.0
-        hit_normals[tid, 0] = 0.0
-        hit_normals[tid, 1] = 0.0
-        hit_normals[tid, 2] = 0.0
-        hit_depths[tid] = 0.0
-        hit_mask[tid] = wp.uint8(0)
-
-        px = tid % img_W
-        py = tid // img_W
-        if py >= img_H:
-            return
-
-        fx = intrinsics[0, 0]
-        fy = intrinsics[1, 1]
-        cx = intrinsics[0, 2]
-        cy = intrinsics[1, 2]
-
-        cam_pos = vec3_from_array(cam_position)
-        cam_quat = quat_from_wxyz_array(cam_quaternion)
-
-        ray_cam_x = (wp.float32(px) + 0.5 - cx) / fx
-        ray_cam_y = (wp.float32(py) + 0.5 - cy) / fy
-        ray_cam_z = 1.0
-
-        ray_len = wp.sqrt(ray_cam_x * ray_cam_x + ray_cam_y * ray_cam_y + ray_cam_z * ray_cam_z)
-        ray_cam = wp.vec3(ray_cam_x / ray_len, ray_cam_y / ray_len, ray_cam_z / ray_len)
-        ray_world = wp.quat_rotate(cam_quat, ray_cam)
-
+        cam_pos: wp.vec3,
+        ray_world: wp.vec3,
+        depth_minimum_distance: wp.float32,
+        depth_maximum_distance: wp.float32,
+        minimum_tsdf_weight: wp.float32,
+    ) -> wp.vec2:
+        """Raymarch through allocated blocks and return ``(hit_t, valid)``."""
         step_size = tsdf.voxel_size * MIN_STEP_SCALE
-        max_steps = wp.int32((depth_maximum_distance - depth_minimum_distance) / step_size) + 1
-        max_steps = wp.min(max_steps, 10000)
 
         t = float(depth_minimum_distance)
         prev_sdf = float(1e10)
         prev_t = float(depth_minimum_distance)
 
-        hit_found = bool(False)
-        hit_t = float(0.0)
+        curr_bx = wp.int32(-999999)
+        curr_by = wp.int32(-999999)
+        curr_bz = wp.int32(-999999)
+        curr_block_allocated = bool(False)
+        curr_block_exit_t = float(0.0)
 
-        for step in range(max_steps):
+        max_iterations = 10000
+
+        for iteration in range(max_iterations):
             if t > depth_maximum_distance:
                 break
 
             pos = cam_pos + ray_world * t
+
+            block_coords = world_to_block_coords(pos)
+            bx = block_coords[0]
+            by = block_coords[1]
+            bz = block_coords[2]
+
+            if bx != curr_bx or by != curr_by or bz != curr_bz:
+                curr_bx = bx
+                curr_by = by
+                curr_bz = bz
+
+                block_idx = hash_lookup(
+                    tsdf.hash_table,
+                    bx,
+                    by,
+                    bz,
+                    tsdf.hash_capacity,
+                )
+                curr_block_allocated = block_idx >= 0
+
+                curr_block_exit_t = ray_block_exit_t(
+                    cam_pos,
+                    ray_world,
+                    bx,
+                    by,
+                    bz,
+                )
+
+            if not curr_block_allocated:
+                t = curr_block_exit_t + step_size
+                prev_sdf = 1e10
+                continue
 
             sdf_result = sample_tsdf_trilinear(tsdf, pos, minimum_tsdf_weight)
             sdf = sdf_result[0]
@@ -603,15 +591,94 @@ def make_raycast_kernels(
                     sdf,
                     minimum_tsdf_weight,
                 )
-                hit_found = True
-                break
+                return wp.vec2(hit_t, 1.0)
 
             prev_sdf = sdf
             prev_t = t
             t += step_size
 
-        if not hit_found:
+        return wp.vec2(0.0, 0.0)
+
+    # =====================================================================
+    # Raycast kernels (2)
+    # =====================================================================
+
+    @warp_kernel(f"raycast_block_sparse_kernel_bs{block_size}")
+    def raycast_block_sparse_kernel(
+        intrinsics: wp.array3d(dtype=wp.float32),
+        cam_positions: wp.array2d(dtype=wp.float32),
+        cam_quaternions: wp.array2d(dtype=wp.float32),
+        tsdf: BlockSparseTSDFWarp,
+        depth_minimum_distance: float,
+        depth_maximum_distance: float,
+        minimum_tsdf_weight: float,
+        hit_points: wp.array2d(dtype=wp.float32),
+        hit_normals: wp.array2d(dtype=wp.float32),
+        hit_depths: wp.array(dtype=wp.float32),
+        hit_mask: wp.array(dtype=wp.uint8),
+        img_H: int,
+        img_W: int,
+        pixels_per_camera: int,
+    ):
+        """Raycast block-sparse TSDF (depth + normals)."""
+        tid = wp.tid()
+
+        hit_points[tid, 0] = 0.0
+        hit_points[tid, 1] = 0.0
+        hit_points[tid, 2] = 0.0
+        hit_normals[tid, 0] = 0.0
+        hit_normals[tid, 1] = 0.0
+        hit_normals[tid, 2] = 0.0
+        hit_depths[tid] = 0.0
+        hit_mask[tid] = wp.uint8(0)
+
+        camera_idx = tid // pixels_per_camera
+        pixel_tid = tid - camera_idx * pixels_per_camera
+
+        px = pixel_tid % img_W
+        py = pixel_tid // img_W
+        if py >= img_H:
             return
+
+        fx = intrinsics[camera_idx, 0, 0]
+        fy = intrinsics[camera_idx, 1, 1]
+        cx = intrinsics[camera_idx, 0, 2]
+        cy = intrinsics[camera_idx, 1, 2]
+
+        cam_pos = wp.vec3(
+            cam_positions[camera_idx, 0],
+            cam_positions[camera_idx, 1],
+            cam_positions[camera_idx, 2],
+        )
+        cam_quat = wp.quat(
+            cam_quaternions[camera_idx, 1],
+            cam_quaternions[camera_idx, 2],
+            cam_quaternions[camera_idx, 3],
+            cam_quaternions[camera_idx, 0],
+        )
+
+        ray_cam_x = (wp.float32(px) + 0.5 - cx) / fx
+        ray_cam_y = (wp.float32(py) + 0.5 - cy) / fy
+        ray_cam_z_raw = 1.0
+
+        ray_len = wp.sqrt(
+            ray_cam_x * ray_cam_x + ray_cam_y * ray_cam_y + ray_cam_z_raw * ray_cam_z_raw
+        )
+        ray_cam_z = ray_cam_z_raw / ray_len
+        ray_cam = wp.vec3(ray_cam_x / ray_len, ray_cam_y / ray_len, ray_cam_z)
+        ray_world = wp.quat_rotate(cam_quat, ray_cam)
+
+        hit = raycast_hit_t(
+            tsdf,
+            cam_pos,
+            ray_world,
+            depth_minimum_distance,
+            depth_maximum_distance,
+            minimum_tsdf_weight,
+        )
+        if hit[1] < 0.5:
+            return
+        hit_t = hit[0]
 
         hit_pos = cam_pos + ray_world * hit_t
         normal = compute_gradient(tsdf, hit_pos, minimum_tsdf_weight)
@@ -628,9 +695,9 @@ def make_raycast_kernels(
 
     @warp_kernel(f"raycast_block_sparse_color_kernel_bs{block_size}")
     def raycast_block_sparse_color_kernel(
-        intrinsics: wp.array2d(dtype=wp.float32),
-        cam_position: wp.array(dtype=wp.float32),
-        cam_quaternion: wp.array(dtype=wp.float32),
+        intrinsics: wp.array3d(dtype=wp.float32),
+        cam_positions: wp.array2d(dtype=wp.float32),
+        cam_quaternions: wp.array2d(dtype=wp.float32),
         tsdf: BlockSparseTSDFWarp,
         depth_minimum_distance: float,
         depth_maximum_distance: float,
@@ -642,6 +709,7 @@ def make_raycast_kernels(
         hit_mask: wp.array(dtype=wp.uint8),
         img_H: int,
         img_W: int,
+        pixels_per_camera: int,
     ):
         """Raycast block-sparse TSDF with color output."""
         tid = wp.tid()
@@ -658,371 +726,53 @@ def make_raycast_kernels(
         hit_depths[tid] = 0.0
         hit_mask[tid] = wp.uint8(0)
 
-        px = tid % img_W
-        py = tid // img_W
+        camera_idx = tid // pixels_per_camera
+        pixel_tid = tid - camera_idx * pixels_per_camera
+
+        px = pixel_tid % img_W
+        py = pixel_tid // img_W
         if py >= img_H:
             return
 
-        fx = intrinsics[0, 0]
-        fy = intrinsics[1, 1]
-        cx = intrinsics[0, 2]
-        cy = intrinsics[1, 2]
+        fx = intrinsics[camera_idx, 0, 0]
+        fy = intrinsics[camera_idx, 1, 1]
+        cx = intrinsics[camera_idx, 0, 2]
+        cy = intrinsics[camera_idx, 1, 2]
 
-        cam_pos = vec3_from_array(cam_position)
-        cam_quat = quat_from_wxyz_array(cam_quaternion)
-
-        ray_cam_x = (wp.float32(px) + 0.5 - cx) / fx
-        ray_cam_y = (wp.float32(py) + 0.5 - cy) / fy
-        ray_cam_z = 1.0
-
-        ray_len = wp.sqrt(ray_cam_x * ray_cam_x + ray_cam_y * ray_cam_y + ray_cam_z * ray_cam_z)
-        ray_cam = wp.vec3(ray_cam_x / ray_len, ray_cam_y / ray_len, ray_cam_z / ray_len)
-        ray_world = wp.quat_rotate(cam_quat, ray_cam)
-
-        step_size = tsdf.voxel_size * MIN_STEP_SCALE
-        max_steps = wp.int32((depth_maximum_distance - depth_minimum_distance) / step_size) + 1
-        max_steps = wp.min(max_steps, 200000)
-
-        t = float(depth_minimum_distance)
-        prev_sdf = float(1e10)
-        prev_t = float(depth_minimum_distance)
-
-        hit_found = bool(False)
-        hit_t = float(0.0)
-
-        for step in range(max_steps):
-            if t > depth_maximum_distance:
-                break
-
-            pos = cam_pos + ray_world * t
-            sdf_result = sample_tsdf_trilinear(tsdf, pos, minimum_tsdf_weight)
-            sdf = sdf_result[0]
-            valid = sdf_result[1]
-
-            if valid < 0.5:
-                t += step_size
-                continue
-
-            if prev_sdf < 1e9 and prev_sdf > 0.0 and sdf < 0.0:
-                hit_t = refine_hit_bisection(
-                    tsdf,
-                    cam_pos,
-                    ray_world,
-                    prev_t,
-                    t,
-                    prev_sdf,
-                    sdf,
-                    minimum_tsdf_weight,
-                )
-                hit_found = True
-                break
-
-            prev_sdf = sdf
-            prev_t = t
-            t += step_size
-
-        if not hit_found:
-            return
-
-        hit_pos = cam_pos + ray_world * hit_t
-        normal = compute_gradient(tsdf, hit_pos, minimum_tsdf_weight)
-        color = sample_rgb(tsdf, hit_pos)
-        z_depth = hit_t * ray_cam_z
-
-        hit_points[tid, 0] = hit_pos[0]
-        hit_points[tid, 1] = hit_pos[1]
-        hit_points[tid, 2] = hit_pos[2]
-        hit_normals[tid, 0] = normal[0]
-        hit_normals[tid, 1] = normal[1]
-        hit_normals[tid, 2] = normal[2]
-        hit_colors[tid, 0] = wp.uint8(color[0])
-        hit_colors[tid, 1] = wp.uint8(color[1])
-        hit_colors[tid, 2] = wp.uint8(color[2])
-        hit_depths[tid] = z_depth
-        hit_mask[tid] = wp.uint8(1)
-
-    @warp_kernel(f"raycast_block_sparse_accelerated_kernel_bs{block_size}")
-    def raycast_block_sparse_accelerated_kernel(
-        intrinsics: wp.array2d(dtype=wp.float32),
-        cam_position: wp.array(dtype=wp.float32),
-        cam_quaternion: wp.array(dtype=wp.float32),
-        tsdf: BlockSparseTSDFWarp,
-        depth_minimum_distance: float,
-        depth_maximum_distance: float,
-        minimum_tsdf_weight: float,
-        hit_points: wp.array2d(dtype=wp.float32),
-        hit_normals: wp.array2d(dtype=wp.float32),
-        hit_depths: wp.array(dtype=wp.float32),
-        hit_mask: wp.array(dtype=wp.uint8),
-        img_H: int,
-        img_W: int,
-    ):
-        """Block-accelerated raycast (skip unallocated blocks)."""
-        tid = wp.tid()
-
-        hit_points[tid, 0] = 0.0
-        hit_points[tid, 1] = 0.0
-        hit_points[tid, 2] = 0.0
-        hit_normals[tid, 0] = 0.0
-        hit_normals[tid, 1] = 0.0
-        hit_normals[tid, 2] = 0.0
-        hit_depths[tid] = 0.0
-        hit_mask[tid] = wp.uint8(0)
-
-        px = tid % img_W
-        py = tid // img_W
-        if py >= img_H:
-            return
-
-        fx = intrinsics[0, 0]
-        fy = intrinsics[1, 1]
-        cx = intrinsics[0, 2]
-        cy = intrinsics[1, 2]
-
-        cam_pos = vec3_from_array(cam_position)
-        cam_quat = quat_from_wxyz_array(cam_quaternion)
+        cam_pos = wp.vec3(
+            cam_positions[camera_idx, 0],
+            cam_positions[camera_idx, 1],
+            cam_positions[camera_idx, 2],
+        )
+        cam_quat = wp.quat(
+            cam_quaternions[camera_idx, 1],
+            cam_quaternions[camera_idx, 2],
+            cam_quaternions[camera_idx, 3],
+            cam_quaternions[camera_idx, 0],
+        )
 
         ray_cam_x = (wp.float32(px) + 0.5 - cx) / fx
         ray_cam_y = (wp.float32(py) + 0.5 - cy) / fy
-        ray_cam_z = 1.0
+        ray_cam_z_raw = 1.0
 
-        ray_len = wp.sqrt(ray_cam_x * ray_cam_x + ray_cam_y * ray_cam_y + ray_cam_z * ray_cam_z)
-        ray_cam = wp.vec3(ray_cam_x / ray_len, ray_cam_y / ray_len, ray_cam_z / ray_len)
+        ray_len = wp.sqrt(
+            ray_cam_x * ray_cam_x + ray_cam_y * ray_cam_y + ray_cam_z_raw * ray_cam_z_raw
+        )
+        ray_cam_z = ray_cam_z_raw / ray_len
+        ray_cam = wp.vec3(ray_cam_x / ray_len, ray_cam_y / ray_len, ray_cam_z)
         ray_world = wp.quat_rotate(cam_quat, ray_cam)
 
-        step_size = tsdf.voxel_size * MIN_STEP_SCALE
-
-        t = float(depth_minimum_distance)
-        prev_sdf = float(1e10)
-        prev_t = float(depth_minimum_distance)
-
-        hit_found = bool(False)
-        hit_t = float(0.0)
-
-        curr_bx = wp.int32(-999999)
-        curr_by = wp.int32(-999999)
-        curr_bz = wp.int32(-999999)
-        curr_block_allocated = bool(False)
-        curr_block_exit_t = float(0.0)
-
-        max_iterations = 10000
-
-        for iteration in range(max_iterations):
-            if t > depth_maximum_distance:
-                break
-
-            pos = cam_pos + ray_world * t
-
-            block_coords = world_to_block_coords(pos)
-            bx = block_coords[0]
-            by = block_coords[1]
-            bz = block_coords[2]
-
-            if bx != curr_bx or by != curr_by or bz != curr_bz:
-                curr_bx = bx
-                curr_by = by
-                curr_bz = bz
-
-                block_idx = hash_lookup(
-                    tsdf.hash_table,
-                    bx,
-                    by,
-                    bz,
-                    tsdf.hash_capacity,
-                )
-                curr_block_allocated = block_idx >= 0
-
-                curr_block_exit_t = ray_block_exit_t(
-                    cam_pos,
-                    ray_world,
-                    bx,
-                    by,
-                    bz,
-                )
-
-            if not curr_block_allocated:
-                t = curr_block_exit_t + step_size
-                prev_sdf = 1e10
-                continue
-
-            sdf_result = sample_tsdf_trilinear(tsdf, pos, minimum_tsdf_weight)
-            sdf = sdf_result[0]
-            valid = sdf_result[1]
-
-            if valid < 0.5:
-                t += step_size
-                continue
-
-            if prev_sdf < 1e9 and prev_sdf > 0.0 and sdf < 0.0:
-                hit_t = refine_hit_bisection(
-                    tsdf,
-                    cam_pos,
-                    ray_world,
-                    prev_t,
-                    t,
-                    prev_sdf,
-                    sdf,
-                    minimum_tsdf_weight,
-                )
-                hit_found = True
-                break
-
-            prev_sdf = sdf
-            prev_t = t
-            t += step_size
-
-        if not hit_found:
+        hit = raycast_hit_t(
+            tsdf,
+            cam_pos,
+            ray_world,
+            depth_minimum_distance,
+            depth_maximum_distance,
+            minimum_tsdf_weight,
+        )
+        if hit[1] < 0.5:
             return
-
-        hit_pos = cam_pos + ray_world * hit_t
-        normal = compute_gradient(tsdf, hit_pos, minimum_tsdf_weight)
-        z_depth = hit_t * ray_cam_z
-
-        hit_points[tid, 0] = hit_pos[0]
-        hit_points[tid, 1] = hit_pos[1]
-        hit_points[tid, 2] = hit_pos[2]
-        hit_normals[tid, 0] = normal[0]
-        hit_normals[tid, 1] = normal[1]
-        hit_normals[tid, 2] = normal[2]
-        hit_depths[tid] = z_depth
-        hit_mask[tid] = wp.uint8(1)
-
-    @warp_kernel(f"raycast_block_sparse_accelerated_color_kernel_bs{block_size}")
-    def raycast_block_sparse_accelerated_color_kernel(
-        intrinsics: wp.array2d(dtype=wp.float32),
-        cam_position: wp.array(dtype=wp.float32),
-        cam_quaternion: wp.array(dtype=wp.float32),
-        tsdf: BlockSparseTSDFWarp,
-        depth_minimum_distance: float,
-        depth_maximum_distance: float,
-        minimum_tsdf_weight: float,
-        hit_points: wp.array2d(dtype=wp.float32),
-        hit_normals: wp.array2d(dtype=wp.float32),
-        hit_colors: wp.array2d(dtype=wp.uint8),
-        hit_depths: wp.array(dtype=wp.float32),
-        hit_mask: wp.array(dtype=wp.uint8),
-        img_H: int,
-        img_W: int,
-    ):
-        """Block-accelerated raycast with color output."""
-        tid = wp.tid()
-
-        hit_points[tid, 0] = 0.0
-        hit_points[tid, 1] = 0.0
-        hit_points[tid, 2] = 0.0
-        hit_normals[tid, 0] = 0.0
-        hit_normals[tid, 1] = 0.0
-        hit_normals[tid, 2] = 0.0
-        hit_colors[tid, 0] = wp.uint8(0)
-        hit_colors[tid, 1] = wp.uint8(0)
-        hit_colors[tid, 2] = wp.uint8(0)
-        hit_depths[tid] = 0.0
-        hit_mask[tid] = wp.uint8(0)
-
-        px = tid % img_W
-        py = tid // img_W
-        if py >= img_H:
-            return
-
-        fx = intrinsics[0, 0]
-        fy = intrinsics[1, 1]
-        cx = intrinsics[0, 2]
-        cy = intrinsics[1, 2]
-
-        cam_pos = vec3_from_array(cam_position)
-        cam_quat = quat_from_wxyz_array(cam_quaternion)
-
-        ray_cam_x = (wp.float32(px) + 0.5 - cx) / fx
-        ray_cam_y = (wp.float32(py) + 0.5 - cy) / fy
-        ray_cam_z = 1.0
-
-        ray_len = wp.sqrt(ray_cam_x * ray_cam_x + ray_cam_y * ray_cam_y + ray_cam_z * ray_cam_z)
-        ray_cam = wp.vec3(ray_cam_x / ray_len, ray_cam_y / ray_len, ray_cam_z / ray_len)
-        ray_world = wp.quat_rotate(cam_quat, ray_cam)
-
-        step_size = tsdf.voxel_size * MIN_STEP_SCALE
-
-        t = float(depth_minimum_distance)
-        prev_sdf = float(1e10)
-        prev_t = float(depth_minimum_distance)
-
-        hit_found = bool(False)
-        hit_t = float(0.0)
-
-        curr_bx = wp.int32(-999999)
-        curr_by = wp.int32(-999999)
-        curr_bz = wp.int32(-999999)
-        curr_block_allocated = bool(False)
-        curr_block_exit_t = float(0.0)
-
-        max_iterations = 10000
-
-        for iteration in range(max_iterations):
-            if t > depth_maximum_distance:
-                break
-
-            pos = cam_pos + ray_world * t
-
-            block_coords = world_to_block_coords(pos)
-            bx = block_coords[0]
-            by = block_coords[1]
-            bz = block_coords[2]
-
-            if bx != curr_bx or by != curr_by or bz != curr_bz:
-                curr_bx = bx
-                curr_by = by
-                curr_bz = bz
-
-                block_idx = hash_lookup(
-                    tsdf.hash_table,
-                    bx,
-                    by,
-                    bz,
-                    tsdf.hash_capacity,
-                )
-                curr_block_allocated = block_idx >= 0
-
-                curr_block_exit_t = ray_block_exit_t(
-                    cam_pos,
-                    ray_world,
-                    bx,
-                    by,
-                    bz,
-                )
-
-            if not curr_block_allocated:
-                t = curr_block_exit_t + step_size
-                prev_sdf = 1e10
-                continue
-
-            sdf_result = sample_tsdf_trilinear(tsdf, pos, minimum_tsdf_weight)
-            sdf = sdf_result[0]
-            valid = sdf_result[1]
-
-            if valid < 0.5:
-                t += step_size
-                continue
-
-            if prev_sdf < 1e9 and prev_sdf > 0.0 and sdf < 0.0:
-                hit_t = refine_hit_bisection(
-                    tsdf,
-                    cam_pos,
-                    ray_world,
-                    prev_t,
-                    t,
-                    prev_sdf,
-                    sdf,
-                    minimum_tsdf_weight,
-                )
-                hit_found = True
-                break
-
-            prev_sdf = sdf
-            prev_t = t
-            t += step_size
-
-        if not hit_found:
-            return
+        hit_t = hit[0]
 
         hit_pos = cam_pos + ray_world * hit_t
         normal = compute_gradient(tsdf, hit_pos, minimum_tsdf_weight)
@@ -1317,10 +1067,6 @@ def make_raycast_kernels(
         "ray_block_exit_t": ray_block_exit_t,
         "raycast_block_sparse_kernel": raycast_block_sparse_kernel,
         "raycast_block_sparse_color_kernel": raycast_block_sparse_color_kernel,
-        "raycast_block_sparse_accelerated_kernel": raycast_block_sparse_accelerated_kernel,
-        "raycast_block_sparse_accelerated_color_kernel": (
-            raycast_block_sparse_accelerated_color_kernel
-        ),
         "count_surface_voxels_kernel": count_surface_voxels_kernel,
         "count_occupied_voxels_kernel": count_occupied_voxels_kernel,
         "count_occupied_voxels_masked_kernel": count_occupied_voxels_masked_kernel,

--- a/curobo/_src/perception/mapper/kernel/builder/builder_raycast.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_raycast.py
@@ -45,9 +45,13 @@ def make_raycast_kernels(
     world_to_block_coords,
     world_to_block_and_local,
     world_to_continuous_voxel,
+    use_color_grid: bool = False,
+    color_grid_size: int = 1,
 ) -> dict[str, object]:
     """Build raycast and voxel-extraction kernels."""
     BS = wp.constant(block_size)
+    USE_COLOR_GRID = wp.constant(bool(use_color_grid))
+    COLOR_GRID_SIZE = wp.constant(wp.int32(color_grid_size))
 
     # Cross-domain helpers are explicit parameters so Warp sees them as
     # local closure bindings when compiling dependent functions.
@@ -257,12 +261,60 @@ def make_raycast_kernels(
         )
         return wp.vec2(sdf, 1.0)
 
-    @warp_func(f"sample_rgb_bs{block_size}")
+    @warp_func(f"sample_block_grid_rgb_bs{block_size}_cg{int(use_color_grid)}_gs{color_grid_size}")
+    def sample_block_grid_rgb(
+        tsdf: BlockSparseTSDFWarp,
+        world_pos: wp.vec3,
+        pool_idx: wp.int32,
+        bx: wp.int32,
+        by: wp.int32,
+        bz: wp.int32,
+    ) -> wp.vec4:
+        """Sample weighted RGBW from the optional per-block RGB grid."""
+        if not USE_COLOR_GRID:
+            return wp.vec4(0.0, 0.0, 0.0, 0.0)
+
+        base = block_key_to_voxel_base(bx, by, bz)
+        voxel_f = world_to_continuous_voxel(world_pos)
+        local_x = voxel_f[0] - wp.float32(base[0])
+        local_y = voxel_f[1] - wp.float32(base[1])
+        local_z = voxel_f[2] - wp.float32(base[2])
+
+        if COLOR_GRID_SIZE <= wp.int32(1) or BS <= wp.int32(1):
+            return wp.vec4(
+                wp.float32(tsdf.block_grid_rgb[pool_idx, 0, 0]),
+                wp.float32(tsdf.block_grid_rgb[pool_idx, 0, 1]),
+                wp.float32(tsdf.block_grid_rgb[pool_idx, 0, 2]),
+                wp.float32(tsdf.block_grid_rgb[pool_idx, 0, 3]),
+            )
+
+        grid_max = wp.float32(COLOR_GRID_SIZE - wp.int32(1))
+        scale = grid_max / wp.float32(BS - wp.int32(1))
+        gx_f = wp.clamp((local_x - wp.float32(0.5)) * scale, wp.float32(0.0), grid_max)
+        gy_f = wp.clamp((local_y - wp.float32(0.5)) * scale, wp.float32(0.0), grid_max)
+        gz_f = wp.clamp((local_z - wp.float32(0.5)) * scale, wp.float32(0.0), grid_max)
+
+        gx = wp.int32(wp.floor(gx_f + wp.float32(0.5)))
+        gy = wp.int32(wp.floor(gy_f + wp.float32(0.5)))
+        gz = wp.int32(wp.floor(gz_f + wp.float32(0.5)))
+        gx = wp.min(wp.max(gx, wp.int32(0)), COLOR_GRID_SIZE - wp.int32(1))
+        gy = wp.min(wp.max(gy, wp.int32(0)), COLOR_GRID_SIZE - wp.int32(1))
+        gz = wp.min(wp.max(gz, wp.int32(0)), COLOR_GRID_SIZE - wp.int32(1))
+        stride_z = COLOR_GRID_SIZE * COLOR_GRID_SIZE
+        idx = gz * stride_z + gy * COLOR_GRID_SIZE + gx
+        return wp.vec4(
+            wp.float32(tsdf.block_grid_rgb[pool_idx, idx, 0]),
+            wp.float32(tsdf.block_grid_rgb[pool_idx, idx, 1]),
+            wp.float32(tsdf.block_grid_rgb[pool_idx, idx, 2]),
+            wp.float32(tsdf.block_grid_rgb[pool_idx, idx, 3]),
+        )
+
+    @warp_func(f"sample_rgb_bs{block_size}_cg{int(use_color_grid)}_gs{color_grid_size}")
     def sample_rgb(
         tsdf: BlockSparseTSDFWarp,
         world_pos: wp.vec3,
     ) -> wp.vec3:
-        """Sample RGB color from TSDF struct (per-block average)."""
+        """Sample RGB color from grid RGB when enabled, else per-block average."""
         coords = world_to_block_and_local(world_pos)
         bx = coords[0]
         by = coords[1]
@@ -271,6 +323,17 @@ def make_raycast_kernels(
         pool_idx = hash_lookup(tsdf.hash_table, bx, by, bz, tsdf.hash_capacity)
         if pool_idx < 0:
             return wp.vec3(0.0, 0.0, 0.0)
+
+        if USE_COLOR_GRID:
+            grid_rgbw = sample_block_grid_rgb(tsdf, world_pos, pool_idx, bx, by, bz)
+            grid_w = grid_rgbw[3]
+            if grid_w > wp.float32(1.0e-6):
+                inv_w = wp.float32(255.0) / grid_w
+                return wp.vec3(
+                    wp.clamp(grid_rgbw[0] * inv_w, wp.float32(0.0), wp.float32(255.0)),
+                    wp.clamp(grid_rgbw[1] * inv_w, wp.float32(0.0), wp.float32(255.0)),
+                    wp.clamp(grid_rgbw[2] * inv_w, wp.float32(0.0), wp.float32(255.0)),
+                )
 
         return compute_avg_rgb_from_block(tsdf.block_rgb, pool_idx)
 

--- a/curobo/_src/perception/mapper/kernel/builder/builder_raycast.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_raycast.py
@@ -36,8 +36,6 @@ def make_raycast_kernels(
     block_size: int,
     *,
     hash_lookup,
-    compute_avg_rgb_from_block,
-    compute_avg_rgb_uint8_from_block,
     voxel_to_world,
     voxel_to_world_corner,
     block_grid_to_key_coords,
@@ -45,12 +43,10 @@ def make_raycast_kernels(
     world_to_block_coords,
     world_to_block_and_local,
     world_to_continuous_voxel,
-    use_color_grid: bool = False,
     color_grid_size: int = 1,
 ) -> dict[str, object]:
     """Build raycast and voxel-extraction kernels."""
     BS = wp.constant(block_size)
-    USE_COLOR_GRID = wp.constant(bool(use_color_grid))
     COLOR_GRID_SIZE = wp.constant(wp.int32(color_grid_size))
 
     # Cross-domain helpers are explicit parameters so Warp sees them as
@@ -261,7 +257,7 @@ def make_raycast_kernels(
         )
         return wp.vec2(sdf, 1.0)
 
-    @warp_func(f"sample_block_grid_rgb_bs{block_size}_cg{int(use_color_grid)}_gs{color_grid_size}")
+    @warp_func(f"sample_block_grid_rgb_bs{block_size}_gs{color_grid_size}")
     def sample_block_grid_rgb(
         tsdf: BlockSparseTSDFWarp,
         world_pos: wp.vec3,
@@ -270,10 +266,7 @@ def make_raycast_kernels(
         by: wp.int32,
         bz: wp.int32,
     ) -> wp.vec4:
-        """Sample weighted RGBW from the optional per-block RGB grid."""
-        if not USE_COLOR_GRID:
-            return wp.vec4(0.0, 0.0, 0.0, 0.0)
-
+        """Sample weighted RGBW from the per-block RGB grid."""
         base = block_key_to_voxel_base(bx, by, bz)
         voxel_f = world_to_continuous_voxel(world_pos)
         local_x = voxel_f[0] - wp.float32(base[0])
@@ -309,12 +302,12 @@ def make_raycast_kernels(
             wp.float32(tsdf.block_grid_rgb[pool_idx, idx, 3]),
         )
 
-    @warp_func(f"sample_rgb_bs{block_size}_cg{int(use_color_grid)}_gs{color_grid_size}")
+    @warp_func(f"sample_rgb_bs{block_size}_gs{color_grid_size}")
     def sample_rgb(
         tsdf: BlockSparseTSDFWarp,
         world_pos: wp.vec3,
     ) -> wp.vec3:
-        """Sample RGB color from grid RGB when enabled, else per-block average."""
+        """Sample RGB color from the nearest RGB-grid node."""
         coords = world_to_block_and_local(world_pos)
         bx = coords[0]
         by = coords[1]
@@ -324,18 +317,16 @@ def make_raycast_kernels(
         if pool_idx < 0:
             return wp.vec3(0.0, 0.0, 0.0)
 
-        if USE_COLOR_GRID:
-            grid_rgbw = sample_block_grid_rgb(tsdf, world_pos, pool_idx, bx, by, bz)
-            grid_w = grid_rgbw[3]
-            if grid_w > wp.float32(1.0e-6):
-                inv_w = wp.float32(255.0) / grid_w
-                return wp.vec3(
-                    wp.clamp(grid_rgbw[0] * inv_w, wp.float32(0.0), wp.float32(255.0)),
-                    wp.clamp(grid_rgbw[1] * inv_w, wp.float32(0.0), wp.float32(255.0)),
-                    wp.clamp(grid_rgbw[2] * inv_w, wp.float32(0.0), wp.float32(255.0)),
-                )
-
-        return compute_avg_rgb_from_block(tsdf.block_rgb, pool_idx)
+        grid_rgbw = sample_block_grid_rgb(tsdf, world_pos, pool_idx, bx, by, bz)
+        grid_w = grid_rgbw[3]
+        if grid_w <= wp.float32(1.0e-6):
+            return wp.vec3(0.0, 0.0, 0.0)
+        inv_w = wp.float32(255.0) / grid_w
+        return wp.vec3(
+            wp.clamp(grid_rgbw[0] * inv_w, wp.float32(0.0), wp.float32(255.0)),
+            wp.clamp(grid_rgbw[1] * inv_w, wp.float32(0.0), wp.float32(255.0)),
+            wp.clamp(grid_rgbw[2] * inv_w, wp.float32(0.0), wp.float32(255.0)),
+        )
 
     @warp_func(f"compute_gradient_bs{block_size}")
     def compute_gradient(
@@ -1308,7 +1299,7 @@ def make_raycast_kernels(
 
         out_sdf[slot] = sdf
 
-        rgb = compute_avg_rgb_uint8_from_block(tsdf.block_rgb, block_idx)
+        rgb = sample_rgb(tsdf, world_pos)
         out_colors[slot, 0] = wp.uint8(rgb[0])
         out_colors[slot, 1] = wp.uint8(rgb[1])
         out_colors[slot, 2] = wp.uint8(rgb[2])

--- a/curobo/_src/perception/mapper/kernel/builder/builder_rescale.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_rescale.py
@@ -35,42 +35,48 @@ def make_rescale_kernels(
     *,
     feature_dim: int,
     color_grid_size: int = 1,
+    feature_block_grid_size: int = 1,
 ) -> dict[str, object]:
     """Build per-block accumulator rescale kernels."""
     FEATURE_DIM = wp.constant(wp.int32(feature_dim))
+    feature_grid_voxels = int(feature_block_grid_size) ** 3
+    FEATURE_GRID_VOXELS = wp.constant(wp.int32(feature_grid_voxels))
     color_grid_voxels = int(color_grid_size) ** 3
     COLOR_GRID_VOXELS = wp.constant(wp.int32(color_grid_voxels))
     COLOR_GRID_RGB_CELLS = wp.constant(wp.int32(color_grid_voxels * 3))
 
-    @warp_kernel(f"rescale_block_accumulators_kernel_bs{block_size}_fd{feature_dim}")
+    @warp_kernel(
+        f"rescale_block_accumulators_kernel_bs{block_size}_fd{feature_dim}"
+        f"_fgs{feature_block_grid_size}"
+    )
     def rescale_block_accumulators_kernel(
         visible_pool_indices: wp.array(dtype=wp.int32),
         n_visible: wp.int32,
         w_max: wp.float32,
-        block_features: wp.array2d(dtype=wp.float16),
-        block_feature_weight: wp.array(dtype=wp.float16),
+        block_features: wp.array3d(dtype=wp.float16),
+        block_feature_weight: wp.array2d(dtype=wp.float16),
     ):
-        """Cap per-block feature weights at ``w_max``; scale sums proportionally.
+        """Cap per-node feature weights at ``w_max``; scale sums proportionally.
 
-        Launch with ``dim = (n_visible, feature_dim)`` — one thread per
-        ``(visible_block, feature_channel)`` pair.
+        Launch with ``dim = (n_visible, feature_grid_voxels, feature_dim)`` — one
+        thread per ``(visible_block, feature_node, feature_channel)`` tuple.
         """
-        vis_idx, ch = wp.tid()
+        vis_idx, node_idx, ch = wp.tid()
 
-        if vis_idx >= n_visible:
+        if vis_idx >= n_visible or node_idx >= FEATURE_GRID_VOXELS:
             return
 
         pool_idx = visible_pool_indices[vis_idx]
         if pool_idx < 0:
             return
         if FEATURE_DIM > 0 and ch < FEATURE_DIM:
-            w_f = wp.float32(block_feature_weight[pool_idx])
+            w_f = wp.float32(block_feature_weight[pool_idx, node_idx])
             if w_f > w_max:
                 s_f = w_max / w_f
-                v_f = wp.float32(block_features[pool_idx, ch]) * s_f
-                block_features[pool_idx, ch] = wp.float16(v_f)
+                v_f = wp.float32(block_features[pool_idx, node_idx, ch]) * s_f
+                block_features[pool_idx, node_idx, ch] = wp.float16(v_f)
                 if ch == 0:
-                    block_feature_weight[pool_idx] = wp.float16(w_max)
+                    block_feature_weight[pool_idx, node_idx] = wp.float16(w_max)
 
     @warp_kernel(
         f"rescale_block_grid_rgb_kernel_bs{block_size}_gs{color_grid_size}"

--- a/curobo/_src/perception/mapper/kernel/builder/builder_rescale.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_rescale.py
@@ -31,9 +31,19 @@ import warp as wp
 from curobo._src.util.warp import warp_kernel
 
 
-def make_rescale_kernels(block_size: int, *, feature_dim: int) -> dict[str, object]:
+def make_rescale_kernels(
+    block_size: int,
+    *,
+    feature_dim: int,
+    use_color_grid: bool = False,
+    color_grid_size: int = 1,
+) -> dict[str, object]:
     """Build per-block accumulator rescale kernels."""
     FEATURE_DIM = wp.constant(wp.int32(feature_dim))
+    USE_COLOR_GRID = wp.constant(bool(use_color_grid))
+    color_grid_voxels = int(color_grid_size) ** 3
+    COLOR_GRID_VOXELS = wp.constant(wp.int32(color_grid_voxels))
+    COLOR_GRID_RGB_CELLS = wp.constant(wp.int32(color_grid_voxels * 3))
 
     @warp_kernel(f"rescale_block_accumulators_kernel_bs{block_size}_fd{feature_dim}")
     def rescale_block_accumulators_kernel(
@@ -85,6 +95,40 @@ def make_rescale_kernels(block_size: int, *, feature_dim: int) -> dict[str, obje
                 if ch == 0:
                     block_rgb[pool_idx, 3] = wp.float16(w_max)
 
+    @warp_kernel(
+        f"rescale_block_grid_rgb_kernel_bs{block_size}_cg{int(use_color_grid)}_gs{color_grid_size}"
+    )
+    def rescale_block_grid_rgb_kernel(
+        visible_pool_indices: wp.array(dtype=wp.int32),
+        n_visible: wp.int32,
+        w_max: wp.float32,
+        block_grid_rgb: wp.array3d(dtype=wp.float16),
+    ):
+        """Cap per-node RGB grid weights at ``w_max`` while preserving means."""
+        vis_idx, cell_idx = wp.tid()
+        if vis_idx >= n_visible or cell_idx >= COLOR_GRID_RGB_CELLS:
+            return
+        if not USE_COLOR_GRID:
+            return
+
+        pool_idx = visible_pool_indices[vis_idx]
+        if pool_idx < 0:
+            return
+
+        node_idx = cell_idx // wp.int32(3)
+        ch = cell_idx - node_idx * wp.int32(3)
+        if node_idx >= COLOR_GRID_VOXELS:
+            return
+
+        rgb_weight = wp.float32(block_grid_rgb[pool_idx, node_idx, 3])
+        if rgb_weight > w_max:
+            current_rgb = wp.float32(block_grid_rgb[pool_idx, node_idx, ch])
+            s = w_max / rgb_weight
+            block_grid_rgb[pool_idx, node_idx, ch] = wp.float16(current_rgb * s)
+            if ch == wp.int32(0):
+                block_grid_rgb[pool_idx, node_idx, 3] = wp.float16(w_max)
+
     return {
         "rescale_block_accumulators_kernel": rescale_block_accumulators_kernel,
+        "rescale_block_grid_rgb_kernel": rescale_block_grid_rgb_kernel,
     }

--- a/curobo/_src/perception/mapper/kernel/builder/builder_rescale.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_rescale.py
@@ -2,16 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-"""Post-frame per-block accumulator rescale kernel, per-``block_size`` builder.
+"""Post-frame accumulator rescale kernels, per-``block_size`` builder.
 
-The fp16 per-block accumulators (``block_rgb``, ``block_features``,
-``block_feature_weight``) grow monotonically across frames as atomic
-adds accumulate weighted pixel contributions. Left unbounded, the
-running sum eventually exceeds fp16's finite range (65504) and
-saturates to ``inf``. This builder adds a post-integration pass that
-caps each per-block weight at ``w_max`` and scales the weighted-sum
-channels proportionally so the mean ``sum / weight`` is preserved
-while magnitudes stay bounded.
+The fp16 accumulators (``block_grid_rgb``, ``block_features``, and
+``block_feature_weight``) grow monotonically across frames as weighted
+pixel contributions accumulate. Left unbounded, the running sum
+eventually exceeds fp16's finite range (65504) and saturates to
+``inf``. This builder adds post-integration passes that cap each
+weight at ``w_max`` and scale weighted-sum channels proportionally so
+the mean ``sum / weight`` is preserved while magnitudes stay bounded.
 
 The cap also gives the mapper EMA semantics: old observations decay at
 a rate set by ``w_max / mean_per_frame_weight``. This is desirable for
@@ -35,12 +34,10 @@ def make_rescale_kernels(
     block_size: int,
     *,
     feature_dim: int,
-    use_color_grid: bool = False,
     color_grid_size: int = 1,
 ) -> dict[str, object]:
     """Build per-block accumulator rescale kernels."""
     FEATURE_DIM = wp.constant(wp.int32(feature_dim))
-    USE_COLOR_GRID = wp.constant(bool(use_color_grid))
     color_grid_voxels = int(color_grid_size) ** 3
     COLOR_GRID_VOXELS = wp.constant(wp.int32(color_grid_voxels))
     COLOR_GRID_RGB_CELLS = wp.constant(wp.int32(color_grid_voxels * 3))
@@ -52,21 +49,11 @@ def make_rescale_kernels(
         w_max: wp.float32,
         block_features: wp.array2d(dtype=wp.float16),
         block_feature_weight: wp.array(dtype=wp.float16),
-        block_rgb: wp.array2d(dtype=wp.float16),
     ):
-        """Cap per-block weights at ``w_max``; scale sums proportionally.
+        """Cap per-block feature weights at ``w_max``; scale sums proportionally.
 
-        Launch with ``dim = (n_visible, n_channels)`` where
-        ``n_channels = max(3, feature_dim)`` — one thread per
-        ``(visible_block, channel)`` pair. Within a warp threads
-        share ``pool_idx`` and stride consecutive ``ch`` slots, so
-        ``block_features[pool_idx, ch]`` loads are coalesced and
-        the per-block weights ``w_rgb`` / ``w_f`` broadcast.
-
-        ``block_rgb`` and ``block_features`` track independent
-        weights (the feature kernel aggregates over a footprint bbox
-        while RGB uses per-voxel pixel coverage), so cap each
-        independently.
+        Launch with ``dim = (n_visible, feature_dim)`` — one thread per
+        ``(visible_block, feature_channel)`` pair.
         """
         vis_idx, ch = wp.tid()
 
@@ -85,18 +72,8 @@ def make_rescale_kernels(
                 if ch == 0:
                     block_feature_weight[pool_idx] = wp.float16(w_max)
 
-        if ch < 3:
-            rgb_weight = wp.float32(block_rgb[pool_idx, 3])
-            if rgb_weight > w_max:
-                current_rgb = wp.float32(block_rgb[pool_idx, ch])
-                s = w_max / rgb_weight
-                scaled_rgb = current_rgb * s
-                block_rgb[pool_idx, ch] = wp.float16(scaled_rgb)
-                if ch == 0:
-                    block_rgb[pool_idx, 3] = wp.float16(w_max)
-
     @warp_kernel(
-        f"rescale_block_grid_rgb_kernel_bs{block_size}_cg{int(use_color_grid)}_gs{color_grid_size}"
+        f"rescale_block_grid_rgb_kernel_bs{block_size}_gs{color_grid_size}"
     )
     def rescale_block_grid_rgb_kernel(
         visible_pool_indices: wp.array(dtype=wp.int32),
@@ -107,8 +84,6 @@ def make_rescale_kernels(
         """Cap per-node RGB grid weights at ``w_max`` while preserving means."""
         vis_idx, cell_idx = wp.tid()
         if vis_idx >= n_visible or cell_idx >= COLOR_GRID_RGB_CELLS:
-            return
-        if not USE_COLOR_GRID:
             return
 
         pool_idx = visible_pool_indices[vis_idx]

--- a/curobo/_src/perception/mapper/kernel/builder/builder_stamp.py
+++ b/curobo/_src/perception/mapper/kernel/builder/builder_stamp.py
@@ -43,6 +43,7 @@ def make_stamp_kernels(
     hash_lookup,
     hash_table_insert_with_pool_idx,
     free_list_pop,
+    color_grid_size: int,
 ) -> dict[str, object]:
     """Build obstacle-stamping kernels."""
     suffix = (
@@ -58,6 +59,8 @@ def make_stamp_kernels(
     ORIGIN_Z = wp.constant(wp.float32(origin_xyz[2]))
     VOXEL_SIZE = wp.constant(wp.float32(voxel_size))
     TRUNCATION_DIST = wp.constant(wp.float32(truncation_distance))
+    color_grid_voxels = int(color_grid_size) ** 3
+    COLOR_GRID_VOXELS = wp.constant(wp.int32(color_grid_voxels))
     max_sdf_threshold = truncation_distance + (3.0**0.5) * block_size * voxel_size * 0.5
     MAX_SDF_THRESHOLD = wp.constant(wp.float32(max_sdf_threshold))
 
@@ -318,37 +321,37 @@ def make_stamp_kernels(
     # Phase 7: Update Block Colors
     # =====================================================================
 
-    @warp_kernel(f"update_block_rgb_kernel_bs{block_size}")
-    def update_block_rgb_kernel(
-        block_rgb: wp.array2d(dtype=wp.float16),
+    @warp_kernel(f"update_block_grid_rgb_kernel_bs{block_size}_gs{color_grid_size}")
+    def update_block_grid_rgb_kernel(
+        block_grid_rgb: wp.array3d(dtype=wp.float16),
         pool_indices: wp.array(dtype=wp.int32),
         n_unique: wp.int32,
         static_color: wp.vec3,
     ):
-        """Update block RGB with constant static color for allocated blocks.
+        """Update every RGB-grid node with constant static color.
 
         ``static_color`` must be pre-normalized to ``[0, 1]`` (the
         launcher divides the uint8-style config value by 255) to
         match the integration convention and keep the fp16-stored
         weighted sums consistent with the dynamic-channel values.
         """
-        tid = wp.tid()
-        if tid >= n_unique:
+        tid, node_idx = wp.tid()
+        if tid >= n_unique or node_idx >= COLOR_GRID_VOXELS:
             return
 
         pool_idx = pool_indices[tid]
         if pool_idx < 0:
             return
 
-        block_rgb[pool_idx, 0] = wp.float16(static_color[0])
-        block_rgb[pool_idx, 1] = wp.float16(static_color[1])
-        block_rgb[pool_idx, 2] = wp.float16(static_color[2])
-        block_rgb[pool_idx, 3] = wp.float16(1.0)
+        block_grid_rgb[pool_idx, node_idx, 0] = wp.float16(static_color[0])
+        block_grid_rgb[pool_idx, node_idx, 1] = wp.float16(static_color[1])
+        block_grid_rgb[pool_idx, node_idx, 2] = wp.float16(static_color[2])
+        block_grid_rgb[pool_idx, node_idx, 3] = wp.float16(1.0)
 
     return {
         "preallocate_unique_blocks_kernel": preallocate_unique_blocks_kernel,
         "enumerate_blocks_from_aabb_kernel": enumerate_blocks_from_aabb_kernel,
         "filter_blocks_by_sdf_kernel": filter_blocks_by_sdf_kernel,
         "stamp_sdf_kernel": stamp_sdf_kernel,
-        "update_block_rgb_kernel": update_block_rgb_kernel,
+        "update_block_grid_rgb_kernel": update_block_grid_rgb_kernel,
     }

--- a/curobo/_src/perception/mapper/kernel/warp_types.py
+++ b/curobo/_src/perception/mapper/kernel/warp_types.py
@@ -49,6 +49,10 @@ class BlockSparseTSDFWarp:
             inside finite range and per-atomic ulp loss stays bounded.
             Access: ``block_rgb[pool_idx, 0/1/2/3]``.
 
+        block_grid_rgb: (max_blocks, COLOR_GRID_SIZE**3, 4) float16
+            Optional per-block local RGBW control grid. Disabled configs pass
+            a dummy ``(1, 1, 4)`` tensor and ``has_color_grid=False``.
+
         block_coords: (max_blocks * 3,) int32
             Signed centered hash block keys: [bx, by, bz] for each block.
             Access: ``bx = block_coords[pool_idx * 3 + 0]``.
@@ -68,6 +72,7 @@ class BlockSparseTSDFWarp:
     # Block pool - dynamic channel (depth integration)
     block_data: wp.array3d(dtype=wp.float16)  # (max_blocks, BLOCK_SIZE**3, 2) or (1, 1, 2) dummy
     block_rgb: wp.array2d(dtype=wp.float16)  # (max_blocks, 4) per-block [R*w, G*w, B*w, W]
+    block_grid_rgb: wp.array3d(dtype=wp.float16)  # (max_blocks, color_grid_size**3, 4) or dummy
 
     # Per-block feature channel (fp16 weighted sums + dedicated weight)
     block_features: wp.array2d(dtype=wp.float16)  # (max_blocks, feature_dim) or (1, 1) dummy
@@ -80,7 +85,9 @@ class BlockSparseTSDFWarp:
     has_dynamic: wp.bool  # True if dynamic channel is enabled
     has_static: wp.bool  # True if static channel is enabled
     has_features: wp.bool  # True if per-block feature channel is enabled
+    has_color_grid: wp.bool  # True if per-block color grid is enabled
     feature_dim: int  # 0 when the feature channel is disabled
+    color_grid_size: int  # 1 when color grid is disabled
 
     # Block metadata
     block_coords: wp.array(dtype=wp.int32)  # (max_blocks * 3,) signed block keys

--- a/curobo/_src/perception/mapper/kernel/warp_types.py
+++ b/curobo/_src/perception/mapper/kernel/warp_types.py
@@ -64,9 +64,11 @@ class BlockSparseTSDFWarp:
     block_data: wp.array3d(dtype=wp.float16)  # (max_blocks, BLOCK_SIZE**3, 2) or (1, 1, 2) dummy
     block_grid_rgb: wp.array3d(dtype=wp.float16)  # (max_blocks, color_grid_size**3, 4)
 
-    # Per-block feature channel (fp16 weighted sums + dedicated weight)
-    block_features: wp.array2d(dtype=wp.float16)  # (max_blocks, feature_dim) or (1, 1) dummy
-    block_feature_weight: wp.array(dtype=wp.float16)  # (max_blocks,) or (1,) dummy
+    # Per-block feature grid (fp16 weighted sums + dedicated weight)
+    # Shape: (max_blocks, feature_block_grid_size**3, feature_dim)
+    block_features: wp.array3d(dtype=wp.float16)
+    # Shape: (max_blocks, feature_block_grid_size**3)
+    block_feature_weight: wp.array2d(dtype=wp.float16)
 
     # Block pool - static channel (primitive SDF)
     static_block_data: wp.array2d(dtype=wp.float16)  # (max_blocks, BLOCK_SIZE**3) or (1, 1) dummy
@@ -77,6 +79,7 @@ class BlockSparseTSDFWarp:
     has_features: wp.bool  # True if per-block feature channel is enabled
     feature_dim: int  # 0 when the feature channel is disabled
     color_grid_size: int
+    feature_block_grid_size: int
 
     # Block metadata
     block_coords: wp.array(dtype=wp.int32)  # (max_blocks * 3,) signed block keys

--- a/curobo/_src/perception/mapper/kernel/warp_types.py
+++ b/curobo/_src/perception/mapper/kernel/warp_types.py
@@ -39,19 +39,10 @@ class BlockSparseTSDFWarp:
             Access: ``static_block_data[pool_idx, local_idx]``.
             Initialized to +inf (no obstacle).
 
-        block_rgb: (max_blocks, 4) float16
-            Per-block RGBW: [R*w, G*w, B*w, weight_sum]. One color per
-            block (not per voxel) - ``BLOCK_SIZE**3`` memory savings.
-            Integration pre-normalizes RGB to ``[0, 1]``; divide by
-            channel 3 at read time and multiply by 255 to get uint8 RGB.
-            A post-frame rescale kernel caps the weight at
-            ``config.accumulator_w_max`` so the fp16 accumulator stays
-            inside finite range and per-atomic ulp loss stays bounded.
-            Access: ``block_rgb[pool_idx, 0/1/2/3]``.
-
         block_grid_rgb: (max_blocks, COLOR_GRID_SIZE**3, 4) float16
-            Optional per-block local RGBW control grid. Disabled configs pass
-            a dummy ``(1, 1, 4)`` tensor and ``has_color_grid=False``.
+            Per-block local RGBW control grid. Integration pre-normalizes
+            RGB to ``[0, 1]``; divide by channel 3 at read time and
+            multiply by 255 to get uint8 RGB.
 
         block_coords: (max_blocks * 3,) int32
             Signed centered hash block keys: [bx, by, bz] for each block.
@@ -71,8 +62,7 @@ class BlockSparseTSDFWarp:
 
     # Block pool - dynamic channel (depth integration)
     block_data: wp.array3d(dtype=wp.float16)  # (max_blocks, BLOCK_SIZE**3, 2) or (1, 1, 2) dummy
-    block_rgb: wp.array2d(dtype=wp.float16)  # (max_blocks, 4) per-block [R*w, G*w, B*w, W]
-    block_grid_rgb: wp.array3d(dtype=wp.float16)  # (max_blocks, color_grid_size**3, 4) or dummy
+    block_grid_rgb: wp.array3d(dtype=wp.float16)  # (max_blocks, color_grid_size**3, 4)
 
     # Per-block feature channel (fp16 weighted sums + dedicated weight)
     block_features: wp.array2d(dtype=wp.float16)  # (max_blocks, feature_dim) or (1, 1) dummy
@@ -85,9 +75,8 @@ class BlockSparseTSDFWarp:
     has_dynamic: wp.bool  # True if dynamic channel is enabled
     has_static: wp.bool  # True if static channel is enabled
     has_features: wp.bool  # True if per-block feature channel is enabled
-    has_color_grid: wp.bool  # True if per-block color grid is enabled
     feature_dim: int  # 0 when the feature channel is disabled
-    color_grid_size: int  # 1 when color grid is disabled
+    color_grid_size: int
 
     # Block metadata
     block_coords: wp.array(dtype=wp.int32)  # (max_blocks * 3,) signed block keys

--- a/curobo/_src/perception/mapper/kernel/wp_decay.py
+++ b/curobo/_src/perception/mapper/kernel/wp_decay.py
@@ -47,9 +47,7 @@ def decay_and_recycle(
 
     if decay_factor < 1.0:
         tsdf.data.block_data[:num_blocks].mul_(decay_factor)
-        tsdf.data.block_rgb[:num_blocks].mul_(decay_factor)
-        if tsdf.data.has_color_grid:
-            tsdf.data.block_grid_rgb[:num_blocks].mul_(decay_factor)
+        tsdf.data.block_grid_rgb[:num_blocks].mul_(decay_factor)
         if tsdf.data.has_features:
             tsdf.data.block_features[:num_blocks].mul_(decay_factor)
             tsdf.data.block_feature_weight[:num_blocks].mul_(decay_factor)
@@ -127,9 +125,7 @@ def apply_decay_from_frustum_flags(
         block_data = tsdf.data.block_data[:n]
         if time_decay < 1.0:
             block_data.mul_(time_decay)
-            tsdf.data.block_rgb[:n].mul_(time_decay)
-            if tsdf.data.has_color_grid:
-                tsdf.data.block_grid_rgb[:n].mul_(time_decay)
+            tsdf.data.block_grid_rgb[:n].mul_(time_decay)
             if tsdf.data.has_features:
                 tsdf.data.block_features[:n].mul_(time_decay)
                 tsdf.data.block_feature_weight[:n].mul_(time_decay)
@@ -143,9 +139,7 @@ def apply_decay_from_frustum_flags(
     factor.masked_fill_(frustum_flags[:n] > 0, time_decay * frustum_decay)
 
     tsdf.data.block_data[:n].mul_(factor.view(n, 1, 1))
-    tsdf.data.block_rgb[:n].mul_(factor.view(n, 1))
-    if tsdf.data.has_color_grid:
-        tsdf.data.block_grid_rgb[:n].mul_(factor.view(n, 1, 1))
+    tsdf.data.block_grid_rgb[:n].mul_(factor.view(n, 1, 1))
     if tsdf.data.has_features:
         tsdf.data.block_features[:n].mul_(factor.view(n, 1))
         tsdf.data.block_feature_weight[:n].mul_(factor)

--- a/curobo/_src/perception/mapper/kernel/wp_decay.py
+++ b/curobo/_src/perception/mapper/kernel/wp_decay.py
@@ -141,8 +141,8 @@ def apply_decay_from_frustum_flags(
     tsdf.data.block_data[:n].mul_(factor.view(n, 1, 1))
     tsdf.data.block_grid_rgb[:n].mul_(factor.view(n, 1, 1))
     if tsdf.data.has_features:
-        tsdf.data.block_features[:n].mul_(factor.view(n, 1))
-        tsdf.data.block_feature_weight[:n].mul_(factor)
+        tsdf.data.block_features[:n].mul_(factor.view(n, 1, 1))
+        tsdf.data.block_feature_weight[:n].mul_(factor.view(n, 1))
 
     tsdf.data.block_sums[:n] = tsdf.data.block_data[:n, :, 1].sum(dim=1, dtype=torch.float32)
 

--- a/curobo/_src/perception/mapper/kernel/wp_decay.py
+++ b/curobo/_src/perception/mapper/kernel/wp_decay.py
@@ -48,6 +48,8 @@ def decay_and_recycle(
     if decay_factor < 1.0:
         tsdf.data.block_data[:num_blocks].mul_(decay_factor)
         tsdf.data.block_rgb[:num_blocks].mul_(decay_factor)
+        if tsdf.data.has_color_grid:
+            tsdf.data.block_grid_rgb[:num_blocks].mul_(decay_factor)
         if tsdf.data.has_features:
             tsdf.data.block_features[:num_blocks].mul_(decay_factor)
             tsdf.data.block_feature_weight[:num_blocks].mul_(decay_factor)
@@ -126,6 +128,8 @@ def apply_decay_from_frustum_flags(
         if time_decay < 1.0:
             block_data.mul_(time_decay)
             tsdf.data.block_rgb[:n].mul_(time_decay)
+            if tsdf.data.has_color_grid:
+                tsdf.data.block_grid_rgb[:n].mul_(time_decay)
             if tsdf.data.has_features:
                 tsdf.data.block_features[:n].mul_(time_decay)
                 tsdf.data.block_feature_weight[:n].mul_(time_decay)
@@ -140,6 +144,8 @@ def apply_decay_from_frustum_flags(
 
     tsdf.data.block_data[:n].mul_(factor.view(n, 1, 1))
     tsdf.data.block_rgb[:n].mul_(factor.view(n, 1))
+    if tsdf.data.has_color_grid:
+        tsdf.data.block_grid_rgb[:n].mul_(factor.view(n, 1, 1))
     if tsdf.data.has_features:
         tsdf.data.block_features[:n].mul_(factor.view(n, 1))
         tsdf.data.block_feature_weight[:n].mul_(factor)

--- a/curobo/_src/perception/mapper/kernel/wp_integrate_camera_project.py
+++ b/curobo/_src/perception/mapper/kernel/wp_integrate_camera_project.py
@@ -250,6 +250,8 @@ class CameraProjectIntegrator:
         """Clear storage for pool slots allocated during the current frame."""
         block_voxels = tsdf.block_size**3
         max_clearable = min(num_visible_blocks, tsdf.config.max_blocks)
+        if max_clearable <= 0:
+            return
         self._timer_start()
         wp.launch(
             kernels.clear_new_blocks_kernel,
@@ -265,6 +267,21 @@ class CameraProjectIntegrator:
             stream=stream,
         )
         self._timer_stop("clear_new_blocks_kernel")
+        if tsdf.data.has_color_grid:
+            self._timer_start()
+            wp.launch(
+                kernels.clear_new_block_grid_rgb_kernel,
+                dim=(max_clearable, kernels.color_grid_voxels * 4),
+                inputs=[
+                    data.block_grid_rgb,
+                    data.new_blocks,
+                    data.new_block_count,
+                    tsdf.config.max_blocks,
+                ],
+                device=device,
+                stream=stream,
+            )
+            self._timer_stop("clear_new_block_grid_rgb_kernel")
         if tsdf.data.has_features:
             self._timer_start()
             feature_dim_cfg = tsdf.data.feature_dim
@@ -274,12 +291,12 @@ class CameraProjectIntegrator:
                 inputs=[
                     data.block_features,
                     data.block_feature_weight,
-                data.new_blocks,
-                data.new_block_count,
-                tsdf.config.max_blocks,
-            ],
-            device=device,
-            stream=stream,
+                    data.new_blocks,
+                    data.new_block_count,
+                    tsdf.config.max_blocks,
+                ],
+                device=device,
+                stream=stream,
             )
             self._timer_stop("clear_new_block_features_kernel")
 
@@ -431,6 +448,20 @@ class CameraProjectIntegrator:
                     data.block_data,
                     data.block_rgb,
                     data.block_sums,
+                    tsdf.config.max_blocks,
+                ],
+                device=device,
+                stream=stream,
+            )
+
+        if tsdf.data.has_color_grid:
+            wp.launch(
+                kernels.clear_block_grid_rgb_by_pool_kernel,
+                dim=(n_clear, kernels.color_grid_voxels * 4),
+                inputs=[
+                    wp.from_torch(pool_indices),
+                    wp.from_torch(self.clear_count),
+                    data.block_grid_rgb,
                     tsdf.config.max_blocks,
                 ],
                 device=device,
@@ -694,15 +725,26 @@ class CameraProjectIntegrator:
                 f"{self.max_visible_blocks_per_integration}. Increase the config value."
             )
 
-        self._build_support_pixels(
-            tsdf,
-            kernels,
-            data,
-            num_block_key_candidates,
-            self.frame_epoch,
-            device,
-            stream,
+        feature_dim_cfg = tsdf.data.feature_dim if tsdf.data.has_features else 0
+        if feature_grid is not None and not tsdf.data.has_features:
+            log_and_raise(
+                "feature_grid was provided but feature_dim == 0; enable features via "
+                "MapperCfg.feature_dim or BlockSparseTSDFIntegratorCfg.feature_dim."
+            )
+
+        needs_support_pixels = (not tsdf.data.has_color_grid) or (
+            tsdf.data.has_features and feature_grid is not None
         )
+        if needs_support_pixels:
+            self._build_support_pixels(
+                tsdf,
+                kernels,
+                data,
+                num_block_key_candidates,
+                self.frame_epoch,
+                device,
+                stream,
+            )
 
         self._clear_new_blocks(tsdf, kernels, data, num_visible_blocks, device, stream)
         block_voxels = tsdf.block_size**3
@@ -728,30 +770,45 @@ class CameraProjectIntegrator:
             stream=stream,
         )
         self._timer_stop("integrate_voxels_kernel")
-        self._timer_start()
-
-        wp.launch(
-            kernels.integrate_block_rgb_from_support_kernel,
-            dim=(num_visible_blocks, n_cameras),
-            inputs=[
-                wp.from_torch(self.pool_indices),
-                num_visible_blocks,
-                wp.from_torch(self.support_counts),
-                wp.from_torch(self.support_pixels),
-                wp.from_torch(rgb_flat, dtype=wp.uint8),
-                data.block_rgb,
-            ],
-            device=device,
-            stream=stream,
-        )
-        self._timer_stop("integrate_block_rgb_from_support_kernel")
-        feature_dim_cfg = tsdf.data.feature_dim if tsdf.data.has_features else 0
-
-        if feature_grid is not None and not tsdf.data.has_features:
-            log_and_raise(
-                "feature_grid was provided but feature_dim == 0; enable features via "
-                "MapperCfg.feature_dim or BlockSparseTSDFIntegratorCfg.feature_dim."
+        if tsdf.data.has_color_grid:
+            self._timer_start()
+            wp.launch(
+                kernels.integrate_block_grid_rgb_kernel,
+                dim=(num_visible_blocks, kernels.color_grid_voxels),
+                inputs=[
+                    wp.from_torch(self.pool_indices),
+                    num_visible_blocks,
+                    wp.from_torch(intrinsics, dtype=wp.float32),
+                    wp.from_torch(cam_positions, dtype=wp.float32),
+                    wp.from_torch(cam_quaternions, dtype=wp.float32),
+                    wp.from_torch(depth_images, dtype=wp.float32),
+                    wp.from_torch(rgb_flat, dtype=wp.uint8),
+                    depth_min,
+                    depth_max,
+                    data.block_coords,
+                    data.block_grid_rgb,
+                ],
+                device=device,
+                stream=stream,
             )
+            self._timer_stop("integrate_block_grid_rgb_kernel")
+        else:
+            self._timer_start()
+            wp.launch(
+                kernels.integrate_block_rgb_from_support_kernel,
+                dim=(num_visible_blocks, n_cameras),
+                inputs=[
+                    wp.from_torch(self.pool_indices),
+                    num_visible_blocks,
+                    wp.from_torch(self.support_counts),
+                    wp.from_torch(self.support_pixels),
+                    wp.from_torch(rgb_flat, dtype=wp.uint8),
+                    data.block_rgb,
+                ],
+                device=device,
+                stream=stream,
+            )
+            self._timer_stop("integrate_block_rgb_from_support_kernel")
 
         if tsdf.data.has_features and feature_grid is not None:
             self._timer_start()
@@ -843,14 +900,10 @@ class CameraProjectIntegrator:
                 feature_kernel_name = "integrate_features_from_support_grouped_kernel"
             self._timer_stop(feature_kernel_name)
 
-        # Cap per-block weights so fp16 accumulators stay in finite range.
-        # Runs every frame on the blocks we just touched; features are
-        # rescaled only if the compiled feature channel is enabled.
-        # One thread per (block, channel): RGB uses ch < 3 (with ch == 0
-        # also writing the capped weight), features use ch < feature_dim.
-        # ``n_channels = max(3, feature_dim)`` keeps RGB live even when
-        # features are disabled.
-        if True:
+        # Cap fp16 accumulators so weighted sums stay finite while preserving
+        # means. Block RGB is only touched on the legacy color path; the
+        # optional RGB grid has its own per-node rescale kernel.
+        if (not tsdf.data.has_color_grid) or tsdf.data.has_features:
             self._timer_start()
             n_channels = max(3, kernels.feature_dim)
             wp.launch(
@@ -868,3 +921,18 @@ class CameraProjectIntegrator:
                 stream=stream,
             )
             self._timer_stop("rescale_block_accumulators_kernel")
+        if tsdf.data.has_color_grid:
+            self._timer_start()
+            wp.launch(
+                kernels.rescale_block_grid_rgb_kernel,
+                dim=(num_visible_blocks, kernels.color_grid_voxels * 3),
+                inputs=[
+                    wp.from_torch(self.pool_indices),
+                    num_visible_blocks,
+                    float(tsdf.config.accumulator_w_max),
+                    data.block_grid_rgb,
+                ],
+                device=device,
+                stream=stream,
+            )
+            self._timer_stop("rescale_block_grid_rgb_kernel")

--- a/curobo/_src/perception/mapper/kernel/wp_integrate_camera_project.py
+++ b/curobo/_src/perception/mapper/kernel/wp_integrate_camera_project.py
@@ -285,7 +285,7 @@ class CameraProjectIntegrator:
             feature_dim_cfg = tsdf.data.feature_dim
             wp.launch(
                 kernels.clear_new_block_features_kernel,
-                dim=(max_clearable, feature_dim_cfg),
+                dim=(max_clearable, kernels.feature_grid_voxels, feature_dim_cfg),
                 inputs=[
                     data.block_features,
                     data.block_feature_weight,
@@ -468,7 +468,7 @@ class CameraProjectIntegrator:
             feature_dim = tsdf.data.feature_dim
             wp.launch(
                 kernels.clear_block_features_by_pool_kernel,
-                dim=(n_clear, feature_dim),
+                dim=(n_clear, kernels.feature_grid_voxels, feature_dim),
                 inputs=[
                     wp.from_torch(pool_indices),
                     wp.from_torch(self.clear_count),
@@ -728,17 +728,15 @@ class CameraProjectIntegrator:
                 "MapperCfg.feature_dim or BlockSparseTSDFIntegratorCfg.feature_dim."
             )
 
-        needs_support_pixels = tsdf.data.has_features and feature_grid is not None
-        if needs_support_pixels:
-            self._build_support_pixels(
-                tsdf,
-                kernels,
-                data,
-                num_block_key_candidates,
-                self.frame_epoch,
-                device,
-                stream,
-            )
+        self._build_support_pixels(
+            tsdf,
+            kernels,
+            data,
+            num_block_key_candidates,
+            self.frame_epoch,
+            device,
+            stream,
+        )
 
         self._clear_new_blocks(tsdf, kernels, data, num_visible_blocks, device, stream)
         block_voxels = tsdf.block_size**3
@@ -776,6 +774,8 @@ class CameraProjectIntegrator:
                 wp.from_torch(cam_quaternions, dtype=wp.float32),
                 wp.from_torch(depth_images, dtype=wp.float32),
                 wp.from_torch(rgb_flat, dtype=wp.vec3ub),
+                wp.from_torch(self.support_counts),
+                wp.from_torch(self.support_pixels),
                 depth_min,
                 depth_max,
                 data.block_coords,
@@ -839,9 +839,16 @@ class CameraProjectIntegrator:
             feature_inputs = [
                 wp.from_torch(self.pool_indices),
                 num_visible_blocks,
+                wp.from_torch(intrinsics, dtype=wp.float32),
+                wp.from_torch(cam_positions, dtype=wp.float32),
+                wp.from_torch(cam_quaternions, dtype=wp.float32),
+                wp.from_torch(depth_images, dtype=wp.float32),
                 wp.from_torch(self.support_counts),
                 wp.from_torch(self.support_pixels),
                 wp.from_torch(feature_grid, dtype=wp.float16),
+                depth_min,
+                depth_max,
+                data.block_coords,
                 data.block_features,
                 data.block_feature_weight,
             ]
@@ -858,7 +865,11 @@ class CameraProjectIntegrator:
                 ) // feature_tile_channels
                 wp.launch_tiled(
                     kernels.integrate_features_from_support_tiled_kernel,
-                    dim=(num_visible_blocks, n_cameras, feature_channel_tiles),
+                    dim=(
+                        num_visible_blocks,
+                        kernels.feature_grid_voxels,
+                        feature_channel_tiles,
+                    ),
                     block_dim=64,
                     inputs=feature_inputs,
                     device=device,
@@ -868,7 +879,11 @@ class CameraProjectIntegrator:
             else:
                 wp.launch(
                     kernels.integrate_features_from_support_grouped_kernel,
-                    dim=(num_visible_blocks, n_cameras, feature_channel_groups),
+                    dim=(
+                        num_visible_blocks,
+                        kernels.feature_grid_voxels,
+                        feature_channel_groups,
+                    ),
                     inputs=feature_inputs,
                     device=device,
                     stream=stream,
@@ -881,7 +896,7 @@ class CameraProjectIntegrator:
             self._timer_start()
             wp.launch(
                 kernels.rescale_block_accumulators_kernel,
-                dim=(num_visible_blocks, kernels.feature_dim),
+                dim=(num_visible_blocks, kernels.feature_grid_voxels, kernels.feature_dim),
                 inputs=[
                     wp.from_torch(self.pool_indices),
                     num_visible_blocks,

--- a/curobo/_src/perception/mapper/kernel/wp_integrate_camera_project.py
+++ b/curobo/_src/perception/mapper/kernel/wp_integrate_camera_project.py
@@ -258,7 +258,6 @@ class CameraProjectIntegrator:
             dim=(max_clearable, block_voxels),
             inputs=[
                 data.block_data,
-                data.block_rgb,
                 data.new_blocks,
                 data.new_block_count,
                 tsdf.config.max_blocks,
@@ -267,21 +266,20 @@ class CameraProjectIntegrator:
             stream=stream,
         )
         self._timer_stop("clear_new_blocks_kernel")
-        if tsdf.data.has_color_grid:
-            self._timer_start()
-            wp.launch(
-                kernels.clear_new_block_grid_rgb_kernel,
-                dim=(max_clearable, kernels.color_grid_voxels * 4),
-                inputs=[
-                    data.block_grid_rgb,
-                    data.new_blocks,
-                    data.new_block_count,
-                    tsdf.config.max_blocks,
-                ],
-                device=device,
-                stream=stream,
-            )
-            self._timer_stop("clear_new_block_grid_rgb_kernel")
+        self._timer_start()
+        wp.launch(
+            kernels.clear_new_block_grid_rgb_kernel,
+            dim=(max_clearable, kernels.color_grid_voxels * 4),
+            inputs=[
+                data.block_grid_rgb,
+                data.new_blocks,
+                data.new_block_count,
+                tsdf.config.max_blocks,
+            ],
+            device=device,
+            stream=stream,
+        )
+        self._timer_stop("clear_new_block_grid_rgb_kernel")
         if tsdf.data.has_features:
             self._timer_start()
             feature_dim_cfg = tsdf.data.feature_dim
@@ -446,7 +444,6 @@ class CameraProjectIntegrator:
                     wp.from_torch(pool_indices),
                     wp.from_torch(self.clear_count),
                     data.block_data,
-                    data.block_rgb,
                     data.block_sums,
                     tsdf.config.max_blocks,
                 ],
@@ -454,19 +451,18 @@ class CameraProjectIntegrator:
                 stream=stream,
             )
 
-        if tsdf.data.has_color_grid:
-            wp.launch(
-                kernels.clear_block_grid_rgb_by_pool_kernel,
-                dim=(n_clear, kernels.color_grid_voxels * 4),
-                inputs=[
-                    wp.from_torch(pool_indices),
-                    wp.from_torch(self.clear_count),
-                    data.block_grid_rgb,
-                    tsdf.config.max_blocks,
-                ],
-                device=device,
-                stream=stream,
-            )
+        wp.launch(
+            kernels.clear_block_grid_rgb_by_pool_kernel,
+            dim=(n_clear, kernels.color_grid_voxels * 4),
+            inputs=[
+                wp.from_torch(pool_indices),
+                wp.from_torch(self.clear_count),
+                data.block_grid_rgb,
+                tsdf.config.max_blocks,
+            ],
+            device=device,
+            stream=stream,
+        )
 
         if tsdf.data.has_features:
             feature_dim = tsdf.data.feature_dim
@@ -732,9 +728,7 @@ class CameraProjectIntegrator:
                 "MapperCfg.feature_dim or BlockSparseTSDFIntegratorCfg.feature_dim."
             )
 
-        needs_support_pixels = (not tsdf.data.has_color_grid) or (
-            tsdf.data.has_features and feature_grid is not None
-        )
+        needs_support_pixels = tsdf.data.has_features and feature_grid is not None
         if needs_support_pixels:
             self._build_support_pixels(
                 tsdf,
@@ -770,45 +764,27 @@ class CameraProjectIntegrator:
             stream=stream,
         )
         self._timer_stop("integrate_voxels_kernel")
-        if tsdf.data.has_color_grid:
-            self._timer_start()
-            wp.launch(
-                kernels.integrate_block_grid_rgb_kernel,
-                dim=(num_visible_blocks, kernels.color_grid_voxels),
-                inputs=[
-                    wp.from_torch(self.pool_indices),
-                    num_visible_blocks,
-                    wp.from_torch(intrinsics, dtype=wp.float32),
-                    wp.from_torch(cam_positions, dtype=wp.float32),
-                    wp.from_torch(cam_quaternions, dtype=wp.float32),
-                    wp.from_torch(depth_images, dtype=wp.float32),
-                    wp.from_torch(rgb_flat, dtype=wp.uint8),
-                    depth_min,
-                    depth_max,
-                    data.block_coords,
-                    data.block_grid_rgb,
-                ],
-                device=device,
-                stream=stream,
-            )
-            self._timer_stop("integrate_block_grid_rgb_kernel")
-        else:
-            self._timer_start()
-            wp.launch(
-                kernels.integrate_block_rgb_from_support_kernel,
-                dim=(num_visible_blocks, n_cameras),
-                inputs=[
-                    wp.from_torch(self.pool_indices),
-                    num_visible_blocks,
-                    wp.from_torch(self.support_counts),
-                    wp.from_torch(self.support_pixels),
-                    wp.from_torch(rgb_flat, dtype=wp.uint8),
-                    data.block_rgb,
-                ],
-                device=device,
-                stream=stream,
-            )
-            self._timer_stop("integrate_block_rgb_from_support_kernel")
+        self._timer_start()
+        wp.launch(
+            kernels.integrate_block_grid_rgb_kernel,
+            dim=(num_visible_blocks, kernels.color_grid_voxels),
+            inputs=[
+                wp.from_torch(self.pool_indices),
+                num_visible_blocks,
+                wp.from_torch(intrinsics, dtype=wp.float32),
+                wp.from_torch(cam_positions, dtype=wp.float32),
+                wp.from_torch(cam_quaternions, dtype=wp.float32),
+                wp.from_torch(depth_images, dtype=wp.float32),
+                wp.from_torch(rgb_flat, dtype=wp.vec3ub),
+                depth_min,
+                depth_max,
+                data.block_coords,
+                data.block_grid_rgb,
+            ],
+            device=device,
+            stream=stream,
+        )
+        self._timer_stop("integrate_block_grid_rgb_kernel")
 
         if tsdf.data.has_features and feature_grid is not None:
             self._timer_start()
@@ -900,39 +876,34 @@ class CameraProjectIntegrator:
                 feature_kernel_name = "integrate_features_from_support_grouped_kernel"
             self._timer_stop(feature_kernel_name)
 
-        # Cap fp16 accumulators so weighted sums stay finite while preserving
-        # means. Block RGB is only touched on the legacy color path; the
-        # optional RGB grid has its own per-node rescale kernel.
-        if (not tsdf.data.has_color_grid) or tsdf.data.has_features:
+        # Cap fp16 accumulators so weighted sums stay finite while preserving means.
+        if tsdf.data.has_features:
             self._timer_start()
-            n_channels = max(3, kernels.feature_dim)
             wp.launch(
                 kernels.rescale_block_accumulators_kernel,
-                dim=(num_visible_blocks, n_channels),
+                dim=(num_visible_blocks, kernels.feature_dim),
                 inputs=[
                     wp.from_torch(self.pool_indices),
                     num_visible_blocks,
                     float(tsdf.config.accumulator_w_max),
                     data.block_features,
                     data.block_feature_weight,
-                    data.block_rgb,
                 ],
                 device=device,
                 stream=stream,
             )
             self._timer_stop("rescale_block_accumulators_kernel")
-        if tsdf.data.has_color_grid:
-            self._timer_start()
-            wp.launch(
-                kernels.rescale_block_grid_rgb_kernel,
-                dim=(num_visible_blocks, kernels.color_grid_voxels * 3),
-                inputs=[
-                    wp.from_torch(self.pool_indices),
-                    num_visible_blocks,
-                    float(tsdf.config.accumulator_w_max),
-                    data.block_grid_rgb,
-                ],
-                device=device,
-                stream=stream,
-            )
-            self._timer_stop("rescale_block_grid_rgb_kernel")
+        self._timer_start()
+        wp.launch(
+            kernels.rescale_block_grid_rgb_kernel,
+            dim=(num_visible_blocks, kernels.color_grid_voxels * 3),
+            inputs=[
+                wp.from_torch(self.pool_indices),
+                num_visible_blocks,
+                float(tsdf.config.accumulator_w_max),
+                data.block_grid_rgb,
+            ],
+            device=device,
+            stream=stream,
+        )
+        self._timer_stop("rescale_block_grid_rgb_kernel")

--- a/curobo/_src/perception/mapper/kernel/wp_integrate_lidar_project.py
+++ b/curobo/_src/perception/mapper/kernel/wp_integrate_lidar_project.py
@@ -254,7 +254,7 @@ class LidarProjectIntegrator:
             self._timer_start()
             wp.launch(
                 kernels.clear_new_block_features_kernel,
-                dim=(max_clearable, tsdf.data.feature_dim),
+                dim=(max_clearable, kernels.feature_grid_voxels, tsdf.data.feature_dim),
                 inputs=[
                     data.block_features,
                     data.block_feature_weight,
@@ -335,6 +335,25 @@ class LidarProjectIntegrator:
                 f"rgb_images shape mismatch: expected {expected_rgb_shape}, "
                 f"got {tuple(rgb_images.shape)}."
             )
+        feature_dim_cfg = tsdf.data.feature_dim if tsdf.data.has_features else 0
+        if feature_grid is not None and not tsdf.data.has_features:
+            log_and_raise(
+                "feature_grid was provided but feature_dim == 0; enable features via "
+                "MapperCfg.feature_dim or BlockSparseTSDFIntegratorCfg.feature_dim."
+            )
+        integrate_features = tsdf.data.has_features and feature_grid is not None
+        if integrate_features:
+            expected_feature_shape = (
+                self.lidar_num_sensors,
+                self.lidar_feature_grid_shape[0],
+                self.lidar_feature_grid_shape[1],
+                feature_dim_cfg,
+            )
+            if tuple(feature_grid.shape) != expected_feature_shape:
+                log_and_raise(
+                    f"feature_grid shape mismatch: expected {expected_feature_shape}, "
+                    f"got {tuple(feature_grid.shape)}."
+                )
 
         data = tsdf.get_warp_data()
         device, stream = get_warp_device_stream(range_images)
@@ -371,7 +390,9 @@ class LidarProjectIntegrator:
                 f"{self.max_visible_blocks_per_lidar_integration}. Increase the config value."
             )
 
-        self._build_support_pixels(tsdf, kernels, data, n_keys, self.frame_epoch, device, stream)
+        self._build_support_pixels(
+            tsdf, kernels, data, n_keys, self.frame_epoch, device, stream
+        )
         self._clear_new_blocks(tsdf, kernels, data, num_visible_blocks, device, stream)
 
         block_voxels = tsdf.block_size**3
@@ -404,42 +425,37 @@ class LidarProjectIntegrator:
         )
         self._timer_start()
         wp.launch(
-            kernels.lidar_integrate_block_grid_rgb_from_support_kernel,
+            kernels.lidar_integrate_block_grid_rgb_kernel,
             dim=(num_visible_blocks, self.lidar_num_sensors, kernels.color_grid_voxels),
             inputs=[
                 wp.from_torch(self.pool_indices),
                 num_visible_blocks,
+                wp.from_torch(lidar_positions, dtype=wp.float32),
+                wp.from_torch(lidar_quaternions, dtype=wp.float32),
+                wp.from_torch(range_images, dtype=wp.float32),
+                wp.from_torch(rgb_flat, dtype=wp.vec3ub),
                 wp.from_torch(self.support_counts),
                 wp.from_torch(self.support_pixels),
-                wp.from_torch(rgb_flat, dtype=wp.uint8),
+                wp.from_torch(valid_range_m, dtype=wp.float32),
+                wp.from_torch(elevation_range_rad, dtype=wp.float32),
+                data.block_coords,
                 data.block_grid_rgb,
             ],
             device=device,
             stream=stream,
         )
-        self._timer_stop("lidar_integrate_block_grid_rgb_from_support_kernel")
+        self._timer_stop("lidar_integrate_block_grid_rgb_kernel")
 
-        feature_dim_cfg = tsdf.data.feature_dim if tsdf.data.has_features else 0
-        if feature_grid is not None and not tsdf.data.has_features:
-            log_and_raise(
-                "feature_grid was provided but feature_dim == 0; enable features via "
-                "MapperCfg.feature_dim or BlockSparseTSDFIntegratorCfg.feature_dim."
-            )
-        if tsdf.data.has_features and feature_grid is not None:
-            expected_feature_shape = (
-                self.lidar_num_sensors,
-                self.lidar_feature_grid_shape[0],
-                self.lidar_feature_grid_shape[1],
-                feature_dim_cfg,
-            )
-            if tuple(feature_grid.shape) != expected_feature_shape:
-                log_and_raise(
-                    f"feature_grid shape mismatch: expected {expected_feature_shape}, "
-                    f"got {tuple(feature_grid.shape)}."
-                )
+        if integrate_features:
             feature_inputs = [
                 wp.from_torch(self.pool_indices),
                 num_visible_blocks,
+                wp.from_torch(lidar_positions, dtype=wp.float32),
+                wp.from_torch(lidar_quaternions, dtype=wp.float32),
+                wp.from_torch(range_images, dtype=wp.float32),
+                wp.from_torch(valid_range_m, dtype=wp.float32),
+                wp.from_torch(elevation_range_rad, dtype=wp.float32),
+                data.block_coords,
                 wp.from_torch(self.support_counts),
                 wp.from_torch(self.support_pixels),
                 wp.from_torch(feature_grid, dtype=wp.float16),
@@ -457,7 +473,11 @@ class LidarProjectIntegrator:
                 ) // feature_tile_channels
                 wp.launch_tiled(
                     kernels.lidar_integrate_features_from_support_tiled_kernel,
-                    dim=(num_visible_blocks, self.lidar_num_sensors, feature_channel_tiles),
+                    dim=(
+                        num_visible_blocks,
+                        self.lidar_num_sensors,
+                        kernels.feature_grid_voxels * feature_channel_tiles,
+                    ),
                     block_dim=64,
                     inputs=feature_inputs,
                     device=device,
@@ -467,7 +487,11 @@ class LidarProjectIntegrator:
             else:
                 wp.launch(
                     kernels.lidar_integrate_features_from_support_grouped_kernel,
-                    dim=(num_visible_blocks, self.lidar_num_sensors, feature_channel_groups),
+                    dim=(
+                        num_visible_blocks,
+                        self.lidar_num_sensors,
+                        kernels.feature_grid_voxels * feature_channel_groups,
+                    ),
                     inputs=feature_inputs,
                     device=device,
                     stream=stream,
@@ -479,7 +503,7 @@ class LidarProjectIntegrator:
             self._timer_start()
             wp.launch(
                 kernels.rescale_block_accumulators_kernel,
-                dim=(num_visible_blocks, kernels.feature_dim),
+                dim=(num_visible_blocks, kernels.feature_grid_voxels, kernels.feature_dim),
                 inputs=[
                     wp.from_torch(self.pool_indices),
                     num_visible_blocks,

--- a/curobo/_src/perception/mapper/kernel/wp_integrate_lidar_project.py
+++ b/curobo/_src/perception/mapper/kernel/wp_integrate_lidar_project.py
@@ -228,7 +228,6 @@ class LidarProjectIntegrator:
             dim=(max_clearable, block_voxels),
             inputs=[
                 data.block_data,
-                data.block_rgb,
                 data.new_blocks,
                 data.new_block_count,
                 tsdf.config.max_blocks,
@@ -237,6 +236,20 @@ class LidarProjectIntegrator:
             stream=stream,
         )
         self._timer_stop("clear_new_blocks_kernel")
+        self._timer_start()
+        wp.launch(
+            kernels.clear_new_block_grid_rgb_kernel,
+            dim=(max_clearable, kernels.color_grid_voxels * 4),
+            inputs=[
+                data.block_grid_rgb,
+                data.new_blocks,
+                data.new_block_count,
+                tsdf.config.max_blocks,
+            ],
+            device=device,
+            stream=stream,
+        )
+        self._timer_stop("clear_new_block_grid_rgb_kernel")
         if tsdf.data.has_features:
             self._timer_start()
             wp.launch(
@@ -391,20 +404,20 @@ class LidarProjectIntegrator:
         )
         self._timer_start()
         wp.launch(
-            kernels.lidar_integrate_block_rgb_from_support_kernel,
-            dim=(num_visible_blocks, self.lidar_num_sensors),
+            kernels.lidar_integrate_block_grid_rgb_from_support_kernel,
+            dim=(num_visible_blocks, self.lidar_num_sensors, kernels.color_grid_voxels),
             inputs=[
                 wp.from_torch(self.pool_indices),
                 num_visible_blocks,
                 wp.from_torch(self.support_counts),
                 wp.from_torch(self.support_pixels),
                 wp.from_torch(rgb_flat, dtype=wp.uint8),
-                data.block_rgb,
+                data.block_grid_rgb,
             ],
             device=device,
             stream=stream,
         )
-        self._timer_stop("lidar_integrate_block_rgb_from_support_kernel")
+        self._timer_stop("lidar_integrate_block_grid_rgb_from_support_kernel")
 
         feature_dim_cfg = tsdf.data.feature_dim if tsdf.data.has_features else 0
         if feature_grid is not None and not tsdf.data.has_features:
@@ -462,20 +475,34 @@ class LidarProjectIntegrator:
                 feature_kernel_name = "lidar_integrate_features_from_support_grouped_kernel"
             self._timer_stop(feature_kernel_name)
 
+        if tsdf.data.has_features:
+            self._timer_start()
+            wp.launch(
+                kernels.rescale_block_accumulators_kernel,
+                dim=(num_visible_blocks, kernels.feature_dim),
+                inputs=[
+                    wp.from_torch(self.pool_indices),
+                    num_visible_blocks,
+                    float(tsdf.config.accumulator_w_max),
+                    data.block_features,
+                    data.block_feature_weight,
+                ],
+                device=device,
+                stream=stream,
+            )
+            self._timer_stop("rescale_block_accumulators_kernel")
+
         self._timer_start()
-        n_channels = max(3, kernels.feature_dim)
         wp.launch(
-            kernels.rescale_block_accumulators_kernel,
-            dim=(num_visible_blocks, n_channels),
+            kernels.rescale_block_grid_rgb_kernel,
+            dim=(num_visible_blocks, kernels.color_grid_voxels * 3),
             inputs=[
                 wp.from_torch(self.pool_indices),
                 num_visible_blocks,
                 float(tsdf.config.accumulator_w_max),
-                data.block_features,
-                data.block_feature_weight,
-                data.block_rgb,
+                data.block_grid_rgb,
             ],
             device=device,
             stream=stream,
         )
-        self._timer_stop("rescale_block_accumulators_kernel")
+        self._timer_stop("rescale_block_grid_rgb_kernel")

--- a/curobo/_src/perception/mapper/kernel/wp_stamp_obstacles.py
+++ b/curobo/_src/perception/mapper/kernel/wp_stamp_obstacles.py
@@ -370,10 +370,9 @@ def stamp_obstacles(
         stream=stream,
     )
 
-    # ``block_rgb`` stores uint8-normalized weighted sums (RGB in [0, 1]).
+    # ``block_grid_rgb`` stores uint8-normalized weighted sums (RGB in [0, 1]).
     # Callers pass uint8-style colors (e.g. (20, 20, 20)); divide by 255
-    # so the stored accumulator matches the dynamic-channel convention
-    # and ``compute_avg_rgb_*_from_block`` recover the intended color.
+    # so the stored accumulator matches the dynamic-channel convention.
     inv_255 = 1.0 / 255.0
     static_rgb = wp.vec3(
         float(static_color[0]) * inv_255,
@@ -381,10 +380,10 @@ def stamp_obstacles(
         float(static_color[2]) * inv_255,
     )
     wp.launch(
-        kernel=kernels.update_block_rgb_kernel,
-        dim=n_unique,
+        kernel=kernels.update_block_grid_rgb_kernel,
+        dim=(n_unique, kernels.color_grid_voxels),
         inputs=[
-            warp_tsdf.block_rgb,
+            warp_tsdf.block_grid_rgb,
             wp.from_torch(pool_indices, dtype=wp.int32),
             n_unique,
             static_rgb,

--- a/curobo/_src/perception/mapper/kernel/wp_voxel_extraction.py
+++ b/curobo/_src/perception/mapper/kernel/wp_voxel_extraction.py
@@ -27,11 +27,14 @@ from curobo._src.util.warp import get_warp_device_stream, init_warp
 def _build_block_data_view(tsdf, num_alloc: int) -> BlockDataView:
     """Zero-copy view over per-block storage tensors."""
     return BlockDataView(
-        rgb=tsdf.data.block_rgb,
+        rgb_grid=tsdf.data.block_grid_rgb,
         coords=tsdf.data.block_coords,
         num_allocated=num_alloc,
+        origin=tsdf.data.origin,
         voxel_size=tsdf.config.voxel_size,
         block_size=tsdf.block_size,
+        grid_shape=tsdf.config.grid_shape,
+        color_grid_size=tsdf.data.color_grid_size,
         features=tsdf.data.block_features,
         feature_weight=tsdf.data.block_feature_weight,
         feature_dim=tsdf.data.feature_dim,
@@ -254,8 +257,8 @@ def extract_matching_voxels_block_sparse(
 
     if block_mask.dtype != torch.uint8:
         block_mask = block_mask.to(torch.uint8)
-    if block_mask.device != tsdf.data.block_rgb.device:
-        block_mask = block_mask.to(tsdf.data.block_rgb.device)
+    if block_mask.device != tsdf.data.block_grid_rgb.device:
+        block_mask = block_mask.to(tsdf.data.block_grid_rgb.device)
     if block_mask.shape[0] < tsdf.config.max_blocks:
         raise ValueError(
             f"block_mask must cover max_blocks={tsdf.config.max_blocks} entries, "

--- a/curobo/_src/perception/mapper/kernel/wp_voxel_extraction.py
+++ b/curobo/_src/perception/mapper/kernel/wp_voxel_extraction.py
@@ -35,6 +35,7 @@ def _build_block_data_view(tsdf, num_alloc: int) -> BlockDataView:
         block_size=tsdf.block_size,
         grid_shape=tsdf.config.grid_shape,
         color_grid_size=tsdf.data.color_grid_size,
+        feature_block_grid_size=tsdf.data.feature_block_grid_size,
         features=tsdf.data.block_features,
         feature_weight=tsdf.data.block_feature_weight,
         feature_dim=tsdf.data.feature_dim,

--- a/curobo/_src/perception/mapper/mapper.py
+++ b/curobo/_src/perception/mapper/mapper.py
@@ -26,6 +26,7 @@ Example:
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from os import PathLike
 from typing import Callable, Optional, Tuple, Union
 
@@ -130,6 +131,9 @@ class Mapper:
             num_cameras=config.num_cameras,
             image_height=config.image_height,
             image_width=config.image_width,
+            texture_num_cameras=config.texture_num_cameras,
+            texture_camera_image_height=config.texture_camera_image_height,
+            texture_camera_image_width=config.texture_camera_image_width,
             lidar_num_sensors=config.lidar_num_sensors,
             lidar_image_height=config.lidar_image_height,
             lidar_image_width=config.lidar_image_width,
@@ -149,6 +153,7 @@ class Mapper:
             block_size=config.block_size,
             roughness=config.roughness,
             feature_dim=config.feature_dim,
+            feature_block_grid_size=config.feature_block_grid_size,
             feature_grid_height=config.feature_grid_height,
             feature_grid_width=config.feature_grid_width,
             max_visible_blocks_per_integration=config.max_visible_blocks_per_integration,
@@ -158,6 +163,7 @@ class Mapper:
             feature_integration_kernel=config.feature_integration_kernel,
             profile_integration_kernel_timings=config.profile_integration_kernel_timings,
             accumulator_w_max=config.accumulator_w_max,
+            color_grid_size=config.color_grid_size,
         )
 
         self._integrator = BlockSparseESDFIntegrator(integrator_config)
@@ -304,17 +310,14 @@ class Mapper:
 
     def extract_mesh(
         self,
-        refine_iterations: int = 2,
+        refine_iterations: int = 0,
         surface_only: bool = True,
-        approximate: bool = False,
     ) -> Mesh:
-        """Extract mesh using GPU marching cubes.
+        """Extract a triangle-soup mesh using GPU marching cubes.
 
         Args:
             refine_iterations: Newton-Raphson iterations for vertex refinement.
             surface_only: Only extract mesh near surface.
-            approximate: If True, use the approximate triangle-soup extractor
-                instead of the shared-vertex extractor.
 
         Returns:
             Mesh object with vertices, faces, and colors.
@@ -322,13 +325,44 @@ class Mapper:
         return self._integrator.extract_mesh(
             refine_iterations=refine_iterations,
             surface_only=surface_only,
-            approximate=approximate,
+        )
+
+    def extract_textured_mesh(
+        self,
+        texture_observations: CameraObservation | Sequence[CameraObservation],
+        refine_iterations: int = 0,
+        surface_only: bool = True,
+        camera_min_distance: Optional[float] = None,
+        camera_max_distance: Optional[float] = None,
+        texture_depth_tolerance_m: Optional[float] = None,
+    ) -> Mesh:
+        """Extract a TSDF mesh with visibility-tested RGB texture.
+
+        This works with TSDF geometry built from camera or LiDAR observations.
+        Texture observations require RGB images, intrinsics, and poses. Optional
+        depth images must be aligned float32 camera-frame z depth in meters; when
+        omitted, visibility depth is rendered from the current TSDF.
+        """
+        return self._integrator.extract_textured_mesh(
+            texture_observations=texture_observations,
+            refine_iterations=refine_iterations,
+            surface_only=surface_only,
+            camera_min_distance=camera_min_distance,
+            camera_max_distance=camera_max_distance,
+            texture_depth_tolerance_m=texture_depth_tolerance_m,
         )
 
     def extract_occupied_voxels(
         self,
-        surface_only: bool = False,
+        surface_only: bool = True,
         sdf_threshold: Optional[float] = None,
+        *,
+        subvoxel_factor: int = 1,
+        max_points: Optional[int] = None,
+        texture_observations: CameraObservation | Sequence[CameraObservation] | None = None,
+        camera_min_distance: Optional[float] = None,
+        camera_max_distance: Optional[float] = None,
+        texture_depth_tolerance_m: Optional[float] = None,
     ) -> OccupiedVoxels:
         """Extract occupied voxel centers and per-voxel block indices.
 
@@ -337,6 +371,15 @@ class Mapper:
                 surface. If False, include inside voxels too.
             sdf_threshold: Surface threshold. Defaults to the underlying
                 TSDF integrator's voxel size.
+            subvoxel_factor: Number of sample points per extracted voxel axis.
+            max_points: Optional cap applied after subvoxel expansion by
+                deterministically downsampling source voxels before expansion.
+            texture_observations: Optional RGB observations used to color output
+                samples when they pass visibility-depth checks.
+            camera_min_distance: Minimum camera-frame z used for texture projection.
+            camera_max_distance: Maximum camera-frame z used for texture projection.
+            texture_depth_tolerance_m: Absolute visibility-depth tolerance. If
+                None, each sample uses the mapper default tolerance policy.
 
         Returns:
             :class:`OccupiedVoxels` with voxel centers, per-voxel block
@@ -345,6 +388,12 @@ class Mapper:
         return self._integrator.extract_occupied_voxels(
             surface_only=surface_only,
             sdf_threshold=sdf_threshold,
+            subvoxel_factor=subvoxel_factor,
+            max_points=max_points,
+            texture_observations=texture_observations,
+            camera_min_distance=camera_min_distance,
+            camera_max_distance=camera_max_distance,
+            texture_depth_tolerance_m=texture_depth_tolerance_m,
         )
 
     def extract_matching_feature_voxels(
@@ -528,12 +577,15 @@ class Mapper:
         """Render depth and normals from current TSDF.
 
         Args:
-            intrinsics: Camera intrinsics (3, 3) or (4,) as [fx, fy, cx, cy].
-            pose: Camera-to-world transform as Pose.
+            intrinsics: Camera intrinsics ``(3, 3)``, ``(4,)``, ``(N, 3, 3)``,
+                or ``(N, 4)`` as ``[fx, fy, cx, cy]``.
+            pose: Camera-to-world transform as :class:`Pose` with matching camera count.
             image_shape: (height, width) of output images.
 
         Returns:
-            Tuple of (depth, normals, valid_mask).
+            Tuple of ``(depth, normals, valid_mask)``. Unbatched single-camera
+            inputs return ``(H, W)``, ``(H, W, 3)``, and ``(H, W)``; batched
+            inputs return ``(N, H, W)``, ``(N, H, W, 3)``, and ``(N, H, W)``.
         """
         return self._get_renderer().render(intrinsics, pose, image_shape)
 
@@ -546,16 +598,15 @@ class Mapper:
         """Render depth, normals, and color from current TSDF.
 
         Args:
-            intrinsics: Camera intrinsics (3, 3) or (4,) as [fx, fy, cx, cy].
-            pose: Camera-to-world transform as Pose.
+            intrinsics: Camera intrinsics ``(3, 3)``, ``(4,)``, ``(N, 3, 3)``,
+                or ``(N, 4)`` as ``[fx, fy, cx, cy]``.
+            pose: Camera-to-world transform as :class:`Pose` with matching camera count.
             image_shape: (height, width) of output images.
 
         Returns:
             Tuple of (depth, normals, color, valid_mask).
-            - depth: (H, W) in meters
-            - normals: (H, W, 3) world-frame normals
-            - color: (H, W, 3) uint8 RGB
-            - valid_mask: (H, W) bool
+            Unbatched single-camera inputs keep ``(H, W)`` and ``(H, W, 3)``
+            shapes; batched inputs include a leading camera dimension.
         """
         return self._get_renderer().render_color(intrinsics, pose, image_shape)
 
@@ -569,11 +620,11 @@ class Mapper:
 
         Args:
             intrinsics: Camera intrinsics.
-            pose: Camera-to-world transform as Pose.
+            pose: Camera-to-world transform as :class:`Pose`.
             image_shape: (height, width) of output images.
 
         Returns:
-            depth: (H, W) in meters.
+            depth: ``(H, W)`` or ``(N, H, W)`` in meters.
         """
         return self._get_renderer().render_depth(intrinsics, pose, image_shape)
 
@@ -591,7 +642,7 @@ class Mapper:
             image_shape: (height, width) of output images.
 
         Returns:
-            color: (H, W, 3) uint8 RGB.
+            color: ``(H, W, 3)`` or ``(N, H, W, 3)`` uint8 RGB.
         """
         return self._get_renderer().render_color_only(intrinsics, pose, image_shape)
 
@@ -615,7 +666,7 @@ class Mapper:
             use_color: If True, use TSDF color. If False, use gray.
 
         Returns:
-            shaded: (H, W, 3) uint8 RGB shaded image.
+            shaded: ``(H, W, 3)`` or ``(N, H, W, 3)`` uint8 RGB shaded image.
         """
         return self._get_renderer().render_shaded(
             intrinsics, pose, image_shape, light_direction, ambient, use_color
@@ -635,7 +686,7 @@ class Mapper:
             image_shape: (height, width) of output images.
 
         Returns:
-            colormap: (H, W, 3) uint8 RGB colormap.
+            colormap: ``(H, W, 3)`` or ``(N, H, W, 3)`` uint8 RGB colormap.
         """
         return self._get_renderer().render_depth_colormap(
             intrinsics, pose, image_shape
@@ -655,6 +706,6 @@ class Mapper:
             image_shape: (height, width) of output images.
 
         Returns:
-            colormap: (H, W, 3) uint8 RGB colormap.
+            colormap: ``(H, W, 3)`` or ``(N, H, W, 3)`` uint8 RGB colormap.
         """
         return self._get_renderer().render_normal_colormap(intrinsics, pose, image_shape)

--- a/curobo/_src/perception/mapper/mapper.py
+++ b/curobo/_src/perception/mapper/mapper.py
@@ -185,6 +185,12 @@ class Mapper:
         Positional ``mapper.integrate(obs)`` calls remain supported. The
         ``observation=`` keyword is retained as a deprecated alias; prefer
         ``camera_observation=`` and/or ``lidar_observation=`` for new code.
+        For geometry-only mapping, pass a cached all-zero ``uint8`` RGB image
+        with the same batch and image shape as the depth or range image. When
+        using lower-level configs that expose color resolution, keep
+        ``color_grid_size=1``. This keeps geometry-only and colored mapping on
+        the same path; local benchmarks showed color work is typically less
+        than 10% of integration time.
 
         Args:
             observation: Deprecated keyword alias for one camera or LiDAR observation.

--- a/curobo/_src/perception/mapper/mapper.py
+++ b/curobo/_src/perception/mapper/mapper.py
@@ -300,12 +300,15 @@ class Mapper:
         self,
         refine_iterations: int = 2,
         surface_only: bool = True,
+        approximate: bool = False,
     ) -> Mesh:
         """Extract mesh using GPU marching cubes.
 
         Args:
             refine_iterations: Newton-Raphson iterations for vertex refinement.
             surface_only: Only extract mesh near surface.
+            approximate: If True, use the approximate triangle-soup extractor
+                instead of the shared-vertex extractor.
 
         Returns:
             Mesh object with vertices, faces, and colors.
@@ -313,6 +316,7 @@ class Mapper:
         return self._integrator.extract_mesh(
             refine_iterations=refine_iterations,
             surface_only=surface_only,
+            approximate=approximate,
         )
 
     def extract_occupied_voxels(

--- a/curobo/_src/perception/mapper/mapper_cfg.py
+++ b/curobo/_src/perception/mapper/mapper_cfg.py
@@ -24,6 +24,8 @@ import torch
 
 from curobo._src.perception.mapper.block_allocation import calculate_tsdf_max_blocks
 from curobo._src.perception.mapper.constants import (
+    _validate_color_grid_size,
+    _validate_feature_block_grid_size,
     _validate_feature_channels_per_thread,
     _validate_feature_grid_shape,
     _validate_feature_integration_kernel,
@@ -90,7 +92,7 @@ class MapperCfg:
     # === Block Storage ===
     #: Voxels per block edge. Supported values are 1 or powers of 2 in [2, 32]. See
     #: :class:`~curobo._src.perception.mapper.kernel.builder.builder_block_sparse_kernel.BlockSparseKernels`.
-    block_size: int = 4
+    block_size: int = 8
     # Target hash table active-entry fraction. 0.5 keeps probe chains short
     # enough that the average lookup cost stays low even after tombstone
     # accumulation from aggressive recycling. Lookup now probes the full
@@ -98,6 +100,8 @@ class MapperCfg:
     # safe from a correctness standpoint but costs probe time per lookup.
     hash_load_factor: float = 0.5
     roughness: float = 3.0
+    #: Number of RGBW control points per block edge.
+    color_grid_size: int = 1
 
     # === Integration ===
     seeding_method: str = "gather"
@@ -135,6 +139,17 @@ class MapperCfg:
     #: Camera image width in pixels. Required; see :attr:`image_height`.
     image_width: Optional[int] = None
 
+    # === Texture Cameras ===
+    #: Number of RGB cameras used by projective texture export. Defaults to
+    #: :attr:`num_cameras` when unset.
+    texture_num_cameras: Optional[int] = None
+    #: RGB texture camera image height in pixels. Defaults to
+    #: :attr:`image_height` when unset.
+    texture_camera_image_height: Optional[int] = None
+    #: RGB texture camera image width in pixels. Defaults to
+    #: :attr:`image_width` when unset.
+    texture_camera_image_width: Optional[int] = None
+
     # === LiDARs ===
     #: Number of batched LiDAR range images accepted by the optional LiDAR
     #: integrator. ``0`` disables LiDAR integration.
@@ -160,6 +175,9 @@ class MapperCfg:
     # === Per-block Features ===
     #: Per-block feature channel dimensionality. 0 disables features.
     feature_dim: int = 0
+    #: Number of feature control points per block edge. This is independent
+    #: from the incoming 2D feature image dimensions below.
+    feature_block_grid_size: int = 1
     #: Compile-time feature-grid height. Required when ``feature_dim > 0``;
     #: must be ``None`` when features are disabled.
     feature_grid_height: Optional[int] = None
@@ -190,8 +208,8 @@ class MapperCfg:
     #: Disabled by default to avoid profiling synchronizations in normal
     #: integration.
     profile_integration_kernel_timings: bool = False
-    #: Upper bound on per-block accumulator weight. Caps fp16
-    #: ``block_grid_rgb`` / ``block_features`` magnitudes each frame and sets
+    #: Upper bound on each RGB or feature-grid node's accumulator weight.
+    #: Caps fp16 ``block_grid_rgb`` / ``block_features`` magnitudes each frame and sets
     #: the EMA decay rate for old observations (effective window
     #: ``~W_max / mean_per_frame_weight``). Raise for longer memory,
     #: lower for faster adaptation to dynamic scenes.
@@ -242,11 +260,44 @@ class MapperCfg:
                 f"image_height and image_width must be positive, got "
                 f"image_height={self.image_height}, image_width={self.image_width}."
             )
+        if self.num_cameras <= 0:
+            log_and_raise(f"num_cameras must be positive, got num_cameras={self.num_cameras}.")
+        if (
+            self.texture_camera_image_height is None
+        ) != (self.texture_camera_image_width is None):
+            log_and_raise(
+                "texture_camera_image_height and texture_camera_image_width must be "
+                "specified together."
+            )
+        if self.texture_num_cameras is None:
+            self.texture_num_cameras = self.num_cameras
+        if self.texture_camera_image_height is None:
+            self.texture_camera_image_height = self.image_height
+            self.texture_camera_image_width = self.image_width
+        if self.texture_num_cameras <= 0:
+            log_and_raise(
+                "texture_num_cameras must be positive, got "
+                f"texture_num_cameras={self.texture_num_cameras}."
+            )
+        if (
+            self.texture_camera_image_height <= 0
+            or self.texture_camera_image_width <= 0
+        ):
+            log_and_raise(
+                "texture_camera_image_height and texture_camera_image_width must be "
+                "positive, got "
+                f"{self.texture_camera_image_height}x{self.texture_camera_image_width}."
+            )
         _validate_feature_channels_per_thread(self.feature_channels_per_thread)
         _validate_feature_grid_shape(
             self.feature_dim,
             self.feature_grid_height,
             self.feature_grid_width,
+        )
+        _validate_color_grid_size(self.color_grid_size, self.block_size)
+        _validate_feature_block_grid_size(
+            self.feature_block_grid_size,
+            self.block_size,
         )
         _validate_lidar_config(
             self.lidar_num_sensors,

--- a/curobo/_src/perception/mapper/mapper_cfg.py
+++ b/curobo/_src/perception/mapper/mapper_cfg.py
@@ -191,7 +191,7 @@ class MapperCfg:
     #: integration.
     profile_integration_kernel_timings: bool = False
     #: Upper bound on per-block accumulator weight. Caps fp16
-    #: ``block_rgb`` / ``block_features`` magnitudes each frame and sets
+    #: ``block_grid_rgb`` / ``block_features`` magnitudes each frame and sets
     #: the EMA decay rate for old observations (effective window
     #: ``~W_max / mean_per_frame_weight``). Raise for longer memory,
     #: lower for faster adaptation to dynamic scenes.

--- a/curobo/_src/perception/mapper/mesh_extractor.py
+++ b/curobo/_src/perception/mapper/mesh_extractor.py
@@ -6,8 +6,8 @@
 
 The Warp kernels and helpers are built by
 :func:`curobo._src.perception.mapper.kernel.builder.builder_mesh.make_mesh_kernels`
-and are reached through ``tsdf.kernels`` at launch time. This module
-only hosts the public :func:`extract_mesh_block_sparse` Python API.
+and are reached through ``tsdf.kernels`` at launch time. This module hosts the
+single Python mesh extraction API for block-sparse TSDF storage.
 """
 
 from __future__ import annotations
@@ -20,10 +20,17 @@ import warp as wp
 from curobo._src.perception.mapper.marching_cubes.kernel.wp_mc_common import (
     MCLookupTables,
 )
-from curobo._src.perception.mapper.marching_cubes.kernel.wp_mc_filter import (
-    filter_triangles,
-)
 from curobo._src.util.warp import get_warp_device_stream
+
+
+def _empty_mesh(
+    device: str,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return (
+        torch.empty((0, 3), dtype=torch.float32, device=device),
+        torch.empty((0, 3), dtype=torch.float32, device=device),
+        torch.empty((0, 3), dtype=torch.uint8, device=device),
+    )
 
 
 def extract_mesh_block_sparse(
@@ -32,22 +39,22 @@ def extract_mesh_block_sparse(
     surface_only: bool = False,
     refine_iterations: int = 0,
     minimum_tsdf_weight: float = 0.1,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Extract mesh from block-sparse TSDF using marching cubes with edge sharing.
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Extract a triangle-soup mesh from a block-sparse TSDF.
 
-    This version uses shared vertices to reduce vertex count by ~3x
-    compared to the non-shared version.
+    Each triangle owns its three vertices. Faces are identity indices and can
+    be created by callers that need a face tensor.
 
     Args:
         tsdf: BlockSparseTSDF instance.
-        level: Isosurface level (typically 0.0).
+        level: Isosurface level, typically ``0.0``.
         surface_only: If True, only extract mesh near the surface.
         refine_iterations: Number of Newton-Raphson iterations for vertex
-            refinement. 0 = no refinement.
-        minimum_tsdf_weight: Minimum weight to consider a voxel as observed.
+            refinement. ``0`` keeps linear edge interpolation.
+        minimum_tsdf_weight: Minimum weight to consider a voxel observed.
 
     Returns:
-        Tuple of (vertices, triangles, normals, colors).
+        Tuple of ``(vertices, normals, colors)``.
     """
     device = tsdf.device
     mc_tables = MCLookupTables.get(device)
@@ -55,263 +62,11 @@ def extract_mesh_block_sparse(
     num_alloc = int(tsdf.data.num_allocated.item())
     kernels = tsdf.kernels
 
-    empty_result = (
-        torch.empty((0, 3), dtype=torch.float32, device=device),
-        torch.empty((0, 3), dtype=torch.int32, device=device),
-        torch.empty((0, 3), dtype=torch.float32, device=device),
-        torch.empty((0, 3), dtype=torch.uint8, device=device),
-    )
-
     if num_alloc == 0:
-        return empty_result
+        return _empty_mesh(device)
 
     surface_band = tsdf.config.truncation_distance if surface_only else 0.0
-
-    block_size = tsdf.block_size
-    block_voxels = block_size**3
-
-    # Step 1a: Count surface cubes.
-    surface_count = torch.zeros(1, dtype=torch.int32, device=device)
-    wp_device, stream = get_warp_device_stream(surface_count)
-
-    wp.launch(
-        kernels.count_surface_cubes_kernel,
-        dim=(num_alloc, block_voxels),
-        inputs=[
-            warp_data,
-            level,
-            surface_band,
-            minimum_tsdf_weight,
-            wp.from_torch(surface_count, dtype=wp.int32),
-        ],
-        device=wp_device,
-        stream=stream,
-        adjoint=False,
-    )
-
-    n_surfaces = int(surface_count.item())
-    if n_surfaces == 0:
-        return empty_result
-
-    # Step 1b: Allocate + append.
-    surface_block_idx = torch.zeros(n_surfaces, dtype=torch.int32, device=device)
-    surface_cube_idx = torch.zeros(n_surfaces, dtype=torch.int32, device=device)
-
-    surface_count.zero_()
-
-    wp.launch(
-        kernels.append_surface_cubes_kernel,
-        dim=(num_alloc, block_voxels),
-        inputs=[
-            warp_data,
-            level,
-            surface_band,
-            minimum_tsdf_weight,
-            wp.from_torch(surface_count, dtype=wp.int32),
-            wp.from_torch(surface_block_idx, dtype=wp.int32),
-            wp.from_torch(surface_cube_idx, dtype=wp.int32),
-        ],
-        device=wp_device,
-        stream=stream,
-    )
-
-    # Step 2: Count owned edges.
-    edge_counts = torch.zeros(n_surfaces, dtype=torch.int32, device=device)
-    wp.launch(
-        kernels.count_edges_block_sparse_kernel,
-        dim=n_surfaces,
-        inputs=[
-            warp_data,
-            level,
-            minimum_tsdf_weight,
-            wp.from_torch(surface_block_idx, dtype=wp.int32),
-            wp.from_torch(surface_cube_idx, dtype=wp.int32),
-            n_surfaces,
-            wp.from_torch(edge_counts, dtype=wp.int32),
-        ],
-        device=wp_device,
-        stream=stream,
-    )
-
-    # Step 3: Prefix sum → vertex offsets.
-    edge_offsets = torch.zeros(n_surfaces, dtype=torch.int32, device=device)
-    if n_surfaces > 0:
-        edge_offsets[1:] = torch.cumsum(edge_counts[:-1], dim=0)
-    total_vertices = int(edge_counts.sum().item())
-
-    if total_vertices == 0:
-        return empty_result
-
-    # Step 4: Generate vertices for owned edges.
-    vertices = torch.zeros((total_vertices, 3), dtype=torch.float32, device=device)
-    normals = torch.zeros((total_vertices, 3), dtype=torch.float32, device=device)
-    edge_vertex_indices = torch.full((n_surfaces * 3,), -1, dtype=torch.int32, device=device)
-
-    wp.launch(
-        kernels.generate_vertices_block_sparse_kernel,
-        dim=n_surfaces,
-        inputs=[
-            warp_data,
-            level,
-            minimum_tsdf_weight,
-            wp.from_torch(surface_block_idx, dtype=wp.int32),
-            wp.from_torch(surface_cube_idx, dtype=wp.int32),
-            wp.from_torch(edge_offsets, dtype=wp.int32),
-            n_surfaces,
-            refine_iterations,
-            wp.from_torch(vertices, dtype=wp.vec3),
-            wp.from_torch(normals, dtype=wp.vec3),
-            wp.from_torch(edge_vertex_indices, dtype=wp.int32),
-        ],
-        device=wp_device,
-        stream=stream,
-    )
-
-    # Step 5: Sort surface cubes for binary-search lookup.
-    global_ids = surface_block_idx.to(torch.int64) * int(block_voxels) + surface_cube_idx.to(
-        torch.int64
-    )
-    sorted_global_ids, sort_order = torch.sort(global_ids)
-    sparse_indices_sorted = sort_order.to(torch.int32)
-
-    # Step 6: Count triangles per surface cube.
-    tri_counts = torch.zeros(n_surfaces, dtype=torch.int32, device=device)
-    wp.launch(
-        kernels.count_triangles_kernel,
-        dim=n_surfaces,
-        inputs=[
-            warp_data,
-            level,
-            minimum_tsdf_weight,
-            wp.from_torch(surface_block_idx, dtype=wp.int32),
-            wp.from_torch(surface_cube_idx, dtype=wp.int32),
-            n_surfaces,
-            mc_tables.num_tris_table,
-            wp.from_torch(tri_counts, dtype=wp.int32),
-        ],
-        device=wp_device,
-        stream=stream,
-    )
-
-    # Step 7: Prefix sum → triangle offsets.
-    tri_offsets = torch.zeros(n_surfaces, dtype=torch.int32, device=device)
-    if n_surfaces > 0:
-        tri_offsets[1:] = torch.cumsum(tri_counts[:-1], dim=0)
-    total_tris = int(tri_counts.sum().item())
-
-    if total_tris == 0:
-        return empty_result
-
-    # Step 8: Generate triangles with shared-vertex lookup. Allocate as
-    # a flat tensor because the kernel indexes it as ``triangles[i * 3 + j]``;
-    # return it reshaped to (M, 3) for the caller.
-    triangles_flat = torch.full(
-        (total_tris * 3,),
-        -1,
-        dtype=torch.int32,
-        device=device,
-    )
-
-    wp.launch(
-        kernels.generate_triangles_shared_kernel,
-        dim=n_surfaces,
-        inputs=[
-            warp_data,
-            level,
-            minimum_tsdf_weight,
-            wp.from_torch(surface_block_idx, dtype=wp.int32),
-            wp.from_torch(surface_cube_idx, dtype=wp.int32),
-            wp.from_torch(tri_offsets, dtype=wp.int32),
-            n_surfaces,
-            mc_tables.tri_table,
-            mc_tables.edge_owner,
-            wp.from_torch(sorted_global_ids, dtype=wp.int64),
-            wp.from_torch(sparse_indices_sorted, dtype=wp.int32),
-            wp.from_torch(edge_vertex_indices, dtype=wp.int32),
-            wp.from_torch(triangles_flat, dtype=wp.int32),
-        ],
-        device=wp_device,
-        stream=stream,
-    )
-
-    triangles = triangles_flat.view(total_tris, 3)
-
-    # Step 9: Filter out invalid (unresolved -1 indices) and degenerate
-    # triangles. Triangles on the boundary of the observed region can
-    # reference edges owned by cubes that are not in the surface list
-    # (owner block not allocated); those entries stay as -1 and are
-    # compacted out here. Also flips winding so normals point outward.
-    triangles = filter_triangles(
-        triangles,
-        vertices,
-        tsdf.config.voxel_size,
-        flip_winding=True,
-    )
-
-    # Step 10: Sample vertex colors.
-    colors = torch.zeros(
-        (total_vertices, 3),
-        dtype=torch.uint8,
-        device=device,
-    )
-    wp.launch(
-        kernels.sample_vertex_colors_kernel,
-        dim=total_vertices,
-        inputs=[
-            wp.from_torch(vertices, dtype=wp.vec3),
-            total_vertices,
-            warp_data,
-            wp.from_torch(colors, dtype=wp.vec3ub),
-        ],
-        device=wp_device,
-        stream=stream,
-    )
-
-    return vertices, triangles, normals, colors
-
-
-def extract_approximate_mesh_block_sparse(
-    tsdf,
-    level: float = 0.0,
-    surface_only: bool = False,
-    minimum_tsdf_weight: float = 0.1,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Extract an approximate triangle-soup mesh from a block-sparse TSDF.
-
-    This path emits one unique vertex per triangle corner. It avoids shared-edge
-    ownership, sorting, binary-search lookup, and invalid-edge filtering used by
-    :func:`extract_mesh_block_sparse`, trading compact topology for a faster
-    contiguous mesh layout that is suitable for realtime rendering.
-
-    Args:
-        tsdf: BlockSparseTSDF instance.
-        level: Isosurface level (typically 0.0).
-        surface_only: If True, only extract mesh near the surface.
-        minimum_tsdf_weight: Minimum weight to consider a voxel as observed.
-
-    Returns:
-        Tuple of (vertices, triangles, normals, colors).
-    """
-    device = tsdf.device
-    mc_tables = MCLookupTables.get(device)
-    warp_data = tsdf.get_warp_data()
-    num_alloc = int(tsdf.data.num_allocated.item())
-    kernels = tsdf.kernels
-
-    empty_result = (
-        torch.empty((0, 3), dtype=torch.float32, device=device),
-        torch.empty((0, 3), dtype=torch.int32, device=device),
-        torch.empty((0, 3), dtype=torch.float32, device=device),
-        torch.empty((0, 3), dtype=torch.uint8, device=device),
-    )
-
-    if num_alloc == 0:
-        return empty_result
-
-    surface_band = tsdf.config.truncation_distance if surface_only else 0.0
-
-    block_size = tsdf.block_size
-    block_voxels = block_size**3
+    block_voxels = tsdf.block_size**3
 
     active_count = torch.zeros(1, dtype=torch.int32, device=device)
     active_block_idx = torch.empty(num_alloc, dtype=torch.int32, device=device)
@@ -332,7 +87,7 @@ def extract_approximate_mesh_block_sparse(
 
     n_active = int(active_count.item())
     if n_active == 0:
-        return empty_result
+        return _empty_mesh(device)
 
     active_block_idx = active_block_idx[:n_active]
     surface_count = torch.zeros(1, dtype=torch.int32, device=device)
@@ -356,7 +111,7 @@ def extract_approximate_mesh_block_sparse(
 
     n_surfaces = int(surface_count.item())
     if n_surfaces == 0:
-        return empty_result
+        return _empty_mesh(device)
 
     surface_block_idx = torch.zeros(n_surfaces, dtype=torch.int32, device=device)
     surface_cube_idx = torch.zeros(n_surfaces, dtype=torch.int32, device=device)
@@ -400,30 +155,28 @@ def extract_approximate_mesh_block_sparse(
     )
 
     total_tris = int(triangle_count.item())
-
     if total_tris == 0:
-        return empty_result
+        return _empty_mesh(device)
 
     total_vertices = total_tris * 3
     vertices = torch.zeros((total_vertices, 3), dtype=torch.float32, device=device)
     normals = torch.zeros((total_vertices, 3), dtype=torch.float32, device=device)
     colors = torch.zeros((total_vertices, 3), dtype=torch.uint8, device=device)
-    triangles_flat = torch.empty((total_vertices,), dtype=torch.int32, device=device)
 
     triangle_count.zero_()
     wp.launch(
-        kernels.generate_approximate_mesh_atomic_kernel,
+        kernels.generate_mesh_kernel,
         dim=n_surfaces,
         inputs=[
             warp_data,
             level,
             minimum_tsdf_weight,
+            refine_iterations,
             wp.from_torch(surface_block_idx, dtype=wp.int32),
             wp.from_torch(surface_cube_idx, dtype=wp.int32),
             n_surfaces,
             mc_tables.tri_table,
             wp.from_torch(vertices, dtype=wp.vec3),
-            wp.from_torch(triangles_flat, dtype=wp.int32),
             wp.from_torch(normals, dtype=wp.vec3),
             wp.from_torch(colors, dtype=wp.vec3ub),
             wp.from_torch(triangle_count, dtype=wp.int32),
@@ -433,4 +186,4 @@ def extract_approximate_mesh_block_sparse(
         stream=stream,
     )
 
-    return vertices, triangles_flat.view(total_tris, 3), normals, colors
+    return vertices, normals, colors

--- a/curobo/_src/perception/mapper/mesh_extractor.py
+++ b/curobo/_src/perception/mapper/mesh_extractor.py
@@ -52,7 +52,7 @@ def extract_mesh_block_sparse(
     device = tsdf.device
     mc_tables = MCLookupTables.get(device)
     warp_data = tsdf.get_warp_data()
-    num_alloc = tsdf.data.num_allocated.item()
+    num_alloc = int(tsdf.data.num_allocated.item())
     kernels = tsdf.kernels
 
     empty_result = (
@@ -268,3 +268,169 @@ def extract_mesh_block_sparse(
     )
 
     return vertices, triangles, normals, colors
+
+
+def extract_approximate_mesh_block_sparse(
+    tsdf,
+    level: float = 0.0,
+    surface_only: bool = False,
+    minimum_tsdf_weight: float = 0.1,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Extract an approximate triangle-soup mesh from a block-sparse TSDF.
+
+    This path emits one unique vertex per triangle corner. It avoids shared-edge
+    ownership, sorting, binary-search lookup, and invalid-edge filtering used by
+    :func:`extract_mesh_block_sparse`, trading compact topology for a faster
+    contiguous mesh layout that is suitable for realtime rendering.
+
+    Args:
+        tsdf: BlockSparseTSDF instance.
+        level: Isosurface level (typically 0.0).
+        surface_only: If True, only extract mesh near the surface.
+        minimum_tsdf_weight: Minimum weight to consider a voxel as observed.
+
+    Returns:
+        Tuple of (vertices, triangles, normals, colors).
+    """
+    device = tsdf.device
+    mc_tables = MCLookupTables.get(device)
+    warp_data = tsdf.get_warp_data()
+    num_alloc = int(tsdf.data.num_allocated.item())
+    kernels = tsdf.kernels
+
+    empty_result = (
+        torch.empty((0, 3), dtype=torch.float32, device=device),
+        torch.empty((0, 3), dtype=torch.int32, device=device),
+        torch.empty((0, 3), dtype=torch.float32, device=device),
+        torch.empty((0, 3), dtype=torch.uint8, device=device),
+    )
+
+    if num_alloc == 0:
+        return empty_result
+
+    surface_band = tsdf.config.truncation_distance if surface_only else 0.0
+
+    block_size = tsdf.block_size
+    block_voxels = block_size**3
+
+    active_count = torch.zeros(1, dtype=torch.int32, device=device)
+    active_block_idx = torch.empty(num_alloc, dtype=torch.int32, device=device)
+    wp_device, stream = get_warp_device_stream(active_count)
+
+    wp.launch(
+        kernels.append_active_blocks_kernel,
+        dim=num_alloc,
+        inputs=[
+            warp_data,
+            wp.from_torch(active_count, dtype=wp.int32),
+            wp.from_torch(active_block_idx, dtype=wp.int32),
+        ],
+        device=wp_device,
+        stream=stream,
+        adjoint=False,
+    )
+
+    n_active = int(active_count.item())
+    if n_active == 0:
+        return empty_result
+
+    active_block_idx = active_block_idx[:n_active]
+    surface_count = torch.zeros(1, dtype=torch.int32, device=device)
+
+    wp.launch(
+        kernels.count_surface_cubes_from_blocks_kernel,
+        dim=(n_active, block_voxels),
+        inputs=[
+            warp_data,
+            wp.from_torch(active_block_idx, dtype=wp.int32),
+            n_active,
+            level,
+            surface_band,
+            minimum_tsdf_weight,
+            wp.from_torch(surface_count, dtype=wp.int32),
+        ],
+        device=wp_device,
+        stream=stream,
+        adjoint=False,
+    )
+
+    n_surfaces = int(surface_count.item())
+    if n_surfaces == 0:
+        return empty_result
+
+    surface_block_idx = torch.zeros(n_surfaces, dtype=torch.int32, device=device)
+    surface_cube_idx = torch.zeros(n_surfaces, dtype=torch.int32, device=device)
+
+    surface_count.zero_()
+
+    wp.launch(
+        kernels.append_surface_cubes_from_blocks_kernel,
+        dim=(n_active, block_voxels),
+        inputs=[
+            warp_data,
+            wp.from_torch(active_block_idx, dtype=wp.int32),
+            n_active,
+            level,
+            surface_band,
+            minimum_tsdf_weight,
+            wp.from_torch(surface_count, dtype=wp.int32),
+            wp.from_torch(surface_block_idx, dtype=wp.int32),
+            wp.from_torch(surface_cube_idx, dtype=wp.int32),
+        ],
+        device=wp_device,
+        stream=stream,
+    )
+
+    triangle_count = torch.zeros(1, dtype=torch.int32, device=device)
+    wp.launch(
+        kernels.count_total_triangles_kernel,
+        dim=n_surfaces,
+        inputs=[
+            warp_data,
+            level,
+            minimum_tsdf_weight,
+            wp.from_torch(surface_block_idx, dtype=wp.int32),
+            wp.from_torch(surface_cube_idx, dtype=wp.int32),
+            n_surfaces,
+            mc_tables.num_tris_table,
+            wp.from_torch(triangle_count, dtype=wp.int32),
+        ],
+        device=wp_device,
+        stream=stream,
+    )
+
+    total_tris = int(triangle_count.item())
+
+    if total_tris == 0:
+        return empty_result
+
+    total_vertices = total_tris * 3
+    vertices = torch.zeros((total_vertices, 3), dtype=torch.float32, device=device)
+    normals = torch.zeros((total_vertices, 3), dtype=torch.float32, device=device)
+    colors = torch.zeros((total_vertices, 3), dtype=torch.uint8, device=device)
+    triangles_flat = torch.empty((total_vertices,), dtype=torch.int32, device=device)
+
+    triangle_count.zero_()
+    wp.launch(
+        kernels.generate_approximate_mesh_atomic_kernel,
+        dim=n_surfaces,
+        inputs=[
+            warp_data,
+            level,
+            minimum_tsdf_weight,
+            wp.from_torch(surface_block_idx, dtype=wp.int32),
+            wp.from_torch(surface_cube_idx, dtype=wp.int32),
+            n_surfaces,
+            mc_tables.tri_table,
+            wp.from_torch(vertices, dtype=wp.vec3),
+            wp.from_torch(triangles_flat, dtype=wp.int32),
+            wp.from_torch(normals, dtype=wp.vec3),
+            wp.from_torch(colors, dtype=wp.vec3ub),
+            wp.from_torch(triangle_count, dtype=wp.int32),
+            total_tris,
+        ],
+        device=wp_device,
+        stream=stream,
+    )
+
+    return vertices, triangles_flat.view(total_tris, 3), normals, colors

--- a/curobo/_src/perception/mapper/projector_texture.py
+++ b/curobo/_src/perception/mapper/projector_texture.py
@@ -1,0 +1,782 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Visibility-tested projective texturing for block-sparse TSDF outputs."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import warp as wp
+
+from curobo._src.geom.transform import torch_quaternion_to_matrix
+from curobo._src.geom.types import Mesh
+from curobo._src.perception.mapper.renderer import BlockSparseTSDFRenderer
+from curobo._src.perception.mapper.storage import BlockSparseTSDF, OccupiedVoxels
+from curobo._src.types.camera import CameraObservation
+from curobo._src.types.pose import Pose
+from curobo._src.util.logging import log_and_raise
+from curobo._src.util.warp import get_warp_device_stream
+
+
+_PROJECTIVE_TEXTURE_ATLAS_MAX_WIDTH_PX = 16_384
+
+TextureBatch = tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]
+
+
+def _projective_texture_atlas_columns(total_cameras: int, image_width: int) -> int:
+    """Return camera tiles per atlas row for common GL texture limits."""
+    if total_cameras <= 0:
+        log_and_raise(f"total_cameras must be positive, got {total_cameras}.")
+    if image_width <= 0:
+        log_and_raise(f"image_width must be positive, got {image_width}.")
+    max_columns = max(1, _PROJECTIVE_TEXTURE_ATLAS_MAX_WIDTH_PX // image_width)
+    return min(total_cameras, max_columns)
+
+
+def _texture_depth_visible(
+    projected_z: torch.Tensor,
+    visibility_depth: torch.Tensor,
+    *,
+    voxel_size: float,
+    texture_depth_tolerance_m: Optional[float],
+) -> torch.Tensor:
+    """Return samples whose projected depth agrees with visibility depth."""
+    valid = (
+        torch.isfinite(projected_z)
+        & torch.isfinite(visibility_depth)
+        & (projected_z > 0.0)
+        & (visibility_depth > 0.0)
+    )
+    if texture_depth_tolerance_m is None:
+        tolerance = torch.maximum(
+            torch.full_like(projected_z, float(2.0 * voxel_size)),
+            projected_z * 0.01,
+        )
+    else:
+        tolerance = torch.full_like(projected_z, float(texture_depth_tolerance_m))
+    return valid & (torch.abs(projected_z - visibility_depth) <= tolerance)
+
+
+def _validate_texture_depth_tolerance(
+    texture_depth_tolerance_m: Optional[float],
+) -> float:
+    """Return the kernel tolerance, using ``-1`` for the adaptive policy."""
+    if texture_depth_tolerance_m is None:
+        return -1.0
+    depth_tolerance = float(texture_depth_tolerance_m)
+    if depth_tolerance < 0.0 or not math.isfinite(depth_tolerance):
+        log_and_raise(
+            "texture_depth_tolerance_m must be non-negative and finite or None, got "
+            f"{texture_depth_tolerance_m}."
+        )
+    return depth_tolerance
+
+
+@dataclass(frozen=True)
+class ProjectiveTextureProjectorCfg:
+    """Construction-time projective texture dimensions and depth limits."""
+
+    #: Cameras in each exact texture projection batch.
+    texture_num_cameras: int
+    #: Height of every RGB and visibility-depth image.
+    image_height: int
+    #: Width of every RGB and visibility-depth image.
+    image_width: int
+    #: Default minimum positive camera-frame depth used for projection.
+    depth_minimum_distance: float
+    #: Default maximum camera-frame depth used for projection.
+    depth_maximum_distance: float
+    #: TSDF voxel size used by the adaptive visibility tolerance.
+    voxel_size: float
+
+
+@dataclass(frozen=True)
+class _PreparedMeshTextureProjection:
+    """Validated texture batches and atlas for one mesh projection."""
+
+    batches: list[TextureBatch]
+    texture_atlas: torch.Tensor
+    atlas_columns: int
+    total_cameras: int
+    depth_tolerance: float
+
+
+class ProjectiveTextureProjector:
+    """Project RGB observations onto TSDF meshes and occupied voxel samples."""
+
+    def __init__(
+        self,
+        tsdf: BlockSparseTSDF,
+        renderer: BlockSparseTSDFRenderer,
+        config: ProjectiveTextureProjectorCfg,
+    ) -> None:
+        """Initialize the projector from sparse storage and a depth renderer."""
+        self._tsdf = tsdf
+        self._renderer = renderer
+        self.config = config
+
+    def prepare_mesh_projection(
+        self,
+        texture_observations: CameraObservation | Sequence[CameraObservation],
+        *,
+        texture_depth_tolerance_m: Optional[float],
+    ) -> _PreparedMeshTextureProjection:
+        """Validate mesh texture inputs and build their camera atlas."""
+        depth_tolerance = _validate_texture_depth_tolerance(
+            texture_depth_tolerance_m
+        )
+        batches = self._normalize_projective_texture_observations(
+            texture_observations
+        )
+        total_cameras = len(batches) * self.config.texture_num_cameras
+        atlas_columns = _projective_texture_atlas_columns(
+            total_cameras,
+            self.config.image_width,
+        )
+        texture_atlas = self._build_projective_texture_atlas(
+            batches,
+            atlas_columns=atlas_columns,
+        )
+        return _PreparedMeshTextureProjection(
+            batches=batches,
+            texture_atlas=texture_atlas,
+            atlas_columns=atlas_columns,
+            total_cameras=total_cameras,
+            depth_tolerance=depth_tolerance,
+        )
+
+    def project_mesh(
+        self,
+        vertices: torch.Tensor,
+        triangles: torch.Tensor,
+        normals: torch.Tensor,
+        colors: torch.Tensor,
+        projection: _PreparedMeshTextureProjection,
+        *,
+        camera_min_distance: Optional[float],
+        camera_max_distance: Optional[float],
+    ) -> Mesh:
+        """Project texture observations onto triangle-soup mesh tensors.
+
+        Args:
+            vertices: ``(3 * M, 3)`` float32 triangle-soup vertices.
+            triangles: ``(M, 3)`` int32 identity triangle indices.
+            normals: ``(3 * M, 3)`` float32 vertex normals.
+            colors: ``(3 * M, 3)`` uint8 fallback vertex colors.
+            projection: Prepared texture batches and atlas.
+            camera_min_distance: Optional minimum camera-frame projection depth.
+            camera_max_distance: Optional maximum camera-frame projection depth.
+
+        Returns:
+            Textured mesh with fallback atlas patches for unprojected triangles.
+        """
+        batches = projection.batches
+        total_cameras = projection.total_cameras
+        atlas_columns = projection.atlas_columns
+        texture_atlas = projection.texture_atlas
+
+        vertices = vertices.contiguous()
+        triangles = triangles.contiguous()
+        normals = normals.contiguous()
+        colors = colors.contiguous()
+        uvs = torch.full(
+            (vertices.shape[0], 2),
+            -1.0,
+            dtype=torch.float32,
+            device=vertices.device,
+        )
+        projection_scores = torch.full(
+            (triangles.shape[0],),
+            -1.0e20,
+            dtype=torch.float32,
+            device=vertices.device,
+        )
+
+        if vertices.shape[0] > 0:
+            min_distance = (
+                self.config.depth_minimum_distance
+                if camera_min_distance is None
+                else camera_min_distance
+            )
+            max_distance = (
+                self.config.depth_maximum_distance
+                if camera_max_distance is None
+                else camera_max_distance
+            )
+            device, stream = get_warp_device_stream(vertices)
+            for batch_idx, (
+                _rgb,
+                visibility_depth,
+                intrinsics,
+                positions,
+                quaternions,
+            ) in enumerate(batches):
+                wp.launch(
+                    self._tsdf.kernels.project_mesh_uvs_kernel,
+                    dim=triangles.shape[0],
+                    inputs=[
+                        wp.from_torch(vertices, dtype=wp.vec3),
+                        vertices.shape[0],
+                        wp.from_torch(visibility_depth, dtype=wp.float32),
+                        wp.from_torch(intrinsics, dtype=wp.float32),
+                        wp.from_torch(positions, dtype=wp.float32),
+                        wp.from_torch(quaternions, dtype=wp.float32),
+                        float(min_distance),
+                        float(max_distance),
+                        projection.depth_tolerance,
+                        batch_idx * self.config.texture_num_cameras,
+                        total_cameras,
+                        atlas_columns,
+                        wp.from_torch(uvs, dtype=wp.vec2),
+                        wp.from_torch(projection_scores, dtype=wp.float32),
+                        wp.from_torch(colors, dtype=wp.vec3ub),
+                        1,
+                        self._tsdf.get_warp_data(),
+                    ],
+                    device=device,
+                    stream=stream,
+                )
+
+        vertex_valid_uv = (
+            (uvs[:, 0] >= 0.0)
+            & (uvs[:, 0] <= 1.0)
+            & (uvs[:, 1] >= 0.0)
+            & (uvs[:, 1] <= 1.0)
+        )
+        triangle_valid_uv = vertex_valid_uv.view(-1, 3).all(dim=1)
+        texture_vertex_valid = triangle_valid_uv.repeat_interleave(3)
+        texture_uvs = torch.where(
+            texture_vertex_valid[:, None],
+            uvs.clamp(0.0, 1.0),
+            torch.zeros_like(uvs),
+        )
+        vertex_colors = colors.clone()
+        if vertices.shape[0] > 0 and bool(texture_vertex_valid.any().item()):
+            atlas_height = texture_atlas.shape[0]
+            atlas_width = texture_atlas.shape[1]
+            px = torch.round(texture_uvs[:, 0] * (atlas_width - 1)).to(torch.long)
+            py = torch.round(texture_uvs[:, 1] * (atlas_height - 1)).to(torch.long)
+            px = px.clamp(0, atlas_width - 1)
+            py = py.clamp(0, atlas_height - 1)
+            vertex_colors[texture_vertex_valid] = texture_atlas[
+                py[texture_vertex_valid], px[texture_vertex_valid]
+            ]
+
+        fallback_triangles = torch.nonzero(~triangle_valid_uv, as_tuple=False).reshape(-1)
+        if vertices.shape[0] > 0 and fallback_triangles.numel() > 0:
+            texture_atlas, texture_uvs = self._append_fallback_texture_patches(
+                texture_atlas,
+                texture_uvs,
+                vertex_colors,
+                texture_vertex_valid,
+                fallback_triangles,
+            )
+
+        return Mesh(
+            name="block_sparse_tsdf_textured_mesh",
+            vertices=vertices,
+            faces=triangles,
+            vertex_colors=(vertex_colors.float() / 255.0),
+            vertex_normals=normals,
+            texture_uvs=texture_uvs,
+            texture_image=texture_atlas,
+        )
+
+    def _append_fallback_texture_patches(
+        self,
+        texture_atlas: torch.Tensor,
+        texture_uvs: torch.Tensor,
+        vertex_colors: torch.Tensor,
+        texture_vertex_valid: torch.Tensor,
+        fallback_triangles: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Append 2x2 fallback patches and assign their triangle UVs."""
+        atlas_height = int(texture_atlas.shape[0])
+        atlas_width = int(texture_atlas.shape[1])
+        patch_size = 2
+        patches_per_row = max(1, atlas_width // patch_size)
+        fallback_count = int(fallback_triangles.numel())
+        fallback_rows = math.ceil(fallback_count / patches_per_row) * patch_size
+        fallback_atlas = torch.zeros(
+            (fallback_rows, atlas_width, 3),
+            dtype=texture_atlas.dtype,
+            device=texture_atlas.device,
+        )
+
+        fallback_slots = torch.arange(
+            fallback_count,
+            dtype=torch.long,
+            device=vertex_colors.device,
+        )
+        patch_x = (fallback_slots % patches_per_row) * patch_size
+        patch_y = (fallback_slots // patches_per_row) * patch_size
+        tri_base = fallback_triangles * 3
+        c0 = vertex_colors[tri_base]
+        c1 = vertex_colors[tri_base + 1]
+        c2 = vertex_colors[tri_base + 2]
+        avg_color = (
+            (c0.to(torch.float32) + c1.to(torch.float32) + c2.to(torch.float32))
+            / 3.0
+        ).round().to(torch.uint8)
+        fallback_atlas[patch_y, patch_x] = c0
+        fallback_atlas[patch_y, patch_x + 1] = c1
+        fallback_atlas[patch_y + 1, patch_x] = c2
+        fallback_atlas[patch_y + 1, patch_x + 1] = avg_color
+
+        texture_atlas = torch.cat((texture_atlas, fallback_atlas), dim=0)
+        new_atlas_height = int(texture_atlas.shape[0])
+        if bool(texture_vertex_valid.any().item()):
+            texture_uvs[texture_vertex_valid, 1] *= float(atlas_height) / float(
+                new_atlas_height
+            )
+
+        fallback_uvs = torch.empty(
+            (fallback_count, 3, 2),
+            dtype=torch.float32,
+            device=vertex_colors.device,
+        )
+        x0 = patch_x.to(torch.float32)
+        y0 = (patch_y + atlas_height).to(torch.float32)
+        fallback_uvs[:, 0, 0] = (x0 + 0.5) / float(atlas_width)
+        fallback_uvs[:, 0, 1] = (y0 + 0.5) / float(new_atlas_height)
+        fallback_uvs[:, 1, 0] = (x0 + 1.5) / float(atlas_width)
+        fallback_uvs[:, 1, 1] = (y0 + 0.5) / float(new_atlas_height)
+        fallback_uvs[:, 2, 0] = (x0 + 0.5) / float(atlas_width)
+        fallback_uvs[:, 2, 1] = (y0 + 1.5) / float(new_atlas_height)
+        fallback_vertex_indices = torch.stack(
+            (tri_base, tri_base + 1, tri_base + 2),
+            dim=1,
+        )
+        texture_uvs[fallback_vertex_indices.reshape(-1)] = fallback_uvs.reshape(-1, 2)
+        return texture_atlas, texture_uvs
+
+    def _normalize_projective_texture_observations(
+        self,
+        texture_observations: CameraObservation | Sequence[CameraObservation],
+    ) -> list[TextureBatch]:
+        """Validate and batch RGB or RGB-D observations for texturing."""
+        if isinstance(texture_observations, CameraObservation):
+            observations = [texture_observations]
+        else:
+            observations = list(texture_observations)
+        if len(observations) == 0:
+            log_and_raise(
+                "texture_observations must contain at least one CameraObservation."
+            )
+
+        batches: list[TextureBatch] = []
+        pending: list[CameraObservation] = []
+        for observation in observations:
+            if observation.rgb_image is None:
+                log_and_raise(
+                    "CameraObservation.rgb_image is required for texture mapping."
+                )
+            if observation.pose is None:
+                log_and_raise(
+                    "CameraObservation.pose is required for texture mapping."
+                )
+            if observation.intrinsics is None:
+                log_and_raise(
+                    "CameraObservation.intrinsics is required for texture mapping."
+                )
+
+            if observation.rgb_image.ndim == 3:
+                pending.append(observation)
+                if len(pending) == self.config.texture_num_cameras:
+                    batches.append(self._stack_projective_texture_batch(pending))
+                    pending = []
+            elif observation.rgb_image.ndim == 4:
+                if pending:
+                    log_and_raise(
+                        "Cannot mix unbatched and batched texture observations in one call."
+                    )
+                batches.append(self._normalize_projective_texture_batch(observation))
+            else:
+                log_and_raise(
+                    "rgb_image must be (H, W, 3) or (num_cameras, H, W, 3), got "
+                    f"shape {tuple(observation.rgb_image.shape)}."
+                )
+
+        if pending:
+            log_and_raise(
+                f"Received {len(pending)} unbatched texture observations, but "
+                f"texture_num_cameras={self.config.texture_num_cameras}; provide "
+                "complete camera batches."
+            )
+        return batches
+
+    def _stack_projective_texture_batch(
+        self,
+        observations: Sequence[CameraObservation],
+    ) -> TextureBatch:
+        """Stack one complete unbatched camera group and fill missing depth."""
+        device = torch.device(self._tsdf.device)
+        expected_depth_shape = (self.config.image_height, self.config.image_width)
+        has_depth = [observation.depth_image is not None for observation in observations]
+        for observation in observations:
+            if observation.depth_image is None:
+                continue
+            if tuple(observation.depth_image.shape) != expected_depth_shape:
+                log_and_raise(
+                    "depth_image must align with unbatched rgb_image as "
+                    f"{expected_depth_shape}, got {tuple(observation.depth_image.shape)}."
+                )
+            if observation.depth_image.dtype != torch.float32:
+                log_and_raise(
+                    "depth_image must be float32 camera-frame z depth in meters, got "
+                    f"{observation.depth_image.dtype}."
+                )
+
+        depth_image = None
+        if all(has_depth):
+            depth_image = torch.stack(
+                [observation.depth_image.to(device=device) for observation in observations]
+            )
+        batch = self._normalize_projective_texture_batch(
+            CameraObservation(
+                rgb_image=torch.stack(
+                    [observation.rgb_image.to(device=device) for observation in observations]
+                ),
+                depth_image=depth_image,
+                pose=Pose(
+                    position=torch.cat(
+                        [
+                            observation.pose.position.view(1, 3).to(device=device)
+                            for observation in observations
+                        ]
+                    ),
+                    quaternion=torch.cat(
+                        [
+                            observation.pose.quaternion.view(1, 4).to(device=device)
+                            for observation in observations
+                        ]
+                    ),
+                ),
+                intrinsics=torch.stack(
+                    [observation.intrinsics.to(device=device) for observation in observations]
+                ),
+            )
+        )
+        if not any(has_depth) or all(has_depth):
+            return batch
+
+        rgb, visibility_depth, intrinsics, positions, quaternions = batch
+        for camera_idx, observation in enumerate(observations):
+            if observation.depth_image is not None:
+                visibility_depth[camera_idx].copy_(
+                    observation.depth_image.to(device=device)
+                )
+        return rgb, visibility_depth, intrinsics, positions, quaternions
+
+    def _normalize_projective_texture_batch(
+        self,
+        observation: CameraObservation,
+    ) -> TextureBatch:
+        """Validate one texture batch and synthesize missing visibility depth."""
+        rgb = observation.rgb_image
+        if rgb.ndim == 3:
+            rgb = rgb.unsqueeze(0)
+        n_cameras = int(rgb.shape[0])
+        expected_rgb_shape = (
+            self.config.texture_num_cameras,
+            self.config.image_height,
+            self.config.image_width,
+            3,
+        )
+        if tuple(rgb.shape) != expected_rgb_shape:
+            log_and_raise(
+                f"rgb_image shape mismatch: expected {expected_rgb_shape}, "
+                f"got {tuple(rgb.shape)}."
+            )
+        if rgb.dtype != torch.uint8:
+            log_and_raise(f"rgb_image dtype must be torch.uint8, got {rgb.dtype}.")
+
+        intrinsics = observation.intrinsics
+        if intrinsics.ndim == 2:
+            intrinsics = intrinsics.unsqueeze(0)
+        if tuple(intrinsics.shape) != (self.config.texture_num_cameras, 3, 3):
+            log_and_raise(
+                "intrinsics must be (texture_num_cameras, 3, 3), got "
+                f"shape {tuple(intrinsics.shape)}."
+            )
+        if intrinsics.dtype != torch.float32:
+            log_and_raise(
+                f"intrinsics dtype must be torch.float32, got {intrinsics.dtype}."
+            )
+
+        position = observation.pose.position
+        quaternion = observation.pose.quaternion
+        if position.numel() != n_cameras * 3:
+            log_and_raise(
+                f"pose.position must contain {n_cameras * 3} values, "
+                f"got {position.numel()}."
+            )
+        if quaternion.numel() != n_cameras * 4:
+            log_and_raise(
+                "pose.quaternion must contain "
+                f"{n_cameras * 4} values, got {quaternion.numel()}."
+            )
+        positions = position.view(n_cameras, 3)
+        quaternions = quaternion.view(n_cameras, 4)
+        if positions.dtype != torch.float32:
+            log_and_raise(
+                f"pose.position dtype must be torch.float32, got {positions.dtype}."
+            )
+        if quaternions.dtype != torch.float32:
+            log_and_raise(
+                f"pose.quaternion dtype must be torch.float32, got {quaternions.dtype}."
+            )
+
+        device = torch.device(self._tsdf.device)
+        rgb = rgb.to(device=device).contiguous()
+        intrinsics = intrinsics.to(device=device).contiguous()
+        positions = positions.to(device=device).contiguous()
+        quaternions = quaternions.to(device=device).contiguous()
+
+        depth = observation.depth_image
+        if depth is None:
+            depth = self._renderer.render_depth(
+                intrinsics,
+                Pose(position=positions, quaternion=quaternions),
+                (self.config.image_height, self.config.image_width),
+            )
+            depth = depth.clone()
+        if depth.ndim == 2:
+            depth = depth.unsqueeze(0)
+        expected_depth_shape = expected_rgb_shape[:3]
+        if tuple(depth.shape) != expected_depth_shape:
+            log_and_raise(
+                "depth_image must align with rgb_image as "
+                f"{expected_depth_shape}, got {tuple(depth.shape)}."
+            )
+        if depth.dtype != torch.float32:
+            log_and_raise(
+                "depth_image must be float32 camera-frame z depth in meters, got "
+                f"{depth.dtype}."
+            )
+
+        return (
+            rgb,
+            depth.to(device=device).contiguous(),
+            intrinsics,
+            positions,
+            quaternions,
+        )
+
+    def _build_projective_texture_atlas(
+        self,
+        batches: Sequence[TextureBatch],
+        *,
+        atlas_columns: int,
+    ) -> torch.Tensor:
+        """Pack batched RGB images into a row-major texture atlas."""
+        total_cameras = len(batches) * self.config.texture_num_cameras
+        atlas_rows = math.ceil(total_cameras / atlas_columns)
+        atlas_width = atlas_columns * self.config.image_width
+        atlas_height = atlas_rows * self.config.image_height
+        texture_atlas = torch.zeros(
+            (atlas_height, atlas_width, 3),
+            dtype=torch.uint8,
+            device=torch.device(self._tsdf.device),
+        )
+        for batch_idx, (rgb, _depth, _intrinsics, _positions, _quaternions) in enumerate(
+            batches
+        ):
+            for camera_idx in range(self.config.texture_num_cameras):
+                atlas_idx = batch_idx * self.config.texture_num_cameras + camera_idx
+                atlas_row = atlas_idx // atlas_columns
+                atlas_col = atlas_idx % atlas_columns
+                y0 = atlas_row * self.config.image_height
+                x0 = atlas_col * self.config.image_width
+                texture_atlas[
+                    y0 : y0 + self.config.image_height,
+                    x0 : x0 + self.config.image_width,
+                    :,
+                ] = rgb[camera_idx]
+        return texture_atlas
+
+    def texture_occupied_voxels(
+        self,
+        voxels: OccupiedVoxels,
+        texture_observations: CameraObservation | Sequence[CameraObservation],
+        *,
+        camera_min_distance: Optional[float],
+        camera_max_distance: Optional[float],
+        texture_depth_tolerance_m: Optional[float],
+    ) -> OccupiedVoxels:
+        """Color occupied voxel samples from RGB or RGB-D observations."""
+        _validate_texture_depth_tolerance(texture_depth_tolerance_m)
+        colors = torch.zeros(
+            (len(voxels), 3),
+            dtype=torch.uint8,
+            device=voxels.centers.device,
+        )
+        valid = torch.zeros(
+            (len(voxels),),
+            dtype=torch.bool,
+            device=voxels.centers.device,
+        )
+        if len(voxels) > 0:
+            min_distance = (
+                self.config.depth_minimum_distance
+                if camera_min_distance is None
+                else camera_min_distance
+            )
+            max_distance = (
+                self.config.depth_maximum_distance
+                if camera_max_distance is None
+                else camera_max_distance
+            )
+            batches = self._normalize_projective_texture_observations(
+                texture_observations
+            )
+            colors, valid = self._project_texture_points(
+                voxels.centers,
+                batches,
+                camera_min_distance=float(min_distance),
+                camera_max_distance=float(max_distance),
+                texture_depth_tolerance_m=texture_depth_tolerance_m,
+            )
+
+        return OccupiedVoxels(
+            centers=voxels.centers,
+            block_idx_per_voxel=voxels.block_idx_per_voxel,
+            block_data=voxels.block_data,
+            texture_colors=colors,
+            texture_valid=valid,
+            subvoxel_factor=voxels.subvoxel_factor,
+        )
+
+    def _project_texture_points(
+        self,
+        points: torch.Tensor,
+        batches: Sequence[TextureBatch],
+        *,
+        camera_min_distance: float,
+        camera_max_distance: float,
+        texture_depth_tolerance_m: Optional[float],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Project world-frame points into texture views and sample visible RGB."""
+        point_count = int(points.shape[0])
+        texture_colors = torch.zeros(
+            (point_count, 3),
+            dtype=torch.uint8,
+            device=points.device,
+        )
+        texture_valid = torch.zeros(
+            (point_count,),
+            dtype=torch.bool,
+            device=points.device,
+        )
+        best_score = torch.full(
+            (point_count,),
+            -float("inf"),
+            dtype=torch.float32,
+            device=points.device,
+        )
+
+        for rgb, visibility_depth, intrinsics, positions, quaternions in batches:
+            batch_colors, batch_valid, batch_score = self._project_texture_points_batch(
+                points,
+                rgb,
+                visibility_depth,
+                intrinsics,
+                positions,
+                quaternions,
+                camera_min_distance=camera_min_distance,
+                camera_max_distance=camera_max_distance,
+                texture_depth_tolerance_m=texture_depth_tolerance_m,
+            )
+            update = batch_valid & (batch_score > best_score)
+            if update.any():
+                texture_colors[update] = batch_colors[update]
+                texture_valid[update] = True
+                best_score[update] = batch_score[update]
+
+        return texture_colors, texture_valid
+
+    def _project_texture_points_batch(
+        self,
+        points: torch.Tensor,
+        rgb: torch.Tensor,
+        visibility_depth: torch.Tensor,
+        intrinsics: torch.Tensor,
+        positions: torch.Tensor,
+        quaternions: torch.Tensor,
+        *,
+        camera_min_distance: float,
+        camera_max_distance: float,
+        texture_depth_tolerance_m: Optional[float],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Project points into one exact texture camera batch."""
+        camera_count = int(rgb.shape[0])
+        point_count = int(points.shape[0])
+        image_height = int(rgb.shape[1])
+        image_width = int(rgb.shape[2])
+
+        rotations = torch_quaternion_to_matrix(quaternions.to(dtype=torch.float32))
+        points_rel = points.to(dtype=torch.float32).unsqueeze(0) - positions[:, None, :]
+        points_cam = torch.matmul(points_rel, rotations)
+        z = points_cam[..., 2]
+
+        fx = intrinsics[:, 0, 0].view(camera_count, 1)
+        fy = intrinsics[:, 1, 1].view(camera_count, 1)
+        cx = intrinsics[:, 0, 2].view(camera_count, 1)
+        cy = intrinsics[:, 1, 2].view(camera_count, 1)
+        safe_z = torch.where(
+            torch.isfinite(z) & (torch.abs(z) > 1.0e-12),
+            z,
+            torch.ones_like(z),
+        )
+        u = fx * points_cam[..., 0] / safe_z + cx
+        v = fy * points_cam[..., 1] / safe_z + cy
+        in_frame = (
+            torch.isfinite(z)
+            & torch.isfinite(u)
+            & torch.isfinite(v)
+            & (z > camera_min_distance)
+            & (z <= camera_max_distance)
+            & (u >= 0.0)
+            & (u < float(image_width))
+            & (v >= 0.0)
+            & (v < float(image_height))
+        )
+
+        px = torch.floor(u).to(torch.long).clamp(0, image_width - 1)
+        py = torch.floor(v).to(torch.long).clamp(0, image_height - 1)
+        camera_indices = torch.arange(
+            camera_count,
+            device=points.device,
+        ).view(camera_count, 1)
+        sampled_depth = visibility_depth[camera_indices, py, px]
+        visible = in_frame & _texture_depth_visible(
+            z,
+            sampled_depth,
+            voxel_size=self.config.voxel_size,
+            texture_depth_tolerance_m=texture_depth_tolerance_m,
+        )
+
+        candidate_score = torch.where(
+            visible,
+            -z,
+            torch.full_like(z, -float("inf")),
+        )
+        best_score, best_camera = candidate_score.max(dim=0)
+        valid = torch.isfinite(best_score)
+        point_indices = torch.arange(point_count, device=points.device)
+        best_px = px[best_camera, point_indices]
+        best_py = py[best_camera, point_indices]
+        colors = rgb[best_camera, best_py, best_px]
+        return colors, valid, best_score

--- a/curobo/_src/perception/mapper/renderer.py
+++ b/curobo/_src/perception/mapper/renderer.py
@@ -34,6 +34,7 @@ import torch
 import warp as wp
 
 from curobo._src.types.pose import Pose
+from curobo._src.util.logging import log_and_raise
 
 
 @dataclass
@@ -47,15 +48,22 @@ class BlockSparseTSDFRendererCfg:
             Since weight = 1/depth² (clamped to [0.001, 2.0]), this can be interpreted
             as the number of observations at 1m depth. E.g., 0.5 = half an observation
             at 1m, or one observation at ~1.4m, or two observations at 2m.
-        use_block_acceleration: If True, use block-level skipping to accelerate
-            raymarching. This skips unallocated blocks entirely, providing 5-50x
-            speedup depending on scene sparsity. Default True.
     """
 
     depth_minimum_distance: float = 0.2
     depth_maximum_distance: float = 15.0
     minimum_tsdf_weight: float = 0.2
-    use_block_acceleration: bool = True
+
+
+@dataclass(frozen=True)
+class _RenderInputs:
+    """Normalized batched camera inputs for renderer kernels."""
+
+    intrinsics: torch.Tensor
+    positions: torch.Tensor
+    quaternions: torch.Tensor
+    camera_count: int
+    single_camera: bool
 
 
 class BlockSparseTSDFRenderer:
@@ -77,24 +85,22 @@ class BlockSparseTSDFRenderer:
     def __init__(
         self,
         integrator,  # BlockSparseESDFIntegrator or BlockSparseTSDFIntegrator
-        use_block_acceleration: bool = True,
-    ):
+    ) -> None:
         """Initialize BlockSparseTSDFRenderer.
 
         Args:
             integrator: Integrator instance with block-sparse TSDF.
-            use_block_acceleration: If True, use block-level skipping for faster
-                raymarching. This skips unallocated blocks entirely, providing
-                significant speedup for sparse scenes. Default True.
         """
         self.integrator = integrator
         self.config = BlockSparseTSDFRendererCfg(
             depth_minimum_distance=integrator.config.depth_minimum_distance,
             depth_maximum_distance=integrator.config.depth_maximum_distance,
             minimum_tsdf_weight=integrator.config.minimum_tsdf_weight,
-            use_block_acceleration=use_block_acceleration,
         )
-        self.device = integrator.device
+        if hasattr(integrator, "device"):
+            self.device = integrator.device
+        else:
+            self.device = integrator._tsdf.device
 
         # Pre-allocated buffers
         self._buffer_size = 0
@@ -104,47 +110,93 @@ class BlockSparseTSDFRenderer:
         self._hit_depths = None
         self._hit_mask = None
 
-        # Camera parameter buffers
-        self.cam_position = torch.zeros(3, dtype=torch.float32, device=self.device)
-        self.cam_quaternion = torch.zeros(4, dtype=torch.float32, device=self.device)
-        self.intrinsics_matrix = torch.zeros((3, 3), dtype=torch.float32, device=self.device)
-
-    def _ensure_buffers(self, n_pixels: int):
+    def _ensure_buffers(self, n_pixels: int, include_color: bool = False) -> None:
         """Ensure output buffers are large enough."""
-        if self._buffer_size >= n_pixels:
+        if self._buffer_size < n_pixels:
+            self._hit_points = torch.zeros((n_pixels, 3), dtype=torch.float32, device=self.device)
+            self._hit_normals = torch.zeros((n_pixels, 3), dtype=torch.float32, device=self.device)
+            self._hit_depths = torch.zeros(n_pixels, dtype=torch.float32, device=self.device)
+            self._hit_mask = torch.zeros(n_pixels, dtype=torch.uint8, device=self.device)
+            self._hit_colors = None
+            self._buffer_size = n_pixels
+        if not include_color:
             return
+        if self._hit_colors is None or self._hit_colors.shape[0] < n_pixels:
+            self._hit_colors = torch.zeros((n_pixels, 3), dtype=torch.uint8, device=self.device)
 
-        self._hit_points = torch.zeros((n_pixels, 3), dtype=torch.float32, device=self.device)
-        self._hit_normals = torch.zeros((n_pixels, 3), dtype=torch.float32, device=self.device)
-        self._hit_colors = torch.zeros((n_pixels, 3), dtype=torch.uint8, device=self.device)
-        self._hit_depths = torch.zeros(n_pixels, dtype=torch.float32, device=self.device)
-        self._hit_mask = torch.zeros(n_pixels, dtype=torch.uint8, device=self.device)
-        self._buffer_size = n_pixels
-
-    def _extract_pose(self, pose: Pose):
-        """Extract position and quaternion from Pose.
-
-        Args:
-            pose: Camera-to-world transform as Pose.
-        """
-        position = pose.position.squeeze().to(self.device, dtype=torch.float32)
-        quaternion = pose.quaternion.squeeze().to(self.device, dtype=torch.float32)
-        self.cam_position.copy_(position)
-        self.cam_quaternion.copy_(quaternion)
-
-    def _extract_intrinsics(self, intrinsics: torch.Tensor):
-        """Extract intrinsics matrix."""
+    def _normalize_intrinsics(self, intrinsics: torch.Tensor) -> tuple[torch.Tensor, bool]:
+        """Return camera intrinsics as ``(N, 3, 3)`` and whether input was batched."""
+        intrinsics_was_batched = (
+            (intrinsics.ndim == 2 and intrinsics.shape != (3, 3)) or intrinsics.ndim == 3
+        )
         intrinsics = intrinsics.to(self.device, dtype=torch.float32)
-        if intrinsics.dim() == 2:
-            self.intrinsics_matrix.copy_(intrinsics[:3, :3])
-        else:
-            # [fx, fy, cx, cy] format
-            fx, fy, cx, cy = intrinsics[:4].tolist()
-            self.intrinsics_matrix.zero_()
-            self.intrinsics_matrix[0, 0] = fx
-            self.intrinsics_matrix[1, 1] = fy
-            self.intrinsics_matrix[0, 2] = cx
-            self.intrinsics_matrix[1, 2] = cy
+        if intrinsics.ndim == 1 and intrinsics.shape[0] == 4:
+            out = torch.zeros((1, 3, 3), dtype=torch.float32, device=self.device)
+            out[0, 0, 0] = intrinsics[0]
+            out[0, 1, 1] = intrinsics[1]
+            out[0, 0, 2] = intrinsics[2]
+            out[0, 1, 2] = intrinsics[3]
+            out[0, 2, 2] = 1.0
+            return out, intrinsics_was_batched
+        if intrinsics.ndim == 2 and intrinsics.shape == (3, 3):
+            return intrinsics.unsqueeze(0).contiguous(), intrinsics_was_batched
+        if intrinsics.ndim == 2 and intrinsics.shape[1] == 4:
+            out = torch.zeros(
+                (intrinsics.shape[0], 3, 3), dtype=torch.float32, device=self.device
+            )
+            out[:, 0, 0] = intrinsics[:, 0]
+            out[:, 1, 1] = intrinsics[:, 1]
+            out[:, 0, 2] = intrinsics[:, 2]
+            out[:, 1, 2] = intrinsics[:, 3]
+            out[:, 2, 2] = 1.0
+            return out, intrinsics_was_batched
+        if intrinsics.ndim == 3 and intrinsics.shape[1:] == (3, 3):
+            return intrinsics.contiguous(), intrinsics_was_batched
+        log_and_raise(
+            "intrinsics must have shape (3, 3), (4,), (N, 3, 3), or (N, 4)."
+        )
+
+    def _normalize_render_inputs(
+        self,
+        intrinsics: torch.Tensor,
+        pose: Pose,
+    ) -> _RenderInputs:
+        """Normalize render inputs with exact camera-count matching."""
+        if pose.position is None or pose.quaternion is None:
+            log_and_raise("pose must contain position and quaternion tensors.")
+
+        intrinsics_matrix, intrinsics_was_batched = self._normalize_intrinsics(intrinsics)
+        positions = pose.position.to(self.device, dtype=torch.float32)
+        quaternions = pose.quaternion.to(self.device, dtype=torch.float32)
+
+        if positions.ndim != 2 or positions.shape[1] != 3:
+            log_and_raise(f"pose.position must have shape (N, 3), got {positions.shape}.")
+        if quaternions.ndim != 2 or quaternions.shape[1] != 4:
+            log_and_raise(
+                f"pose.quaternion must have shape (N, 4), got {quaternions.shape}."
+            )
+        if positions.shape[0] != quaternions.shape[0]:
+            log_and_raise(
+                "pose.position and pose.quaternion must have the same camera count, "
+                f"got {positions.shape[0]} and {quaternions.shape[0]}."
+            )
+
+        camera_count = positions.shape[0]
+        if intrinsics_matrix.shape[0] != camera_count:
+            log_and_raise(
+                "intrinsics and pose must have the same camera count; "
+                f"got {intrinsics_matrix.shape[0]} and {camera_count}."
+            )
+        if camera_count <= 0:
+            log_and_raise("render camera count must be positive.")
+
+        return _RenderInputs(
+            intrinsics=intrinsics_matrix.contiguous(),
+            positions=positions.contiguous(),
+            quaternions=quaternions.contiguous(),
+            camera_count=camera_count,
+            single_camera=camera_count == 1 and not intrinsics_was_batched,
+        )
 
     def render(
         self,
@@ -155,42 +207,36 @@ class BlockSparseTSDFRenderer:
         """Render depth and normal images from block-sparse TSDF.
 
         Args:
-            intrinsics: [3, 3] or [4] camera intrinsics (fx, fy, cx, cy).
-            pose: Camera-to-world transform as Pose.
+            intrinsics: ``(3, 3)``, ``(4,)``, ``(N, 3, 3)``, or ``(N, 4)`` camera
+                intrinsics. Batched intrinsics require a pose with the same camera count.
+            pose: Camera-to-world transform as :class:`Pose`.
             image_shape: (H, W) output image dimensions.
 
         Returns:
-            depth_image: [H, W] rendered depth in meters (0 where no hit).
-            normal_image: [H, W, 3] surface normals in world frame.
-            valid_mask: [H, W] boolean mask of valid pixels.
+            Tuple of depth, normals, and valid mask. Single-camera inputs return
+            ``(H, W)``, ``(H, W, 3)``, and ``(H, W)``. Batched inputs return
+            ``(N, H, W)``, ``(N, H, W, 3)``, and ``(N, H, W)``.
         """
         H, W = image_shape
-        n_pixels = H * W
+        render_inputs = self._normalize_render_inputs(intrinsics, pose)
+        n_pixels_per_camera = H * W
+        n_pixels = render_inputs.camera_count * n_pixels_per_camera
 
         self._ensure_buffers(n_pixels)
-        self._extract_pose(pose)
-        self._extract_intrinsics(intrinsics)
 
         # Get block-sparse TSDF data and per-instance kernel specialization.
         tsdf = self.integrator._tsdf
         warp_data = tsdf.get_warp_data()
         kernels = tsdf.kernels
 
-        # Select kernel based on acceleration setting
-        kernel = (
-            kernels.raycast_block_sparse_accelerated_kernel
-            if self.config.use_block_acceleration
-            else kernels.raycast_block_sparse_kernel
-        )
-
         # Launch raycast kernel with struct-based API
         wp.launch(
-            kernel=kernel,
+            kernel=kernels.raycast_block_sparse_kernel,
             dim=n_pixels,
             inputs=[
-                wp.from_torch(self.intrinsics_matrix, dtype=wp.float32),
-                wp.from_torch(self.cam_position, dtype=wp.float32),
-                wp.from_torch(self.cam_quaternion, dtype=wp.float32),
+                wp.from_torch(render_inputs.intrinsics, dtype=wp.float32),
+                wp.from_torch(render_inputs.positions, dtype=wp.float32),
+                wp.from_torch(render_inputs.quaternions, dtype=wp.float32),
                 warp_data,
                 self.config.depth_minimum_distance,
                 self.config.depth_maximum_distance,
@@ -201,14 +247,24 @@ class BlockSparseTSDFRenderer:
                 wp.from_torch(self._hit_mask[:n_pixels], dtype=wp.uint8),
                 H,
                 W,
+                n_pixels_per_camera,
             ],
         )
 
         # Kernel clears hit_* to zero on miss, so output buffers are
         # authoritative and no additional masking is required here.
-        depth_image = self._hit_depths[:n_pixels].view(H, W)
-        normal_image = self._hit_normals[:n_pixels].view(H, W, 3)
-        valid_mask = self._hit_mask[:n_pixels].view(H, W).bool()
+        if render_inputs.single_camera:
+            depth_image = self._hit_depths[:n_pixels].view(H, W)
+            normal_image = self._hit_normals[:n_pixels].view(H, W, 3)
+            valid_mask = self._hit_mask[:n_pixels].view(H, W).bool()
+        else:
+            depth_image = self._hit_depths[:n_pixels].view(render_inputs.camera_count, H, W)
+            normal_image = self._hit_normals[:n_pixels].view(
+                render_inputs.camera_count, H, W, 3
+            )
+            valid_mask = self._hit_mask[:n_pixels].view(
+                render_inputs.camera_count, H, W
+            ).bool()
 
         return depth_image, normal_image, valid_mask
 
@@ -221,43 +277,36 @@ class BlockSparseTSDFRenderer:
         """Render depth, normals, and color from block-sparse TSDF.
 
         Args:
-            intrinsics: [3, 3] or [4] camera intrinsics.
-            pose: Camera-to-world transform as Pose.
+            intrinsics: ``(3, 3)``, ``(4,)``, ``(N, 3, 3)``, or ``(N, 4)`` camera
+                intrinsics. Batched intrinsics require a pose with the same camera count.
+            pose: Camera-to-world transform as :class:`Pose`.
             image_shape: (H, W) output dimensions.
 
         Returns:
-            depth_image: [H, W] rendered depth in meters.
-            normal_image: [H, W, 3] surface normals.
-            color_image: [H, W, 3] uint8 RGB colors.
-            valid_mask: [H, W] boolean mask.
+            Tuple of depth, normals, color, and valid mask. Single-camera inputs
+            keep the existing ``(H, W)`` and ``(H, W, 3)`` shapes; batched inputs
+            include a leading camera dimension.
         """
         H, W = image_shape
-        n_pixels = H * W
+        render_inputs = self._normalize_render_inputs(intrinsics, pose)
+        n_pixels_per_camera = H * W
+        n_pixels = render_inputs.camera_count * n_pixels_per_camera
 
-        self._ensure_buffers(n_pixels)
-        self._extract_pose(pose)
-        self._extract_intrinsics(intrinsics)
+        self._ensure_buffers(n_pixels, include_color=True)
 
         # Get block-sparse TSDF data and per-instance kernel specialization.
         tsdf = self.integrator._tsdf
         warp_data = tsdf.get_warp_data()
         kernels = tsdf.kernels
 
-        # Select kernel based on acceleration setting
-        kernel = (
-            kernels.raycast_block_sparse_accelerated_color_kernel
-            if self.config.use_block_acceleration
-            else kernels.raycast_block_sparse_color_kernel
-        )
-
         # Launch color raycast kernel with struct-based API
         wp.launch(
-            kernel=kernel,
+            kernel=kernels.raycast_block_sparse_color_kernel,
             dim=n_pixels,
             inputs=[
-                wp.from_torch(self.intrinsics_matrix, dtype=wp.float32),
-                wp.from_torch(self.cam_position, dtype=wp.float32),
-                wp.from_torch(self.cam_quaternion, dtype=wp.float32),
+                wp.from_torch(render_inputs.intrinsics, dtype=wp.float32),
+                wp.from_torch(render_inputs.positions, dtype=wp.float32),
+                wp.from_torch(render_inputs.quaternions, dtype=wp.float32),
                 warp_data,
                 self.config.depth_minimum_distance,
                 self.config.depth_maximum_distance,
@@ -269,15 +318,28 @@ class BlockSparseTSDFRenderer:
                 wp.from_torch(self._hit_mask[:n_pixels], dtype=wp.uint8),
                 H,
                 W,
+                n_pixels_per_camera,
             ],
         )
 
         # Kernel clears hit_* to zero on miss, so output buffers are
         # authoritative and no additional masking is required here.
-        depth_image = self._hit_depths[:n_pixels].view(H, W)
-        normal_image = self._hit_normals[:n_pixels].view(H, W, 3)
-        color_image = self._hit_colors[:n_pixels].view(H, W, 3)
-        valid_mask = self._hit_mask[:n_pixels].view(H, W).bool()
+        if render_inputs.single_camera:
+            depth_image = self._hit_depths[:n_pixels].view(H, W)
+            normal_image = self._hit_normals[:n_pixels].view(H, W, 3)
+            color_image = self._hit_colors[:n_pixels].view(H, W, 3)
+            valid_mask = self._hit_mask[:n_pixels].view(H, W).bool()
+        else:
+            depth_image = self._hit_depths[:n_pixels].view(render_inputs.camera_count, H, W)
+            normal_image = self._hit_normals[:n_pixels].view(
+                render_inputs.camera_count, H, W, 3
+            )
+            color_image = self._hit_colors[:n_pixels].view(
+                render_inputs.camera_count, H, W, 3
+            )
+            valid_mask = self._hit_mask[:n_pixels].view(
+                render_inputs.camera_count, H, W
+            ).bool()
 
         return depth_image, normal_image, color_image, valid_mask
 
@@ -295,7 +357,7 @@ class BlockSparseTSDFRenderer:
             image_shape: (H, W) output dimensions.
 
         Returns:
-            depth_image: [H, W] rendered depth in meters.
+            depth_image: ``(H, W)`` or ``(N, H, W)`` rendered depth in meters.
         """
         depth, _, _ = self.render(intrinsics, pose, image_shape)
         return depth
@@ -314,7 +376,7 @@ class BlockSparseTSDFRenderer:
             image_shape: (H, W) output dimensions.
 
         Returns:
-            normal_image: [H, W, 3] surface normals.
+            normal_image: ``(H, W, 3)`` or ``(N, H, W, 3)`` surface normals.
         """
         _, normals, _ = self.render(intrinsics, pose, image_shape)
         return normals
@@ -333,7 +395,7 @@ class BlockSparseTSDFRenderer:
             image_shape: (H, W) output dimensions.
 
         Returns:
-            color_image: [H, W, 3] uint8 RGB colors.
+            color_image: ``(H, W, 3)`` or ``(N, H, W, 3)`` uint8 RGB colors.
         """
         _, _, color, _ = self.render_color(intrinsics, pose, image_shape)
         # Kernel already writes 0 for invalid pixels (see render_color).
@@ -353,10 +415,15 @@ class BlockSparseTSDFRenderer:
             image_shape: (H, W) output dimensions.
 
         Returns:
-            color_image: [H, W, 3] uint8 RGB colormap.
+            color_image: ``(H, W, 3)`` or ``(N, H, W, 3)`` uint8 RGB colormap.
         """
         depth, _, valid = self.render(intrinsics, pose, image_shape)
-        return depth_to_colormap(depth, self.config.depth_minimum_distance, self.config.depth_maximum_distance, valid)
+        return depth_to_colormap(
+            depth,
+            self.config.depth_minimum_distance,
+            self.config.depth_maximum_distance,
+            valid,
+        )
 
     def render_normal_colormap(
         self,
@@ -372,7 +439,7 @@ class BlockSparseTSDFRenderer:
             image_shape: (H, W) output dimensions.
 
         Returns:
-            color_image: [H, W, 3] uint8 RGB colormap.
+            color_image: ``(H, W, 3)`` or ``(N, H, W, 3)`` uint8 RGB colormap.
         """
         _, normals, valid = self.render(intrinsics, pose, image_shape)
         return normals_to_colormap(normals, valid)
@@ -397,23 +464,29 @@ class BlockSparseTSDFRenderer:
             use_color: If True, use TSDF color. If False, use gray.
 
         Returns:
-            shaded_image: [H, W, 3] uint8 RGB shaded image.
+            shaded_image: ``(H, W, 3)`` or ``(N, H, W, 3)`` uint8 RGB shaded image.
         """
         if use_color:
             _, normals, colors, valid = self.render_color(intrinsics, pose, image_shape)
             base_color = colors.float() / 255.0
         else:
             _, normals, valid = self.render(intrinsics, pose, image_shape)
-            base_color = torch.ones(*normals.shape[:-1], 3, device=self.device)
+            base_color = torch.ones_like(normals)
 
         # Transform light to world frame and normalize
-        R = pose.get_rotation_matrix().squeeze().to(self.device, dtype=torch.float32)
+        R = pose.get_rotation_matrix().to(self.device, dtype=torch.float32)
         light_cam = torch.tensor(light_direction, device=self.device, dtype=torch.float32)
-        light_world = R @ light_cam
-        light_world = light_world / light_world.norm()
+        if normals.ndim == 4:
+            light_world = torch.matmul(R, light_cam.view(1, 3, 1)).squeeze(-1)
+            light_world = light_world / light_world.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+            light_view = light_world.view(light_world.shape[0], 1, 1, 3)
+        else:
+            light_world = R[0] @ light_cam
+            light_world = light_world / light_world.norm().clamp_min(1e-6)
+            light_view = light_world.view(1, 1, 3)
 
         # Lambertian shading: max(0, n · l)
-        n_dot_l = (normals * light_world.view(1, 1, 3)).sum(dim=-1)
+        n_dot_l = (normals * light_view).sum(dim=-1)
         shading = torch.clamp(n_dot_l, 0, 1)
 
         # Apply ambient + diffuse
@@ -458,7 +531,9 @@ def depth_to_colormap(
         valid_mask = depth > 0
 
     # Normalize depth to [0, 1]
-    depth_normalized = (depth - depth_minimum_distance) / (depth_maximum_distance - depth_minimum_distance)
+    depth_normalized = (depth - depth_minimum_distance) / (
+        depth_maximum_distance - depth_minimum_distance
+    )
     depth_normalized = torch.clamp(depth_normalized, 0, 1)
 
     t = depth_normalized

--- a/curobo/_src/perception/mapper/storage.py
+++ b/curobo/_src/perception/mapper/storage.py
@@ -131,6 +131,13 @@ class BlockSparseTSDFCfg:
     #: Compile-time support-pixel capacity specialized into RGB and feature
     #: integration kernels. Must match the projective scratch depth.
     max_support_pixels_per_block_camera: int = 32
+    #: Enable a per-block local RGBW control grid. When disabled the mapper
+    #: uses the legacy one-RGBW-accumulator-per-block path.
+    use_color_grid: bool = False
+    #: Number of RGBW control points per block edge when ``use_color_grid`` is
+    #: enabled. Total storage is ``color_grid_size ** 3`` RGBW accumulators per
+    #: block.
+    color_grid_size: int = 1
     #: Upper bound on per-block accumulator weight (``block_rgb[:, 3]`` and
     #: ``block_feature_weight``) after each integration step. Caps the
     #: magnitude of the fp16 weighted-sum accumulators so they stay inside
@@ -169,6 +176,16 @@ class BlockSparseTSDFCfg:
             raise ValueError(
                 "max_support_pixels_per_block_camera must be positive, got "
                 f"{self.max_support_pixels_per_block_camera}."
+            )
+        if not isinstance(self.use_color_grid, bool):
+            raise ValueError(
+                "use_color_grid must be bool, got "
+                f"{type(self.use_color_grid).__name__}."
+            )
+        if self.color_grid_size <= 0:
+            raise ValueError(
+                "color_grid_size must be positive, got "
+                f"{self.color_grid_size}."
             )
         if self.max_blocks > DEFAULT_HASH_LAYOUT.max_pool_idx:
             raise ValueError(
@@ -363,6 +380,7 @@ class BlockSparseTSDFData:
     # Block pool - packed voxel data (3D for Warp INT32_MAX compatibility)
     block_data: torch.Tensor  # (max_blocks, block_size**3, 2) float16 or (1, 1, 2) dummy
     block_rgb: torch.Tensor  # (max_blocks, 4) float16 - per-block [R×w, G×w, B×w, W]
+    block_grid_rgb: torch.Tensor  # (max_blocks, color_grid_size**3, 4) fp16 or dummy
 
     # Per-block feature channel (weighted-sum accumulator + dedicated weight)
     block_features: torch.Tensor  # (max_blocks, feature_dim) float16 or (1, 1) dummy
@@ -409,7 +427,9 @@ class BlockSparseTSDFData:
     has_dynamic: bool = True
     has_static: bool = False
     has_features: bool = False
+    has_color_grid: bool = False
     feature_dim: int = 0
+    color_grid_size: int = 1
 
     def to_warp(self) -> BlockSparseTSDFWarp:
         """Convert to Warp struct for kernel launches.
@@ -429,6 +449,7 @@ class BlockSparseTSDFData:
         s.block_data = wp.from_torch(self.block_data, dtype=wp.float16)
         # Per-block weighted sums (fp16)
         s.block_rgb = wp.from_torch(self.block_rgb, dtype=wp.float16)
+        s.block_grid_rgb = wp.from_torch(self.block_grid_rgb, dtype=wp.float16)
 
         # Per-block feature channel (fp16 weighted sums, post-frame cap bounds magnitude)
         s.block_features = wp.from_torch(self.block_features, dtype=wp.float16)
@@ -441,7 +462,9 @@ class BlockSparseTSDFData:
         s.has_dynamic = self.has_dynamic
         s.has_static = self.has_static
         s.has_features = self.has_features
+        s.has_color_grid = self.has_color_grid
         s.feature_dim = self.feature_dim
+        s.color_grid_size = self.color_grid_size
 
         # Block metadata
         s.block_coords = wp.from_torch(self.block_coords, dtype=wp.int32)
@@ -605,6 +628,14 @@ class BlockSparseTSDF:
             "config.max_support_pixels_per_block_camera="
             f"{config.max_support_pixels_per_block_camera}"
         )
+        assert kernels.use_color_grid == config.use_color_grid, (
+            f"kernels.use_color_grid={kernels.use_color_grid} does not match "
+            f"config.use_color_grid={config.use_color_grid}"
+        )
+        assert kernels.color_grid_size == config.color_grid_size, (
+            f"kernels.color_grid_size={kernels.color_grid_size} does not match "
+            f"config.color_grid_size={config.color_grid_size}"
+        )
         assert kernels.hash_layout == DEFAULT_HASH_LAYOUT, (
             f"kernels.hash_layout={kernels.hash_layout} does not match "
             f"DEFAULT_HASH_LAYOUT={DEFAULT_HASH_LAYOUT}"
@@ -671,6 +702,20 @@ class BlockSparseTSDF:
                 device=self.device,
             )
 
+        color_grid_voxels = config.color_grid_size**3
+        if config.use_color_grid:
+            block_grid_rgb = torch.zeros(
+                (config.max_blocks, color_grid_voxels, 4),
+                dtype=torch.float16,
+                device=self.device,
+            )
+        else:
+            block_grid_rgb = torch.zeros(
+                (1, 1, 4),
+                dtype=torch.float16,
+                device=self.device,
+            )
+
         # Pre-allocate all tensors
         self._data = BlockSparseTSDFData(
             # Hash table (packed key+value, -1 = empty)
@@ -693,6 +738,9 @@ class BlockSparseTSDF:
                 dtype=torch.float16,
                 device=self.device,
             ),
+            # Optional per-block local RGBW control lattice. Kept separate
+            # from block_rgb so legacy block-color behavior remains available.
+            block_grid_rgb=block_grid_rgb,
             # Per-block feature channel (conditional). feature_dim==0 gives
             # (1, 1) / (1,) dummies so the Warp struct can always be built.
             block_features=block_features,
@@ -764,7 +812,9 @@ class BlockSparseTSDF:
             has_dynamic=config.enable_dynamic,
             has_static=config.enable_static,
             has_features=has_features,
+            has_color_grid=config.use_color_grid,
             feature_dim=config.feature_dim,
+            color_grid_size=config.color_grid_size,
         )
 
         # Cached Warp struct (for CUDA graph compatibility)
@@ -848,7 +898,7 @@ class BlockSparseTSDF:
         if self._data.has_static:
             self._data.static_block_data.fill_(float("inf"))
 
-        # Note: block_data and block_rgb are cleared lazily when blocks
+        # Note: block_data, block_rgb, and block_grid_rgb are cleared lazily when blocks
         # are allocated (via clear_new_blocks_kernel)
 
     def export_blocks(self) -> Dict[str, torch.Tensor]:
@@ -1143,6 +1193,7 @@ class BlockSparseTSDF:
         total += self._data.hash_table.numel() * 8  # int64 (packed key+value)
         total += self._data.block_data.numel() * 2  # float16
         total += self._data.block_rgb.numel() * 2  # float16
+        total += self._data.block_grid_rgb.numel() * 2  # float16
         total += self._data.block_features.numel() * 2  # float16
         total += self._data.block_feature_weight.numel() * 2  # float16
         total += self._data.static_block_data.numel() * 2  # float16

--- a/curobo/_src/perception/mapper/storage.py
+++ b/curobo/_src/perception/mapper/storage.py
@@ -13,7 +13,8 @@ Memory Layout:
     Block size: ``block_size**3`` voxels per block (default 8**3 = 512)
     Per voxel: 2 × float16 (sdf_weight, weight)
     Per block: color_grid_size**3 × 4 × float16 RGBW +
-        feature_dim × float16 features + 1 × float16 feature_weight
+        feature_block_grid_size**3 × feature_dim × float16 features +
+        feature_block_grid_size**3 × float16 feature_weight
 
 Memory Budget example (block_size=8, 100K blocks):
     - hash_table:         1.6 MB (200K × 8 bytes, packed key+value)
@@ -31,7 +32,7 @@ All per-block weighted-sum accumulators (``block_grid_rgb``,
 ``block_features``, ``block_feature_weight``) are stored as fp16. The
 integration kernels pre-normalize RGB inputs by 255 and feature inputs
 to unit magnitude so per-pixel atomic-add increments stay ``O(1)``.
-A post-frame rescale kernel caps each per-node/block weight at
+A post-frame rescale kernel caps each per-node weight at
 :attr:`BlockSparseTSDFCfg.accumulator_w_max` and scales the weighted-sum
 channels proportionally, preserving the weighted mean while keeping
 magnitudes inside fp16's finite range.
@@ -57,10 +58,11 @@ from curobo._src.perception.mapper.constants import (
     PY_HASH_EMPTY,
     PY_HASH_TOMBSTONE,
     PY_VALUE_MASK,
+    _validate_block_size,
     _validate_color_grid_size,
+    _validate_feature_block_grid_size,
     _validate_feature_channels_per_thread,
     _validate_feature_grid_shape,
-    _validate_block_size,
     validate_grid_shape_for_hash_layout,
 )
 from curobo._src.perception.mapper.kernel.builder.builder_block_sparse_kernel import (
@@ -117,6 +119,9 @@ class BlockSparseTSDFCfg:
     #: Per-block feature channel dimensionality. 0 disables the channel
     #: (dummy tensors are allocated for Warp compatibility).
     feature_dim: int = 0
+    #: Number of feature control points per block edge. This is independent
+    #: from the incoming 2D feature image dimensions.
+    feature_block_grid_size: int = 1
     #: Compile-time feature-grid height used when this storage builds its
     #: own kernel bundle. Required when ``feature_dim > 0``; must be
     #: ``None`` when features are disabled.
@@ -138,7 +143,7 @@ class BlockSparseTSDFCfg:
     #: kernel specialization value; changing it requires rebuilding storage and
     #: kernels. Total storage is ``color_grid_size ** 3`` RGBW accumulators per block.
     color_grid_size: int = 1
-    #: Upper bound on per-node RGB grid weight and per-block feature weight
+    #: Upper bound on per-node RGB and feature-grid weights
     #: after each integration step. Caps the magnitude of fp16 weighted-sum
     #: accumulators so they stay inside fp16's finite range and bounds
     #: ulp-loss on subsequent atomic adds.
@@ -178,6 +183,10 @@ class BlockSparseTSDFCfg:
                 f"{self.max_support_pixels_per_block_camera}."
             )
         _validate_color_grid_size(self.color_grid_size, self.block_size)
+        _validate_feature_block_grid_size(
+            self.feature_block_grid_size,
+            self.block_size,
+        )
         if self.max_blocks > DEFAULT_HASH_LAYOUT.max_pool_idx:
             raise ValueError(
                 f"max_blocks={self.max_blocks:,} exceeds the "
@@ -207,7 +216,7 @@ class BlockDataView:
     voxel centers returned by :func:`extract_occupied_voxels`.
 
     When the feature channel is disabled (``feature_dim == 0``),
-    ``features`` / ``feature_weight`` are dummy ``(1, 1)`` / ``(1,)``
+    ``features`` / ``feature_weight`` are dummy ``(1, 1, 1)`` / ``(1, 1)``
     tensors kept only for Warp compatibility.
     """
 
@@ -219,8 +228,9 @@ class BlockDataView:
     block_size: int
     grid_shape: Tuple[int, int, int]
     color_grid_size: int
-    features: torch.Tensor  # (max_blocks, feature_dim) fp16 weighted sums, or (1, 1) dummy
-    feature_weight: torch.Tensor  # (max_blocks,) fp16 weight sums, or (1,) dummy
+    feature_block_grid_size: int
+    features: torch.Tensor  # (max_blocks, feature_block_grid_size**3, feature_dim) fp16 or dummy
+    feature_weight: torch.Tensor  # (max_blocks, feature_block_grid_size**3) fp16 or dummy
     feature_dim: int  # 0 when the feature channel is disabled
 
     def sample_rgbw_at_centers(
@@ -267,10 +277,78 @@ class BlockDataView:
         )
         return self.rgb_grid[pool_idx, node_idx].float()
 
+    def _feature_node_indices_at_centers(
+        self,
+        centers: torch.Tensor,
+        block_idx_per_voxel: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return nearest local feature-node indices for voxel centers."""
+        pool_idx = block_idx_per_voxel.long()
+        if self.feature_block_grid_size <= 1 or self.block_size <= 1:
+            return torch.zeros_like(pool_idx, dtype=torch.long)
+
+        coords = self.coords.view(-1, 3)[pool_idx].long()
+        grid_d, grid_h, grid_w = (int(v) for v in self.grid_shape)
+        blocks_x = (grid_w + self.block_size - 1) // self.block_size
+        blocks_y = (grid_h + self.block_size - 1) // self.block_size
+        blocks_z = (grid_d + self.block_size - 1) // self.block_size
+        offsets = torch.tensor(
+            [blocks_x // 2, blocks_y // 2, blocks_z // 2],
+            dtype=coords.dtype,
+            device=coords.device,
+        )
+        block_base = (coords + offsets).to(dtype=centers.dtype) * float(self.block_size)
+        center_offset = torch.tensor(
+            [grid_w, grid_h, grid_d],
+            dtype=centers.dtype,
+            device=centers.device,
+        ) * 0.5
+        voxel_f = centers - self.origin.to(device=centers.device, dtype=centers.dtype)
+        voxel_f = voxel_f / float(self.voxel_size) + center_offset
+        local = voxel_f - block_base.to(device=centers.device)
+
+        grid_max = float(self.feature_block_grid_size - 1)
+        scale = grid_max / float(self.block_size - 1)
+        grid_f = ((local - 0.5) * scale).clamp(min=0.0, max=grid_max)
+        grid_idx = torch.floor(grid_f + 0.5).to(dtype=torch.long)
+        return (
+            grid_idx[:, 2]
+            * self.feature_block_grid_size
+            * self.feature_block_grid_size
+            + grid_idx[:, 1] * self.feature_block_grid_size
+            + grid_idx[:, 0]
+        )
+
+    def sample_features_at_centers(
+        self,
+        centers: torch.Tensor,
+        block_idx_per_voxel: torch.Tensor,
+        eps: float = 1e-6,
+    ) -> torch.Tensor:
+        """Gather nearest-node normalized features for voxel centers."""
+        if self.feature_dim == 0:
+            raise RuntimeError(
+                "sample_features_at_centers() called with feature_dim == 0. "
+                "Enable features via BlockSparseTSDFCfg.feature_dim."
+            )
+        if centers.numel() == 0:
+            return self.features.new_empty((0, self.feature_dim), dtype=torch.float32)
+
+        pool_idx = block_idx_per_voxel.long()
+        node_idx = self._feature_node_indices_at_centers(
+            centers,
+            block_idx_per_voxel,
+        )
+        gathered = self.features[pool_idx, node_idx].float()
+        weight = self.feature_weight[pool_idx, node_idx].float()
+        return gathered / weight.clamp(min=eps).unsqueeze(-1)
+
     def features_normalized(self, eps: float = 1e-6) -> torch.Tensor:
         """Return active-block features normalized by per-block weight.
 
-        Shape: ``(num_allocated, feature_dim)`` float32. Accumulators
+        Shape: ``(num_allocated, feature_dim)`` float32. The per-block
+        descriptor is the weighted mean across that block's feature grid.
+        Accumulators
         are stored fp16; the divide is done in fp32 to avoid compounding
         ulp loss on top of the post-frame rescale. Raises if the feature
         channel is disabled so callers fail loudly rather than silently
@@ -283,8 +361,9 @@ class BlockDataView:
                 "BlockSparseTSDFCfg.feature_dim (or MapperCfg.feature_dim)."
             )
         n = self.num_allocated
-        weight = self.feature_weight[:n].float().clamp(min=eps).unsqueeze(-1)
-        return self.features[:n].float() / weight
+        summed_features = self.features[:n].float().sum(dim=1)
+        summed_weight = self.feature_weight[:n].float().sum(dim=1).clamp(min=eps)
+        return summed_features / summed_weight.unsqueeze(-1)
 
 
 @dataclass
@@ -292,40 +371,65 @@ class OccupiedVoxels:
     """Result of :func:`extract_occupied_voxels`.
 
     Attributes:
-        centers: ``(N, 3)`` float32 voxel world positions.
+        centers: ``(N, 3)`` float32 voxel or subvoxel sample world positions.
         block_idx_per_voxel: ``(N,)`` int32 global ``pool_idx`` — index into
             :class:`BlockDataView` fields.
         block_data: Reference view of per-block storage tensors.
+        texture_colors: Optional ``(N, 3)`` uint8 RGB samples from visibility-tested
+            texture observations.
+        texture_valid: Optional ``(N,)`` bool mask. True entries use
+            :attr:`texture_colors` when callers prefer texture output.
+        subvoxel_factor: Number of point samples per source voxel axis.
     """
 
     centers: torch.Tensor
     block_idx_per_voxel: torch.Tensor
     block_data: BlockDataView
+    texture_colors: Optional[torch.Tensor] = None
+    texture_valid: Optional[torch.Tensor] = None
+    subvoxel_factor: int = 1
 
     def __len__(self) -> int:
         return self.centers.shape[0]
 
-    def colors_uint8(self, eps: float = 1e-6) -> torch.Tensor:
+    def colors_uint8(self, eps: float = 1e-6, prefer_texture: bool = True) -> torch.Tensor:
         """Gather per-voxel RGB colors as ``(N, 3)`` uint8.
 
         Weighted sums (stored fp16, RGB normalized to ``[0, 1]`` at the
         integration site) are divided in fp32 and rescaled back to
         ``[0, 255]`` before the uint8 cast. Clamp protects degenerate
-        blocks with zero weight from division by zero.
+        blocks with zero weight from division by zero. When texture colors
+        are present and ``prefer_texture`` is true, valid texture samples
+        replace the persistent TSDF color-grid color.
         """
         rgb = self.block_data.sample_rgbw_at_centers(
             self.centers,
             self.block_idx_per_voxel,
         )
+        observed = rgb[:, 3] > eps
         normalized = rgb[:, :3] / rgb[:, 3:4].clamp(min=eps)
-        return (normalized * 255.0).clamp(0.0, 255.0).to(torch.uint8)
+        colors = (normalized * 255.0).clamp(0.0, 255.0).to(torch.uint8)
+        if (~observed).any():
+            colors = colors.clone()
+            colors[~observed] = 128
+        if (
+            prefer_texture
+            and self.texture_colors is not None
+            and self.texture_valid is not None
+            and self.texture_colors.numel() > 0
+        ):
+            valid = self.texture_valid.bool()
+            if valid.any():
+                colors = colors.clone()
+                colors[valid] = self.texture_colors[valid]
+        return colors
 
     def features(self, eps: float = 1e-6) -> torch.Tensor:
         """Gather per-voxel normalized features as ``(N, feature_dim)`` float32.
 
         Weighted sums (stored fp16) are divided in fp32 to avoid
-        compounding ulp loss. The per-block feature weight is clamped to
-        avoid division by zero for blocks that never received a feature
+        compounding ulp loss. The per-node feature weight is clamped to
+        avoid division by zero for nodes that never received a feature
         observation.
         """
         if self.block_data.feature_dim == 0:
@@ -333,9 +437,11 @@ class OccupiedVoxels:
                 "OccupiedVoxels.features() called with feature_dim == 0. "
                 "Enable features via BlockSparseTSDFCfg.feature_dim."
             )
-        gathered = self.block_data.features[self.block_idx_per_voxel].float()
-        weight = self.block_data.feature_weight[self.block_idx_per_voxel].float()
-        return gathered / weight.clamp(min=eps).unsqueeze(-1)
+        return self.block_data.sample_features_at_centers(
+            self.centers,
+            self.block_idx_per_voxel,
+            eps=eps,
+        )
 
 
 @dataclass
@@ -420,9 +526,9 @@ class BlockSparseTSDFData:
     block_data: torch.Tensor  # (max_blocks, block_size**3, 2) float16 or (1, 1, 2) dummy
     block_grid_rgb: torch.Tensor  # (max_blocks, color_grid_size**3, 4) fp16 RGBW sums
 
-    # Per-block feature channel (weighted-sum accumulator + dedicated weight)
-    block_features: torch.Tensor  # (max_blocks, feature_dim) float16 or (1, 1) dummy
-    block_feature_weight: torch.Tensor  # (max_blocks,) float16 or (1,) dummy
+    # Per-block feature grid (weighted-sum accumulator + dedicated weight)
+    block_features: torch.Tensor  # (max_blocks, feature_block_grid_size**3, feature_dim) or dummy
+    block_feature_weight: torch.Tensor  # (max_blocks, feature_block_grid_size**3) or dummy
 
     # Static SDF channel (separate tensor for primitives)
     static_block_data: torch.Tensor  # (max_blocks, block_size**3) float16 or (1, 1) dummy
@@ -467,6 +573,7 @@ class BlockSparseTSDFData:
     has_features: bool = False
     feature_dim: int = 0
     color_grid_size: int = 1
+    feature_block_grid_size: int = 1
 
     def to_warp(self) -> BlockSparseTSDFWarp:
         """Convert to Warp struct for kernel launches.
@@ -486,7 +593,7 @@ class BlockSparseTSDFData:
         s.block_data = wp.from_torch(self.block_data, dtype=wp.float16)
         s.block_grid_rgb = wp.from_torch(self.block_grid_rgb, dtype=wp.float16)
 
-        # Per-block feature channel (fp16 weighted sums, post-frame cap bounds magnitude)
+        # Per-block feature grid (fp16 weighted sums, post-frame cap bounds magnitude)
         s.block_features = wp.from_torch(self.block_features, dtype=wp.float16)
         s.block_feature_weight = wp.from_torch(self.block_feature_weight, dtype=wp.float16)
 
@@ -499,6 +606,7 @@ class BlockSparseTSDFData:
         s.has_features = self.has_features
         s.feature_dim = self.feature_dim
         s.color_grid_size = self.color_grid_size
+        s.feature_block_grid_size = self.feature_block_grid_size
 
         # Block metadata
         s.block_coords = wp.from_torch(self.block_coords, dtype=wp.int32)
@@ -666,6 +774,12 @@ class BlockSparseTSDF:
             f"kernels.color_grid_size={kernels.color_grid_size} does not match "
             f"config.color_grid_size={config.color_grid_size}"
         )
+        assert kernels.feature_block_grid_size == config.feature_block_grid_size, (
+            "kernels.feature_block_grid_size="
+            f"{kernels.feature_block_grid_size} does not match "
+            "config.feature_block_grid_size="
+            f"{config.feature_block_grid_size}"
+        )
         assert kernels.hash_layout == DEFAULT_HASH_LAYOUT, (
             f"kernels.hash_layout={kernels.hash_layout} does not match "
             f"DEFAULT_HASH_LAYOUT={DEFAULT_HASH_LAYOUT}"
@@ -706,33 +820,35 @@ class BlockSparseTSDF:
                 device=self.device,
             )
 
-        # Conditional allocation for per-block feature channel
+        color_grid_voxels = config.color_grid_size**3
+        feature_grid_voxels = config.feature_block_grid_size**3
+
+        # Conditional allocation for per-block feature grid
         has_features = config.feature_dim > 0
         if has_features:
             block_features = torch.zeros(
-                (config.max_blocks, config.feature_dim),
+                (config.max_blocks, feature_grid_voxels, config.feature_dim),
                 dtype=torch.float16,
                 device=self.device,
             )
             block_feature_weight = torch.zeros(
-                config.max_blocks,
+                (config.max_blocks, feature_grid_voxels),
                 dtype=torch.float16,
                 device=self.device,
             )
         else:
             # Dummy tensors for Warp compatibility when disabled
             block_features = torch.zeros(
-                (1, 1),
+                (1, 1, 1),
                 dtype=torch.float16,
                 device=self.device,
             )
             block_feature_weight = torch.zeros(
-                1,
+                (1, 1),
                 dtype=torch.float16,
                 device=self.device,
             )
 
-        color_grid_voxels = config.color_grid_size**3
         block_grid_rgb = torch.zeros(
             (config.max_blocks, color_grid_voxels, 4),
             dtype=torch.float16,
@@ -754,8 +870,8 @@ class BlockSparseTSDF:
             # to [0, 1] at integration/stamping sites; divide by channel 3
             # and multiply by 255 at read time for uint8 colors.
             block_grid_rgb=block_grid_rgb,
-            # Per-block feature channel (conditional). feature_dim==0 gives
-            # (1, 1) / (1,) dummies so the Warp struct can always be built.
+            # Per-block feature grid (conditional). feature_dim==0 gives
+            # small dummies so the Warp struct can always be built.
             block_features=block_features,
             block_feature_weight=block_feature_weight,
             # Block pool - static channel (conditional)
@@ -827,6 +943,7 @@ class BlockSparseTSDF:
             has_features=has_features,
             feature_dim=config.feature_dim,
             color_grid_size=config.color_grid_size,
+            feature_block_grid_size=config.feature_block_grid_size,
         )
 
         # Cached Warp struct (for CUDA graph compatibility)
@@ -910,8 +1027,8 @@ class BlockSparseTSDF:
         if self._data.has_static:
             self._data.static_block_data.fill_(float("inf"))
 
-        # Note: block_data and block_grid_rgb are cleared lazily when blocks
-        # are allocated.
+        # Note: block_data, block_grid_rgb, and feature grids are cleared
+        # lazily when blocks are allocated.
 
     def export_blocks(self) -> Dict[str, torch.Tensor]:
         """Export active block payload tensors in compact pool order.

--- a/curobo/_src/perception/mapper/storage.py
+++ b/curobo/_src/perception/mapper/storage.py
@@ -12,12 +12,13 @@ This module provides:
 Memory Layout:
     Block size: ``block_size**3`` voxels per block (default 8**3 = 512)
     Per voxel: 2 × float16 (sdf_weight, weight)
-    Per block: 4 × float16 RGBW + feature_dim × float16 features + 1 × float16 feature_weight
+    Per block: color_grid_size**3 × 4 × float16 RGBW +
+        feature_dim × float16 features + 1 × float16 feature_weight
 
 Memory Budget example (block_size=8, 100K blocks):
     - hash_table:         1.6 MB (200K × 8 bytes, packed key+value)
     - block_data:       200.0 MB (100K × 512 × 2 × 2 bytes)
-    - block_rgb:          0.8 MB (100K × 4 × 2 bytes)
+    - block_grid_rgb:     0.8 MB (100K × 1 × 4 × 2 bytes, color_grid_size=1)
     - block_coords:       1.2 MB (100K × 3 × 4 bytes)
     - block_to_hash_slot: 0.4 MB (100K × 4 bytes)
     - free_list:          0.4 MB (100K × 4 bytes)
@@ -26,13 +27,14 @@ Memory Budget example (block_size=8, 100K blocks):
     ─────────────────────────────────
     Total:              ~205 MB (vs 4+ GB dense = 20× savings)
 
-All per-block weighted-sum accumulators (``block_rgb``, ``block_features``,
-``block_feature_weight``) are stored as fp16. The integration kernels
-pre-normalize RGB inputs by 255 and feature inputs to unit magnitude so
-per-pixel atomic-add increments stay ``O(1)``. A post-frame rescale
-kernel caps each per-block weight at :attr:`BlockSparseTSDFCfg.accumulator_w_max`
-and scales the weighted-sum channels proportionally, preserving the
-weighted mean while keeping magnitudes inside fp16's finite range.
+All per-block weighted-sum accumulators (``block_grid_rgb``,
+``block_features``, ``block_feature_weight``) are stored as fp16. The
+integration kernels pre-normalize RGB inputs by 255 and feature inputs
+to unit magnitude so per-pixel atomic-add increments stay ``O(1)``.
+A post-frame rescale kernel caps each per-node/block weight at
+:attr:`BlockSparseTSDFCfg.accumulator_w_max` and scales the weighted-sum
+channels proportionally, preserving the weighted mean while keeping
+magnitudes inside fp16's finite range.
 """
 
 import math
@@ -55,6 +57,7 @@ from curobo._src.perception.mapper.constants import (
     PY_HASH_EMPTY,
     PY_HASH_TOMBSTONE,
     PY_VALUE_MASK,
+    _validate_color_grid_size,
     _validate_feature_channels_per_thread,
     _validate_feature_grid_shape,
     _validate_block_size,
@@ -131,17 +134,14 @@ class BlockSparseTSDFCfg:
     #: Compile-time support-pixel capacity specialized into RGB and feature
     #: integration kernels. Must match the projective scratch depth.
     max_support_pixels_per_block_camera: int = 32
-    #: Enable a per-block local RGBW control grid. When disabled the mapper
-    #: uses the legacy one-RGBW-accumulator-per-block path.
-    use_color_grid: bool = False
-    #: Number of RGBW control points per block edge when ``use_color_grid`` is
-    #: enabled. Total storage is ``color_grid_size ** 3`` RGBW accumulators per
-    #: block.
+    #: Number of RGBW control points per block edge. This is a construction-time
+    #: kernel specialization value; changing it requires rebuilding storage and
+    #: kernels. Total storage is ``color_grid_size ** 3`` RGBW accumulators per block.
     color_grid_size: int = 1
-    #: Upper bound on per-block accumulator weight (``block_rgb[:, 3]`` and
-    #: ``block_feature_weight``) after each integration step. Caps the
-    #: magnitude of the fp16 weighted-sum accumulators so they stay inside
-    #: fp16's finite range and bounds ulp-loss on subsequent atomic adds.
+    #: Upper bound on per-node RGB grid weight and per-block feature weight
+    #: after each integration step. Caps the magnitude of fp16 weighted-sum
+    #: accumulators so they stay inside fp16's finite range and bounds
+    #: ulp-loss on subsequent atomic adds.
     #: Setting this finite also gives the mapper EMA semantics: old
     #: observations decay at a rate set by
     #: ``W_max / mean_per_frame_weight``, which is desirable for dynamic
@@ -177,16 +177,7 @@ class BlockSparseTSDFCfg:
                 "max_support_pixels_per_block_camera must be positive, got "
                 f"{self.max_support_pixels_per_block_camera}."
             )
-        if not isinstance(self.use_color_grid, bool):
-            raise ValueError(
-                "use_color_grid must be bool, got "
-                f"{type(self.use_color_grid).__name__}."
-            )
-        if self.color_grid_size <= 0:
-            raise ValueError(
-                "color_grid_size must be positive, got "
-                f"{self.color_grid_size}."
-            )
+        _validate_color_grid_size(self.color_grid_size, self.block_size)
         if self.max_blocks > DEFAULT_HASH_LAYOUT.max_pool_idx:
             raise ValueError(
                 f"max_blocks={self.max_blocks:,} exceeds the "
@@ -207,29 +198,74 @@ class BlockSparseTSDFCfg:
 class BlockDataView:
     """References (not copies) to per-block tensors.
 
-    Index any field with ``block_idx_per_voxel`` (global ``pool_idx``) returned
-    by :func:`extract_occupied_voxels`. Normalize RGB by dividing the first
-    3 columns by the weight column::
-
-        rgb_unweighted = view.rgb[:, :3] / view.rgb[:, 3:4]
-
     The tensors reference the underlying
     :class:`BlockSparseTSDFData` storage; callers must treat them as
     read-only (mutation affects storage).
+
+    RGB is stored as a per-block local control grid. Use
+    :meth:`sample_rgbw_at_centers` to gather nearest-node RGBW values for
+    voxel centers returned by :func:`extract_occupied_voxels`.
 
     When the feature channel is disabled (``feature_dim == 0``),
     ``features`` / ``feature_weight`` are dummy ``(1, 1)`` / ``(1,)``
     tensors kept only for Warp compatibility.
     """
 
-    rgb: torch.Tensor  # (max_blocks, 4) fp16 weighted sums [R*w, G*w, B*w, W]
+    rgb_grid: torch.Tensor  # (max_blocks, color_grid_size**3, 4) fp16 RGBW sums
     coords: torch.Tensor  # (max_blocks * 3,) int32 signed centered block keys
     num_allocated: int
+    origin: torch.Tensor  # (3,) float32 grid center
     voxel_size: float
     block_size: int
+    grid_shape: Tuple[int, int, int]
+    color_grid_size: int
     features: torch.Tensor  # (max_blocks, feature_dim) fp16 weighted sums, or (1, 1) dummy
     feature_weight: torch.Tensor  # (max_blocks,) fp16 weight sums, or (1,) dummy
     feature_dim: int  # 0 when the feature channel is disabled
+
+    def sample_rgbw_at_centers(
+        self,
+        centers: torch.Tensor,
+        block_idx_per_voxel: torch.Tensor,
+    ) -> torch.Tensor:
+        """Gather nearest-node RGBW values for voxel centers."""
+        if centers.numel() == 0:
+            return self.rgb_grid.new_empty((0, 4), dtype=torch.float32)
+
+        pool_idx = block_idx_per_voxel.long()
+        if self.color_grid_size <= 1 or self.block_size <= 1:
+            return self.rgb_grid[pool_idx, 0].float()
+
+        coords = self.coords.view(-1, 3)[pool_idx].long()
+        grid_d, grid_h, grid_w = (int(v) for v in self.grid_shape)
+        blocks_x = (grid_w + self.block_size - 1) // self.block_size
+        blocks_y = (grid_h + self.block_size - 1) // self.block_size
+        blocks_z = (grid_d + self.block_size - 1) // self.block_size
+        offsets = torch.tensor(
+            [blocks_x // 2, blocks_y // 2, blocks_z // 2],
+            dtype=coords.dtype,
+            device=coords.device,
+        )
+        block_base = (coords + offsets).to(dtype=centers.dtype) * float(self.block_size)
+        center_offset = torch.tensor(
+            [grid_w, grid_h, grid_d],
+            dtype=centers.dtype,
+            device=centers.device,
+        ) * 0.5
+        voxel_f = (centers - self.origin.to(device=centers.device, dtype=centers.dtype))
+        voxel_f = voxel_f / float(self.voxel_size) + center_offset
+        local = voxel_f - block_base.to(device=centers.device)
+
+        grid_max = float(self.color_grid_size - 1)
+        scale = grid_max / float(self.block_size - 1)
+        grid_f = ((local - 0.5) * scale).clamp(min=0.0, max=grid_max)
+        grid_idx = torch.floor(grid_f + 0.5).to(dtype=torch.long)
+        node_idx = (
+            grid_idx[:, 2] * self.color_grid_size * self.color_grid_size
+            + grid_idx[:, 1] * self.color_grid_size
+            + grid_idx[:, 0]
+        )
+        return self.rgb_grid[pool_idx, node_idx].float()
 
     def features_normalized(self, eps: float = 1e-6) -> torch.Tensor:
         """Return active-block features normalized by per-block weight.
@@ -277,7 +313,10 @@ class OccupiedVoxels:
         ``[0, 255]`` before the uint8 cast. Clamp protects degenerate
         blocks with zero weight from division by zero.
         """
-        rgb = self.block_data.rgb[self.block_idx_per_voxel].float()
+        rgb = self.block_data.sample_rgbw_at_centers(
+            self.centers,
+            self.block_idx_per_voxel,
+        )
         normalized = rgb[:, :3] / rgb[:, 3:4].clamp(min=eps)
         return (normalized * 255.0).clamp(0.0, 255.0).to(torch.uint8)
 
@@ -379,8 +418,7 @@ class BlockSparseTSDFData:
 
     # Block pool - packed voxel data (3D for Warp INT32_MAX compatibility)
     block_data: torch.Tensor  # (max_blocks, block_size**3, 2) float16 or (1, 1, 2) dummy
-    block_rgb: torch.Tensor  # (max_blocks, 4) float16 - per-block [R×w, G×w, B×w, W]
-    block_grid_rgb: torch.Tensor  # (max_blocks, color_grid_size**3, 4) fp16 or dummy
+    block_grid_rgb: torch.Tensor  # (max_blocks, color_grid_size**3, 4) fp16 RGBW sums
 
     # Per-block feature channel (weighted-sum accumulator + dedicated weight)
     block_features: torch.Tensor  # (max_blocks, feature_dim) float16 or (1, 1) dummy
@@ -427,7 +465,6 @@ class BlockSparseTSDFData:
     has_dynamic: bool = True
     has_static: bool = False
     has_features: bool = False
-    has_color_grid: bool = False
     feature_dim: int = 0
     color_grid_size: int = 1
 
@@ -447,8 +484,6 @@ class BlockSparseTSDFData:
 
         # Block pool - dynamic channel
         s.block_data = wp.from_torch(self.block_data, dtype=wp.float16)
-        # Per-block weighted sums (fp16)
-        s.block_rgb = wp.from_torch(self.block_rgb, dtype=wp.float16)
         s.block_grid_rgb = wp.from_torch(self.block_grid_rgb, dtype=wp.float16)
 
         # Per-block feature channel (fp16 weighted sums, post-frame cap bounds magnitude)
@@ -462,7 +497,6 @@ class BlockSparseTSDFData:
         s.has_dynamic = self.has_dynamic
         s.has_static = self.has_static
         s.has_features = self.has_features
-        s.has_color_grid = self.has_color_grid
         s.feature_dim = self.feature_dim
         s.color_grid_size = self.color_grid_size
 
@@ -628,10 +662,6 @@ class BlockSparseTSDF:
             "config.max_support_pixels_per_block_camera="
             f"{config.max_support_pixels_per_block_camera}"
         )
-        assert kernels.use_color_grid == config.use_color_grid, (
-            f"kernels.use_color_grid={kernels.use_color_grid} does not match "
-            f"config.use_color_grid={config.use_color_grid}"
-        )
         assert kernels.color_grid_size == config.color_grid_size, (
             f"kernels.color_grid_size={kernels.color_grid_size} does not match "
             f"config.color_grid_size={config.color_grid_size}"
@@ -703,18 +733,11 @@ class BlockSparseTSDF:
             )
 
         color_grid_voxels = config.color_grid_size**3
-        if config.use_color_grid:
-            block_grid_rgb = torch.zeros(
-                (config.max_blocks, color_grid_voxels, 4),
-                dtype=torch.float16,
-                device=self.device,
-            )
-        else:
-            block_grid_rgb = torch.zeros(
-                (1, 1, 4),
-                dtype=torch.float16,
-                device=self.device,
-            )
+        block_grid_rgb = torch.zeros(
+            (config.max_blocks, color_grid_voxels, 4),
+            dtype=torch.float16,
+            device=self.device,
+        )
 
         # Pre-allocate all tensors
         self._data = BlockSparseTSDFData(
@@ -727,19 +750,9 @@ class BlockSparseTSDF:
             ),
             # Block pool - dynamic channel (conditional)
             block_data=block_data,
-            # Per-block RGBW: [R×w, G×w, B×w, weight_sum]
-            # One color per block (not per voxel) - block_size**3 memory savings
-            # Divide by channel 3 (weight_sum) at read time for averaging.
-            # fp16 storage: integration pre-normalizes RGB to [0, 1] and a
-            # post-frame rescale kernel caps the weight at
-            # config.accumulator_w_max so accumulators stay in fp16 range.
-            block_rgb=torch.zeros(
-                (config.max_blocks, 4),
-                dtype=torch.float16,
-                device=self.device,
-            ),
-            # Optional per-block local RGBW control lattice. Kept separate
-            # from block_rgb so legacy block-color behavior remains available.
+            # Per-block local RGBW control lattice. RGB is pre-normalized
+            # to [0, 1] at integration/stamping sites; divide by channel 3
+            # and multiply by 255 at read time for uint8 colors.
             block_grid_rgb=block_grid_rgb,
             # Per-block feature channel (conditional). feature_dim==0 gives
             # (1, 1) / (1,) dummies so the Warp struct can always be built.
@@ -812,7 +825,6 @@ class BlockSparseTSDF:
             has_dynamic=config.enable_dynamic,
             has_static=config.enable_static,
             has_features=has_features,
-            has_color_grid=config.use_color_grid,
             feature_dim=config.feature_dim,
             color_grid_size=config.color_grid_size,
         )
@@ -898,8 +910,8 @@ class BlockSparseTSDF:
         if self._data.has_static:
             self._data.static_block_data.fill_(float("inf"))
 
-        # Note: block_data, block_rgb, and block_grid_rgb are cleared lazily when blocks
-        # are allocated (via clear_new_blocks_kernel)
+        # Note: block_data and block_grid_rgb are cleared lazily when blocks
+        # are allocated.
 
     def export_blocks(self) -> Dict[str, torch.Tensor]:
         """Export active block payload tensors in compact pool order.
@@ -921,7 +933,9 @@ class BlockSparseTSDF:
         }
         if self._data.has_dynamic:
             blocks["block_data"] = self._data.block_data[active_pool_idx].clone()
-            blocks["block_rgb"] = self._data.block_rgb[active_pool_idx].clone()
+            blocks["block_grid_rgb"] = self._data.block_grid_rgb[
+                active_pool_idx
+            ].clone()
         if self._data.has_features:
             blocks["block_features"] = self._data.block_features[active_pool_idx].clone()
             blocks["block_feature_weight"] = self._data.block_feature_weight[
@@ -1001,13 +1015,13 @@ class BlockSparseTSDF:
 
         if self._data.has_dynamic:
             self._data.block_data.zero_()
-            self._data.block_rgb.zero_()
+            self._data.block_grid_rgb.zero_()
             if n_blocks > 0:
                 self._data.block_data[:n_blocks].copy_(
                     blocks["block_data"].to(device=self.device)
                 )
-                self._data.block_rgb[:n_blocks].copy_(
-                    blocks["block_rgb"].to(device=self.device)
+                self._data.block_grid_rgb[:n_blocks].copy_(
+                    blocks["block_grid_rgb"].to(device=self.device)
                 )
                 self._data.block_sums[:n_blocks].copy_(
                     self._data.block_data[:n_blocks, :, 1].sum(
@@ -1192,7 +1206,6 @@ class BlockSparseTSDF:
         total = 0
         total += self._data.hash_table.numel() * 8  # int64 (packed key+value)
         total += self._data.block_data.numel() * 2  # float16
-        total += self._data.block_rgb.numel() * 2  # float16
         total += self._data.block_grid_rgb.numel() * 2  # float16
         total += self._data.block_features.numel() * 2  # float16
         total += self._data.block_feature_weight.numel() * 2  # float16

--- a/curobo/examples/getting_started/volumetric_mapping.py
+++ b/curobo/examples/getting_started/volumetric_mapping.py
@@ -102,6 +102,11 @@ same mapper configuration values and pass ``--resume-from``:
      --root ./datasets/sun3d/sun3d-mit_76_studyroom-76-1studyroom2 \\
      --resume-from ~/.cache/curobo/examples/volumetric_mapping/tsdf_blocks.pt
 
+When ``--visualize`` is set, the live reconstruction preview uses surface
+voxels split into smaller points and colors those points from the current RGB-D
+frame using the mapper's visibility-tested texture path. This avoids extracting
+a mesh during depth fusion while still showing a higher-resolution color preview.
+
 Step 3: Check the output
 ---------------------------
 
@@ -117,7 +122,7 @@ When the tutorial finishes successfully you will see::
 
     Computing ESDF...
     Extracting mesh...
-    Saved mesh: output_mesh.ply (150,000 vertices)
+    Saved mesh: output_mesh.glb (150,000 vertices)
 
 The following files are written to ``~/.cache/curobo/examples/volumetric_mapping/``
 (override with ``curobo._src.runtime.cache_dir``):
@@ -125,9 +130,11 @@ The following files are written to ``~/.cache/curobo/examples/volumetric_mapping
 - ``rendered_depth.png``: depth colormap rendered from the first camera pose
 - ``rendered_normals.png``: surface normal colormap
 - ``rendered_shaded.png``: Phong-shaded surface view
-- ``output_mesh.ply``: colored triangle mesh of the full reconstruction
+- ``output_mesh.glb``: textured triangle mesh of the full reconstruction
 - ``tsdf_blocks.pt``: compact mapper block checkpoint when ``--checkpoint`` is set
 """
+
+from __future__ import annotations
 
 import argparse
 import os
@@ -148,6 +155,10 @@ from curobo.profiling import CudaEventTimer
 from curobo.scene import Cuboid, Mesh, SceneData
 from curobo.types import CameraObservation, DeviceCfg, Pose
 from curobo.viewer import ViserVisualizer
+
+LIVE_PREVIEW_MAX_POINTS = 200_000
+LIVE_PREVIEW_PERIOD_FRAMES = 20
+LIVE_PREVIEW_SUBVOXEL_FACTOR = 1
 
 
 def create_scene_with_static_obstacles(device: str = "cuda:0") -> SceneData:
@@ -278,6 +289,48 @@ def extract_esdf_slice(
     return colors
 
 
+def extract_textured_subvoxel_preview(
+    mapper: Mapper,
+    *,
+    observation: CameraObservation | None,
+    subvoxel_factor: int = LIVE_PREVIEW_SUBVOXEL_FACTOR,
+    max_points: int = LIVE_PREVIEW_MAX_POINTS,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Extract visibility-textured surface subvoxels for live visualization."""
+    voxels = mapper.extract_occupied_voxels(
+        surface_only=True,
+        subvoxel_factor=subvoxel_factor,
+        max_points=max_points,
+        texture_observations=observation,
+    )
+    points = voxels.centers
+    colors = voxels.colors_uint8()
+    del voxels
+    return points, colors
+
+
+def flip_texture_image_for_glb(mesh: Mesh) -> None:
+    """Counter Trimesh's GLB export-time UV V flip without changing mapper UVs."""
+    if mesh.texture_image is None:
+        return
+    if isinstance(mesh.texture_image, torch.Tensor):
+        mesh.texture_image = torch.flip(mesh.texture_image, dims=(0,))
+    else:
+        mesh.texture_image = np.flip(mesh.texture_image, axis=0).copy()
+
+
+def clone_texture_observation(observation: CameraObservation) -> CameraObservation:
+    """Keep only RGB, pose, and intrinsics needed for final texture projection."""
+    return CameraObservation(
+        rgb_image=observation.rgb_image.detach().clone(),
+        pose=Pose(
+            position=observation.pose.position.detach().clone(),
+            quaternion=observation.pose.quaternion.detach().clone(),
+        ),
+        intrinsics=observation.intrinsics.detach().clone(),
+    )
+
+
 class Sun3dDataset(Dataset):
     """Sun3D RGB-D dataset loader."""
 
@@ -337,9 +390,18 @@ def main():
     parser.add_argument("--root", type=str, required=True, help="Sun3D dataset root path")
     parser.add_argument("--voxel-size", type=float, default=0.02, help="Voxel size (m)")
     parser.add_argument("--max-frames", type=int, default=10000, help="Max frames to process")
-    parser.add_argument("--output", type=str, default="output_mesh.ply", help="Output mesh")
+    parser.add_argument("--output", type=str, default="output_mesh.glb", help="Output mesh")
     parser.add_argument("--visualize", action="store_true", help="Enable viser visualization")
     parser.add_argument("--num-cameras", type=int, default=1, help="Number of cameras")
+    parser.add_argument(
+        "--texture-max-batches",
+        type=int,
+        default=50,
+        help=(
+            "Maximum number of integrated camera batches retained for final "
+            "textured mesh export. Set 0 to save voxel-colored mesh only."
+        ),
+    )
     parser.add_argument(
         "--checkpoint",
         type=Path,
@@ -358,6 +420,8 @@ def main():
     args = parser.parse_args()
     if args.checkpoint is not None and args.resume_from is not None:
         raise ValueError("--checkpoint and --resume-from are mutually exclusive")
+    if args.texture_max_batches < 0:
+        raise ValueError("--texture-max-batches must be >= 0")
     checkpoint_path = args.checkpoint.expanduser() if args.checkpoint is not None else None
     resume_path = args.resume_from.expanduser() if args.resume_from is not None else None
 
@@ -374,7 +438,7 @@ def main():
         truncation_distance=args.voxel_size * 6,
         depth_maximum_distance=6.0,
         depth_minimum_distance=0.05,
-        minimum_tsdf_weight=2.0,
+        minimum_tsdf_weight=4.0,
         decay_factor=1.0,
         frustum_decay_factor=1.0,
         # enable_static=True allocates a separate geometry channel for analytic
@@ -385,6 +449,8 @@ def main():
         num_cameras=args.num_cameras,
         image_height=480,
         image_width=640,
+        block_size=8,
+        color_grid_size=8,
     )
     if resume_path is None:
         mapper = Mapper(config)
@@ -448,6 +514,16 @@ def main():
     n_cams = args.num_cameras
     pbar = tqdm(range(0, max_frames, n_cams))
     dt_s_list = []
+    latest_preview_observation: CameraObservation | None = None
+    texture_observations: list[CameraObservation] = []
+    total_batches = (max_frames + n_cams - 1) // n_cams if max_frames > 0 else 0
+    if args.texture_max_batches > 0 and total_batches > 0:
+        texture_batch_stride = max(
+            1,
+            (total_batches + args.texture_max_batches - 1) // args.texture_max_batches,
+        )
+    else:
+        texture_batch_stride = 0
     for batch_start in pbar:
         batch_end = min(batch_start + n_cams, max_frames)
         batch_obs = []
@@ -495,40 +571,50 @@ def main():
         timer = CudaEventTimer().start()
         mapper.integrate(batched)
         dt_s = timer.stop()
+        latest_preview_observation = batched
+
+        batch_idx = batch_start // n_cams
+        if (
+            texture_batch_stride > 0
+            and batch_idx % texture_batch_stride == 0
+            and len(texture_observations) < args.texture_max_batches
+        ):
+            texture_observations.append(clone_texture_observation(batched))
 
         dt_s_list.append(dt_s)
-        pbar.set_postfix(
-            load_ms=f"{t_load * 1000:.0f}",
-            filter_ms=f"{t_filter * 1000:.0f}",
-            integrate_ms=f"{np.mean(dt_s_list) * 1000:.1f}",
-            n_cams=n_cams,
-        )
+        postfix = {
+            "load_ms": f"{t_load * 1000:.0f}",
+            "filter_ms": f"{t_filter * 1000:.0f}",
+            "integrate_ms": f"{np.mean(dt_s_list) * 1000:.1f}",
+            "n_cams": n_cams,
+        }
+
         if len(dt_s_list) > 10:
             dt_s_list = dt_s_list[-10:]
 
-        if visualizer and (batch_end) % 20 < n_cams:
-            voxels = mapper.integrator.extract_occupied_voxels(surface_only=False)
-            if len(voxels) > 0:
-                centers = voxels.centers
-                colors = voxels.colors_uint8()
-                if len(centers) > 100_000:
-                    scale = int(len(centers) / 100_000)
-                    if scale > 1:
-                        centers = centers[::scale]
-                        colors = colors[::scale]
-
-                points_np = centers.cpu().numpy()
+        if visualizer and (batch_end) % LIVE_PREVIEW_PERIOD_FRAMES < n_cams:
+            t0 = time.perf_counter()
+            points, colors = extract_textured_subvoxel_preview(
+                mapper,
+                observation=batched,
+            )
+            preview_dt = time.perf_counter() - t0
+            postfix["preview_ms"] = f"{preview_dt * 1000:.0f}"
+            postfix["preview_points"] = f"{len(points):,}"
+            if len(points) > 0:
+                points_np = points.cpu().numpy()
                 colors_np = colors.cpu().numpy()
                 visualizer.add_point_cloud(
                     pointcloud=points_np,
                     colors=colors_np,
-                    point_size=args.voxel_size,
+                    point_size=args.voxel_size / LIVE_PREVIEW_SUBVOXEL_FACTOR,
                     name="/reconstruction",
                 )
-                del centers, colors, points_np, colors_np
-            del voxels
+                del points_np, colors_np
+            del points, colors
             torch.cuda.empty_cache()
 
+        if visualizer and (batch_end) % LIVE_PREVIEW_PERIOD_FRAMES < n_cams:
             for cam_i, vis_obs in enumerate(batch_obs):
                 visualizer.add_frame(
                     f"/cameras/frame_{cam_i}", vis_obs.pose, scale=0.1,
@@ -546,6 +632,7 @@ def main():
                     pose=vis_obs.pose,
                     name=f"/cameras/image_{cam_i}",
                 )
+        pbar.set_postfix(**postfix)
 
     if checkpoint_path is not None:
         checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
@@ -565,27 +652,69 @@ def main():
     print("Static obstacles stamped into TSDF geometry channel")
 
     if visualizer:
-        voxels = mapper.integrator.extract_occupied_voxels(surface_only=False)
-        if len(voxels) > 0:
-            centers = voxels.centers
-            colors = voxels.colors_uint8()
-            print(f"Extracted {len(centers)} voxels (with static obstacles)")
-            if len(centers) > 100_000:
-                scale = int(len(centers) / 100_000)
-                if scale > 1:
-                    centers = centers[::scale]
-                    colors = colors[::scale]
-            points_np = centers.cpu().numpy()
+        points, colors = extract_textured_subvoxel_preview(
+            mapper,
+            observation=latest_preview_observation,
+        )
+        print(f"Extracted {len(points):,} textured subvoxel preview points")
+        if len(points) > 0:
+            points_np = points.cpu().numpy()
             colors_np = colors.cpu().numpy()
             visualizer.add_point_cloud(
                 pointcloud=points_np,
                 colors=colors_np,
-                point_size=args.voxel_size,
+                point_size=args.voxel_size / LIVE_PREVIEW_SUBVOXEL_FACTOR,
                 name="/reconstruction",
             )
-            del centers, colors, points_np, colors_np
-        del voxels
+            del points_np, colors_np
+        del points, colors
         torch.cuda.empty_cache()
+
+    # Compute the ESDF over the workspace. The ESDF is generated at a coarser
+    # resolution than the TSDF, fine enough for robot collision spheres but
+    # cheap enough to recompute after each depth update. At query time, cuRobo
+    # uses trilinear interpolation over this grid for O(1) distance lookups.
+    print("\nComputing ESDF...")
+    voxel_grid = mapper.compute_esdf()
+    if voxel_grid.feature_tensor is not None:
+        print(
+            f"  ESDF shape: {voxel_grid.feature_tensor.shape}, "
+            f"voxel_size: {voxel_grid.voxel_size:.4f}m"
+        )
+
+    # Extract and save mesh
+    print("\nExtracting mesh...")
+    output_path = Path(args.output)
+    output_suffix = output_path.suffix.lower()
+    use_textured_mesh = (
+        len(texture_observations) > 0 and output_suffix in {".glb", ".obj"}
+    )
+    if use_textured_mesh:
+        print(
+            "Using "
+            f"{len(texture_observations)} RGB camera batches for textured mesh export"
+        )
+        mesh = mapper.extract_textured_mesh(
+            texture_observations,
+            surface_only=True,
+            refine_iterations=2,
+        )
+    else:
+        if output_suffix in {".glb", ".obj"} and len(texture_observations) == 0:
+            print("No retained RGB batches available; saving voxel-colored mesh")
+        mesh = mapper.extract_mesh(surface_only=False)
+    if mesh.vertices is not None and len(mesh.vertices) > 0:
+        if output_suffix not in {".glb", ".obj"}:
+            mesh.texture_uvs = None
+            mesh.texture_image = None
+        elif output_suffix == ".glb":
+            flip_texture_image_for_glb(mesh)
+        print(f"Saving mesh to {output_path}")
+        mesh.save_as_mesh(str(output_path))
+        print(f"Saved mesh: {output_path} ({len(mesh.vertices):,} vertices)")
+
+    else:
+        print("No mesh extracted (empty reconstruction)")
 
     # Render from first camera pose
     print("\nRendering from first camera pose. First call will take minutes to compile kernel.")
@@ -620,29 +749,6 @@ def main():
         iio.imwrite(str(out / "rendered_normals.png"), normal_colormap.cpu().numpy())
         iio.imwrite(str(out / "rendered_shaded.png"), shaded.cpu().numpy())
         print(f"Saved renders to: {out}")
-
-    # Compute the ESDF over the workspace. The ESDF is generated at a coarser
-    # resolution than the TSDF, fine enough for robot collision spheres but
-    # cheap enough to recompute after each depth update. At query time, cuRobo
-    # uses trilinear interpolation over this grid for O(1) distance lookups.
-    print("\nComputing ESDF...")
-    voxel_grid = mapper.compute_esdf()
-    if voxel_grid.feature_tensor is not None:
-        print(
-            f"  ESDF shape: {voxel_grid.feature_tensor.shape}, "
-            f"voxel_size: {voxel_grid.voxel_size:.4f}m"
-        )
-
-    # Extract and save mesh
-    print("\nExtracting mesh...")
-    mesh = mapper.extract_mesh(surface_only=False)
-    if mesh.vertices is not None and len(mesh.vertices) > 0:
-        print(f"Saving mesh to {args.output}")
-        mesh.save_as_mesh(args.output)
-        print(f"Saved mesh: {args.output} ({len(mesh.vertices):,} vertices)")
-
-    else:
-        print("No mesh extracted (empty reconstruction)")
 
     # Keep viser running with interactive ESDF slice
     if visualizer:

--- a/curobo/examples/getting_started/volumetric_mapping.py
+++ b/curobo/examples/getting_started/volumetric_mapping.py
@@ -686,9 +686,7 @@ def main():
     print("\nExtracting mesh...")
     output_path = Path(args.output)
     output_suffix = output_path.suffix.lower()
-    use_textured_mesh = (
-        len(texture_observations) > 0 and output_suffix in {".glb", ".obj"}
-    )
+    use_textured_mesh = False
     if use_textured_mesh:
         print(
             "Using "

--- a/curobo/examples/reference/lidar_volumetric_mapping.py
+++ b/curobo/examples/reference/lidar_volumetric_mapping.py
@@ -1042,9 +1042,11 @@ def tsdf_surface_voxels_with_blocks(mapper) -> tuple[np.ndarray, np.ndarray, np.
         + mapper.config.grid_center.detach().to(device="cpu").numpy()
     ).astype(np.float32)
 
-    rgbw = blocks["block_rgb"].to(device="cpu").float().numpy()
-    weight_rgb = np.clip(rgbw[block_idx, 3:4], 1e-6, None)
-    colors = np.clip((rgbw[block_idx, :3] / weight_rgb) * 255.0, 0.0, 255.0).astype(np.uint8)
+    rgbw = blocks["block_grid_rgb"].to(device="cpu").float().numpy()
+    weight_rgb = np.clip(rgbw[block_idx, 0, 3:4], 1e-6, None)
+    colors = np.clip((rgbw[block_idx, 0, :3] / weight_rgb) * 255.0, 0.0, 255.0).astype(
+        np.uint8
+    )
     return centers, colors, block_idx.astype(np.int64), blocks
 
 

--- a/curobo/examples/reference/lidar_volumetric_mapping.py
+++ b/curobo/examples/reference/lidar_volumetric_mapping.py
@@ -52,6 +52,12 @@ Run LiDAR volumetric mapping:
 
    python curobo/examples/reference/lidar_volumetric_mapping.py
 
+Export a final UV-textured mesh from rectified timestamp-matched RGB cameras:
+
+.. code-block:: bash
+
+   python curobo/examples/reference/lidar_volumetric_mapping.py --mesh-output output_lidar.glb
+
 Run feature mapping and text queries:
 
 .. code-block:: bash
@@ -80,7 +86,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 import numpy as np
 
@@ -179,6 +185,100 @@ class CameraCalibration:
     image_paths: list[Path]
 
 
+@dataclass
+class FisheyeToPinholeRectifier:
+    """Rectify raw fisheye RGB into a pinhole image for mapper texturing."""
+
+    camera: CameraCalibration
+    torch_module: Any
+    sampling_grid: Any
+    intrinsics: Any
+
+    @classmethod
+    def from_camera(
+        cls,
+        camera: CameraCalibration,
+        torch_module: Any,
+    ) -> FisheyeToPinholeRectifier:
+        """Build a cached inverse fisheye sampling grid.
+
+        The rectified image keeps the raw image shape and uses a pinhole
+        intrinsic matrix with the same focal lengths and principal point as
+        the calibration file. This gives the mapper a standard pinhole RGB
+        camera without adding a dependency on OpenCV.
+        """
+        height = int(camera.image_height)
+        width = int(camera.image_width)
+        y, x = torch_module.meshgrid(
+            torch_module.arange(height, dtype=torch_module.float32),
+            torch_module.arange(width, dtype=torch_module.float32),
+            indexing="ij",
+        )
+        x_ray = (x - float(camera.cx)) / float(camera.fx)
+        y_ray = (y - float(camera.cy)) / float(camera.fy)
+        radius = torch_module.sqrt(x_ray * x_ray + y_ray * y_ray)
+        theta = torch_module.atan(radius)
+        theta2 = theta * theta
+        k1, k2, k3, k4 = (float(v) for v in camera.distortion)
+        theta_d = theta * (
+            1.0
+            + k1 * theta2
+            + k2 * theta2 * theta2
+            + k3 * theta2 * theta2 * theta2
+            + k4 * theta2 * theta2 * theta2 * theta2
+        )
+        scale = torch_module.ones_like(radius)
+        nonzero = radius > 1.0e-8
+        scale[nonzero] = theta_d[nonzero] / radius[nonzero]
+        raw_u = float(camera.fx) * x_ray * scale + float(camera.cx)
+        raw_v = float(camera.fy) * y_ray * scale + float(camera.cy)
+
+        grid_x = 2.0 * raw_u / float(max(width - 1, 1)) - 1.0
+        grid_y = 2.0 * raw_v / float(max(height - 1, 1)) - 1.0
+        sampling_grid = torch_module.stack((grid_x, grid_y), dim=-1).unsqueeze(0)
+        intrinsics = torch_module.tensor(
+            [
+                [camera.fx, 0.0, camera.cx],
+                [0.0, camera.fy, camera.cy],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=torch_module.float32,
+        )
+        return cls(
+            camera=camera,
+            torch_module=torch_module,
+            sampling_grid=sampling_grid.contiguous(),
+            intrinsics=intrinsics,
+        )
+
+    def rectify(self, image: np.ndarray) -> tuple[Any, Any]:
+        """Return rectified RGB uint8 tensor and pinhole intrinsics."""
+        image_tensor = (
+            self.torch_module.from_numpy(np.ascontiguousarray(image))
+            .to(dtype=self.torch_module.float32)
+            .permute(2, 0, 1)
+            .unsqueeze(0)
+            / 255.0
+        )
+        rectified = self.torch_module.nn.functional.grid_sample(
+            image_tensor,
+            self.sampling_grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=True,
+        )
+        rectified_rgb = (
+            rectified[0]
+            .permute(1, 2, 0)
+            .clamp(0.0, 1.0)
+            .mul(255.0)
+            .round()
+            .to(dtype=self.torch_module.uint8)
+            .contiguous()
+        )
+        return rectified_rgb, self.intrinsics.clone()
+
+
 @dataclass(frozen=True)
 class RangeImageResult:
     range_image: np.ndarray
@@ -226,6 +326,9 @@ This fetches only:
 Run LiDAR volumetric mapping:
   python curobo/examples/reference/lidar_volumetric_mapping.py
 
+Export a final UV-textured mesh from rectified timestamp-matched RGB cameras:
+  python curobo/examples/reference/lidar_volumetric_mapping.py --mesh-output output_lidar.glb
+
 Run feature mapping and text queries:
   python curobo/examples/reference/lidar_volumetric_mapping.py --enable-features --max-frames 10
 """,
@@ -233,9 +336,18 @@ Run feature mapping and text queries:
     parser.add_argument("--sequence-dir", type=Path, default=DEFAULT_SEQUENCE_DIR)
     parser.add_argument("--curobo-root", type=Path, default=DEFAULT_CUROBO_ROOT)
     parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument(
+        "--mesh-output",
+        type=Path,
+        default=None,
+        help=(
+            "Optional final mesh export path. Use .glb or .obj to save UV texture "
+            "coordinates projected from timestamp-matched RGB camera frames."
+        ),
+    )
     parser.add_argument("--device", default="cuda:0")
     parser.add_argument("--start-index", type=int, default=0)
-    parser.add_argument("--max-frames", type=int, default=64, help="Use 0 for all frames.")
+    parser.add_argument("--max-frames", type=int, default=12, help="Use 0 for all frames.")
     parser.add_argument("--frame-stride", type=int, default=1)
     parser.add_argument("--lidar-height", type=int, default=64)
     parser.add_argument("--lidar-width", type=int, default=1024)
@@ -269,7 +381,13 @@ Run feature mapping and text queries:
         default=DEFAULT_ESDF_SLICE_RESOLUTION,
         help="Pixel width and height of the Viser ESDF slice image.",
     )
-    parser.add_argument("--block-size", type=int, default=4)
+    parser.add_argument("--block-size", type=int, default=8)
+    parser.add_argument(
+        "--feature-block-grid-size",
+        type=int,
+        default=1,
+        help="Feature control points per block edge; independent from RGB resolution.",
+    )
     parser.add_argument(
         "--max-blocks",
         type=int,
@@ -291,6 +409,15 @@ Run feature mapping and text queries:
         help="Fuse C-RADIO patch features and enable Viser text-query overlays.",
     )
     parser.add_argument("--feature-model", default=RADIO_MODEL_NAME)
+    parser.add_argument(
+        "--texture-max-batches",
+        type=int,
+        default=16,
+        help=(
+            "Maximum RGB camera frame batches retained for final .glb/.obj "
+            "textured mesh export. Set 0 to save voxel-colored mesh."
+        ),
+    )
     parser.add_argument("--status-every", type=int, default=10)
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
@@ -302,9 +429,10 @@ Run feature mapping and text queries:
         parser.error("--esdf-voxel-size must be positive")
     if args.esdf_slice_resolution <= 0:
         parser.error("--esdf-slice-resolution must be positive")
-    if args.output is None:
-        default_output = DEFAULT_FEATURE_OUTPUT if args.enable_features else DEFAULT_TSDF_OUTPUT
-        args.output = args.sequence_dir / default_output
+    if args.texture_max_batches < 0:
+        parser.error("--texture-max-batches must be non-negative")
+    if args.mesh_output is not None and args.mesh_output == args.output:
+        parser.error("--mesh-output must be different from --output")
     return args
 
 
@@ -852,66 +980,88 @@ def make_range_image(
 
     points = xyz[mask]
     ranges = ranges[mask]
+    source_idx = np.arange(points.shape[0], dtype=np.int64)
     elevation = elevation[mask]
     azimuth = np.arctan2(points[:, 1], points[:, 0])
-    u = np.mod(np.rint((azimuth + math.pi) * (image_width / (2.0 * math.pi))), image_width)
+    u = np.mod((azimuth + math.pi) * (image_width / (2.0 * math.pi)), image_width)
     if image_height == 1:
         v = np.zeros_like(u)
     else:
-        v = np.rint(
+        v = (
             (elevation_max_rad - elevation)
             * ((image_height - 1.0) / (elevation_max_rad - elevation_min_rad))
         )
-    u_i = u.astype(np.int64)
-    v_i = np.clip(v.astype(np.int64), 0, image_height - 1)
-    flat = v_i * image_width + u_i
 
-    order = np.lexsort((ranges, flat))
-    flat_sorted = flat[order]
+    u0 = np.floor(u).astype(np.int64)
+    u0 = np.mod(u0, image_width)
+    u1 = np.mod(u0 + 1, image_width)
+    if image_height == 1:
+        v0 = np.zeros_like(u0)
+        candidate_flat = np.concatenate((u0, u1))
+        candidate_source = np.concatenate((source_idx, source_idx))
+    else:
+        v0 = np.floor(v).astype(np.int64)
+        v0 = np.clip(v0, 0, image_height - 1)
+        v1 = np.clip(v0 + 1, 0, image_height - 1)
+        candidate_flat = np.concatenate(
+            (
+                v0 * image_width + u0,
+                v0 * image_width + u1,
+                v1 * image_width + u0,
+                v1 * image_width + u1,
+            )
+        )
+        candidate_source = np.concatenate((source_idx, source_idx, source_idx, source_idx))
+
+    candidate_ranges = ranges[candidate_source]
+    order = np.lexsort((candidate_ranges, candidate_flat))
+    flat_sorted = candidate_flat[order]
     first = np.empty(flat_sorted.shape[0], dtype=bool)
     first[0] = True
     first[1:] = flat_sorted[1:] != flat_sorted[:-1]
-    winners = order[first]
+    winner_candidates = order[first]
+    winner_source = candidate_source[winner_candidates]
+    winner_flat = candidate_flat[winner_candidates]
 
     range_flat = np.zeros(image_height * image_width, dtype=np.float32)
-    range_flat[flat[winners]] = ranges[winners]
+    range_flat[winner_flat] = ranges[winner_source]
 
     rgb_flat = np.zeros((image_height * image_width, 3), dtype=np.uint8)
     if point_colors is None:
         colors = colorize_points(
-            points[winners],
-            intensity[mask][winners] if intensity is not None else None,
+            points[winner_source],
+            intensity[mask][winner_source] if intensity is not None else None,
             color_mode,
         )
         camera_rgb_pixels = 0
     else:
-        colors = point_colors[mask][winners]
+        colors = point_colors[mask][winner_source]
         camera_rgb_pixels = (
-            int(camera_color_mask[mask][winners].sum())
+            int(camera_color_mask[mask][winner_source].sum())
             if camera_color_mask is not None
             else 0
         )
-    rgb_flat[flat[winners]] = colors
+    rgb_flat[winner_flat] = colors
     feature_grid = None
     feature_pixels = 0
     if point_features is not None:
         feature_dim = int(point_features.shape[1])
         feature_flat = np.zeros((image_height * image_width, feature_dim), dtype=np.float16)
-        winner_features = point_features[mask][winners].copy()
+        winner_features = point_features[mask][winner_source].copy()
         if feature_mask is not None:
-            winner_feature_mask = feature_mask[mask][winners]
+            winner_feature_mask = feature_mask[mask][winner_source]
             feature_pixels = int(winner_feature_mask.sum())
             if feature_pixels > 0:
                 mean_feature = winner_features[winner_feature_mask].astype(np.float32).mean(axis=0)
                 winner_features[~winner_feature_mask] = mean_feature.astype(np.float16)
-        feature_flat[flat[winners]] = winner_features
+        feature_flat[winner_flat] = winner_features
         feature_grid = feature_flat.reshape(image_height, image_width, feature_dim)
     return RangeImageResult(
         range_image=range_flat.reshape(image_height, image_width),
         rgb_image=rgb_flat.reshape(image_height, image_width, 3),
-        projected_pixels=int(winners.size),
+        projected_pixels=int(winner_source.size),
         camera_rgb_pixels=camera_rgb_pixels,
-        sample_points_base=points[winners],
+        sample_points_base=points[winner_source],
         sample_colors=colors,
         feature_grid=feature_grid,
         feature_pixels=feature_pixels,
@@ -1043,10 +1193,27 @@ def tsdf_surface_voxels_with_blocks(mapper) -> tuple[np.ndarray, np.ndarray, np.
     ).astype(np.float32)
 
     rgbw = blocks["block_grid_rgb"].to(device="cpu").float().numpy()
-    weight_rgb = np.clip(rgbw[block_idx, 0, 3:4], 1e-6, None)
-    colors = np.clip((rgbw[block_idx, 0, :3] / weight_rgb) * 255.0, 0.0, 255.0).astype(
+    color_grid_size = int(mapper.config.color_grid_size)
+    if color_grid_size <= 1 or block_size <= 1:
+        rgb_node_idx = np.zeros_like(block_idx, dtype=np.int64)
+    else:
+        grid_max = float(color_grid_size - 1)
+        scale = grid_max / float(block_size - 1)
+        rgb_grid = np.clip(local_xyz * scale, 0.0, grid_max)
+        rgb_grid_idx = np.floor(rgb_grid + 0.5).astype(np.int64)
+        rgb_node_idx = (
+            rgb_grid_idx[:, 2] * color_grid_size * color_grid_size
+            + rgb_grid_idx[:, 1] * color_grid_size
+            + rgb_grid_idx[:, 0]
+        )
+    sampled_rgbw = rgbw[block_idx, rgb_node_idx]
+    weight_rgb = np.clip(sampled_rgbw[:, 3:4], 1e-6, None)
+    colors = np.clip((sampled_rgbw[:, :3] / weight_rgb) * 255.0, 0.0, 255.0).astype(
         np.uint8
     )
+    missing_rgb = sampled_rgbw[:, 3] <= 1e-6
+    if missing_rgb.any():
+        colors[missing_rgb] = 128
     return centers, colors, block_idx.astype(np.int64), blocks
 
 
@@ -1131,7 +1298,7 @@ def update_viser_tsdf_voxels(visualizer, mapper, voxel_size: float) -> int:
         visualizer.add_point_cloud(
             pointcloud=tsdf_points,
             colors=tsdf_colors,
-            point_size=max(0.025, voxel_size * 1.5),
+            point_size=max(0.025, voxel_size),
             name=VISER_TSDF_POINTCLOUD_NAME,
         )
     return int(tsdf_points.shape[0])
@@ -1144,6 +1311,124 @@ def pose_from_transform(T: np.ndarray, Pose, torch_module):
         dtype=torch_module.float32,
     )
     return Pose(position=position, quaternion=quaternion, normalize_rotation=True)
+
+
+def uses_textured_mesh_export(args: argparse.Namespace) -> bool:
+    return (
+        args.mesh_output is not None
+        and args.mesh_output.suffix.lower() in {".glb", ".obj"}
+        and args.texture_max_batches > 0
+    )
+
+
+def texture_camera_shape(cameras: list[CameraCalibration]) -> tuple[int, int, int]:
+    image_height = cameras[0].image_height
+    image_width = cameras[0].image_width
+    for camera in cameras:
+        if camera.image_height != image_height or camera.image_width != image_width:
+            raise RuntimeError(
+                "Textured mesh export requires all RGB cameras to share "
+                "the same image shape."
+            )
+    return image_height, image_width, len(cameras)
+
+
+def make_texture_observation(
+    frame: Frame,
+    cameras: list[CameraCalibration],
+    rectifiers: dict[str, FisheyeToPinholeRectifier],
+    CameraObservation: type,
+    Pose: type,
+    torch_module: Any,
+) -> object | None:
+    rgb_images = []
+    intrinsics = []
+    positions = []
+    quaternions = []
+    for camera in cameras:
+        image_path = find_camera_image(camera, frame.pose)
+        if image_path is None:
+            return None
+        image = load_rgb_image(image_path)
+        expected_shape = (camera.image_height, camera.image_width, 3)
+        if image.shape != expected_shape:
+            raise RuntimeError(
+                f"{image_path} shape mismatch: expected {expected_shape}, got {image.shape}."
+            )
+        rectified_rgb, rectified_intrinsics = rectifiers[camera.name].rectify(image)
+        T_world_cam = camera_world_transform(frame, camera)
+        rgb_images.append(rectified_rgb)
+        intrinsics.append(rectified_intrinsics)
+        positions.append(torch_module.tensor(T_world_cam[:3, 3], dtype=torch_module.float32))
+        quaternions.append(
+            torch_module.tensor(
+                quat_wxyz_from_matrix(T_world_cam[:3, :3]),
+                dtype=torch_module.float32,
+            )
+        )
+
+    return CameraObservation(
+        rgb_image=torch_module.stack(rgb_images),
+        pose=Pose(
+            position=torch_module.stack(positions),
+            quaternion=torch_module.stack(quaternions),
+            normalize_rotation=True,
+        ),
+        intrinsics=torch_module.stack(intrinsics),
+    )
+
+
+def flip_texture_image_for_glb(mesh: Any, torch_module: Any) -> None:
+    """Counter Trimesh's GLB export-time UV V flip without changing mapper UVs."""
+    if mesh.texture_image is None:
+        return
+    if isinstance(mesh.texture_image, torch_module.Tensor):
+        mesh.texture_image = torch_module.flip(mesh.texture_image, dims=(0,))
+    else:
+        mesh.texture_image = np.flip(mesh.texture_image, axis=0).copy()
+
+
+def save_final_mesh_export(
+    mapper: Any,
+    args: argparse.Namespace,
+    texture_observations: list[object],
+    torch_module: Any,
+) -> None:
+    if args.mesh_output is None:
+        return
+
+    output_suffix = args.mesh_output.suffix.lower()
+    use_textured_mesh = bool(
+        texture_observations and output_suffix in {".glb", ".obj"}
+    )
+    if use_textured_mesh:
+        print(
+            "Using "
+            f"{len(texture_observations)} RGB camera batches for textured mesh export"
+        )
+        mesh = mapper.extract_textured_mesh(
+            texture_observations,
+            surface_only=False,
+        )
+    else:
+        if output_suffix in {".glb", ".obj"}:
+            print("No retained RGB camera batches available; saving voxel-colored mesh")
+        mesh = mapper.extract_mesh(surface_only=False)
+
+    if mesh.vertices is None or len(mesh.vertices) == 0:
+        print("No mesh extracted (empty reconstruction)")
+        return
+
+    if output_suffix not in {".glb", ".obj"}:
+        mesh.texture_uvs = None
+        mesh.texture_image = None
+    elif output_suffix == ".glb":
+        flip_texture_image_for_glb(mesh, torch_module)
+
+    args.mesh_output.parent.mkdir(parents=True, exist_ok=True)
+    print(f"Saving mesh to {args.mesh_output}")
+    mesh.save_as_mesh(str(args.mesh_output))
+    print(f"Saved mesh: {args.mesh_output} ({len(mesh.vertices):,} vertices)")
 
 
 def synchronize_if_cuda(torch_module, device) -> None:
@@ -1303,9 +1588,9 @@ def update_viser_feature_voxels(
     if points.shape[0] == 0 or "block_features" not in blocks:
         return 0, pca_basis
 
-    block_features = blocks["block_features"].float()
-    block_weight = blocks["block_feature_weight"].float().clamp(min=1e-6).unsqueeze(1)
-    normalized_features = block_features / block_weight
+    block_features = blocks["block_features"].float().sum(dim=1)
+    block_weight = blocks["block_feature_weight"].float().sum(dim=1).clamp(min=1e-6)
+    normalized_features = block_features / block_weight.unsqueeze(1)
     block_colors, pca_basis = pca_colorize_tensor(normalized_features, prev_basis=pca_basis)
     colors = block_colors[block_idx].cpu().numpy()
     points, colors = downsample_points(points, colors, VISER_MAX_FEATURE_POINTS)
@@ -1511,13 +1796,30 @@ def run_mapper(args: argparse.Namespace, frames: list[Frame], bounds: Bounds) ->
         )
 
     cameras = load_camera_calibrations(args.sequence_dir)
+    texture_export = uses_textured_mesh_export(args)
+    if texture_export:
+        (
+            texture_camera_image_height,
+            texture_camera_image_width,
+            texture_num_cameras,
+        ) = texture_camera_shape(cameras)
+    else:
+        texture_camera_image_height = None
+        texture_camera_image_width = None
+        texture_num_cameras = None
 
+    from curobo._src.types.camera import CameraObservation
     from curobo._src.perception.mapper.mapper import Mapper
     from curobo._src.perception.mapper.mapper_cfg import MapperCfg
     from curobo._src.types.lidar import LidarObservation
     from curobo._src.types.pose import Pose
     from curobo._src.util.warp import init_warp
 
+    texture_rectifiers = (
+        {camera.name: FisheyeToPinholeRectifier.from_camera(camera, torch) for camera in cameras}
+        if texture_export
+        else {}
+    )
     feature_model = None
     feature_dim = 0
     feature_shape_hw: tuple[int, int] | None = None
@@ -1556,6 +1858,9 @@ def run_mapper(args: argparse.Namespace, frames: list[Frame], bounds: Bounds) ->
         "image_height": 1,
         "image_width": 1,
         "num_cameras": 1,
+        "texture_num_cameras": texture_num_cameras,
+        "texture_camera_image_height": texture_camera_image_height,
+        "texture_camera_image_width": texture_camera_image_width,
         "lidar_num_sensors": 1,
         "lidar_image_height": int(args.lidar_height),
         "lidar_image_width": int(args.lidar_width),
@@ -1564,7 +1869,8 @@ def run_mapper(args: argparse.Namespace, frames: list[Frame], bounds: Bounds) ->
         "extent_esdf_meters_xyz": (float(args.esdf_extent_meters),) * 3,
         "esdf_voxel_size": float(args.esdf_voxel_size),
         "device": args.device,
-        "minimum_tsdf_weight": 0.0001,
+        "minimum_tsdf_weight": 2.0,
+        "color_grid_size": int(args.block_size),
     }
     if args.enable_features:
         cfg_kwargs.update(
@@ -1572,6 +1878,7 @@ def run_mapper(args: argparse.Namespace, frames: list[Frame], bounds: Bounds) ->
                 "lidar_feature_grid_height": int(args.lidar_height),
                 "lidar_feature_grid_width": int(args.lidar_width),
                 "feature_dim": feature_dim,
+                "feature_block_grid_size": int(args.feature_block_grid_size),
                 "feature_grid_height": int(args.lidar_height),
                 "feature_grid_width": int(args.lidar_width),
                 "feature_integration_kernel": "grouped",
@@ -1581,6 +1888,13 @@ def run_mapper(args: argparse.Namespace, frames: list[Frame], bounds: Bounds) ->
     cfg = MapperCfg(**cfg_kwargs)
     mapper = Mapper(cfg)
     print(f"Mapper initialized: {mapper.memory_usage_mb():.1f} MB")
+    if texture_export:
+        print(
+            "Textured mesh export enabled: "
+            f"{texture_num_cameras} RGB cameras, "
+            f"image_shape=({texture_camera_image_height}, {texture_camera_image_width}), "
+            f"max_batches={args.texture_max_batches}"
+        )
     if args.esdf_every > 0:
         esdf_grid_shape = tuple(
             int(math.ceil(args.esdf_extent_meters / args.esdf_voxel_size)) for _ in range(3)
@@ -1619,6 +1933,14 @@ def run_mapper(args: argparse.Namespace, frames: list[Frame], bounds: Bounds) ->
     camera_feature_pixels = 0
     camera_rgb_counts = {camera.name: 0 for camera in cameras}
     camera_feature_counts = {camera.name: 0 for camera in cameras}
+    texture_frames: list[Frame] = []
+    if texture_export:
+        texture_frame_stride = max(
+            1,
+            (len(frames) + args.texture_max_batches - 1) // args.texture_max_batches,
+        )
+    else:
+        texture_frame_stride = 0
     for i, frame in enumerate(frames):
         xyz, intensity = read_binary_pcd_xyz_intensity(frame.cloud_path)
         fallback_colors = colorize_points(xyz, intensity, args.color_mode)
@@ -1697,6 +2019,12 @@ def run_mapper(args: argparse.Namespace, frames: list[Frame], bounds: Bounds) ->
         tsdf_ms = (time.perf_counter() - tsdf_t0) * 1000.0
 
         integrated += 1
+        if (
+            texture_frame_stride > 0
+            and i % texture_frame_stride == 0
+            and len(texture_frames) < args.texture_max_batches
+        ):
+            texture_frames.append(frame)
         esdf_ms = None
         esdf_slice_ms = None
         esdf_shape = None
@@ -1762,36 +2090,54 @@ def run_mapper(args: argparse.Namespace, frames: list[Frame], bounds: Bounds) ->
                 status += f" feature_pixels={range_result.feature_pixels}"
             print(status)
 
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    mapper.save_blocks(args.output)
-    stats = mapper.get_stats(scan_pool=True, scan_hash=False)
-    metadata = build_metadata(
-        args,
-        frames,
-        bounds,
-        stats,
-        projected_points,
-        integrated,
-        camera_rgb_pixels,
-        camera_rgb_counts,
-        feature_pixels=camera_feature_pixels if args.enable_features else None,
-        camera_feature_counts=camera_feature_counts if args.enable_features else None,
-        feature_dim=feature_dim if args.enable_features else None,
-        feature_shape_hw=feature_shape_hw,
-    )
-    write_metadata(args.output, metadata)
-    print(f"saved {args.output}")
-    print(f"saved {args.output.with_suffix(args.output.suffix + '.json')}")
-    print(
-        json.dumps(
-            {
-                k: stats[k]
-                for k in ("frame_count", "active_blocks", "num_allocated", "memory_mb")
-                if k in stats
-            },
-            indent=2,
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        mapper.save_blocks(args.output)
+    texture_observations: list[CameraObservation] = []
+    if texture_export:
+        for texture_frame in texture_frames:
+            texture_observation = make_texture_observation(
+                texture_frame,
+                cameras,
+                texture_rectifiers,
+                CameraObservation,
+                Pose,
+                torch,
+            )
+            if texture_observation is not None:
+                texture_observations.append(texture_observation)
+    save_final_mesh_export(mapper, args, texture_observations, torch)
+    if args.output is not None:
+        stats = mapper.get_stats(scan_pool=True, scan_hash=False)
+        metadata = build_metadata(
+            args,
+            frames,
+            bounds,
+            stats,
+            projected_points,
+            integrated,
+            camera_rgb_pixels,
+            camera_rgb_counts,
+            feature_pixels=camera_feature_pixels if args.enable_features else None,
+            camera_feature_counts=camera_feature_counts if args.enable_features else None,
+            feature_dim=feature_dim if args.enable_features else None,
+            feature_shape_hw=feature_shape_hw,
+            texture_batches=len(texture_observations),
         )
-    )
+        write_metadata(args.output, metadata)
+        print(f"saved {args.output}")
+        print(f"saved {args.output.with_suffix(args.output.suffix + '.json')}")
+        print(
+            json.dumps(
+                {
+                    k: stats[k]
+                    for k in ("frame_count", "active_blocks", "num_allocated", "memory_mb")
+                    if k in stats
+                },
+                indent=2,
+            )
+        )
     keep_viser_alive(
         viser_port,
         enable_features=args.enable_features,
@@ -1812,6 +2158,7 @@ def build_metadata(
     camera_feature_counts: dict[str, int] | None = None,
     feature_dim: int | None = None,
     feature_shape_hw: tuple[int, int] | None = None,
+    texture_batches: int = 0,
 ) -> dict:
     extent_xyz = np.asarray(args.extent_meters_xyz, dtype=np.float32) if args.extent_meters_xyz else bounds.extent_xyz
     center = np.asarray(args.grid_center, dtype=np.float32) if args.grid_center else bounds.center
@@ -1844,6 +2191,12 @@ def build_metadata(
         "block_size": args.block_size,
         "max_blocks": args.max_blocks,
         "roughness": args.roughness,
+        "mesh_output": None if args.mesh_output is None else str(args.mesh_output),
+        "texture_max_batches": args.texture_max_batches,
+        "texture_batches": texture_batches,
+        "texture_rectification": (
+            "fisheye_to_pinhole" if texture_batches > 0 else None
+        ),
         "mapper_stats": stats,
     }
     if args.enable_features:
@@ -1852,6 +2205,7 @@ def build_metadata(
                 "feature_model": args.feature_model,
                 "text_adaptor": TEXT_ADAPTOR_NAME,
                 "feature_dim": feature_dim,
+                "feature_block_grid_size": args.feature_block_grid_size,
                 "feature_grid_shape_hw": (
                     None if feature_shape_hw is None else list(feature_shape_hw)
                 ),
@@ -1923,6 +2277,8 @@ def print_dry_run(args: argparse.Namespace, frames: list[Frame], bounds: Bounds)
                 "esdf_slice_resolution": args.esdf_slice_resolution,
                 "block_size": args.block_size,
                 "output": str(args.output),
+                "mesh_output": None if args.mesh_output is None else str(args.mesh_output),
+                "texture_max_batches": args.texture_max_batches,
             },
             indent=2,
         )

--- a/curobo/tests/_src/geom/test_types.py
+++ b/curobo/tests/_src/geom/test_types.py
@@ -5,7 +5,9 @@
 """Tests for geometry types module."""
 
 # Standard Library
+import json
 import os
+import struct
 import tempfile
 
 # Third Party
@@ -263,6 +265,43 @@ class TestMesh:
         mesh = Mesh(name="tri", pose=[5, 5, 5, 1, 0, 0, 0], vertices=vertices, faces=faces)
         trimesh_obj = mesh.get_trimesh_mesh(transform_with_pose=True)
         assert trimesh_obj is not None
+
+    def test_mesh_textured_glb_export_from_numpy_image(self, tmp_path):
+        """Test textured GLB export from a numpy texture image."""
+        vertices = [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]]
+        faces = [[0, 1, 2], [0, 2, 3]]
+        texture_uvs = np.array(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+            dtype=np.float32,
+        )
+        texture_image = np.zeros((2, 2, 3), dtype=np.uint8)
+        texture_image[0, 0] = [255, 0, 0]
+        texture_image[0, 1] = [0, 255, 0]
+        texture_image[1, 0] = [0, 0, 255]
+        texture_image[1, 1] = [255, 255, 255]
+        mesh = Mesh(
+            name="textured",
+            pose=[0, 0, 0, 1, 0, 0, 0],
+            vertices=vertices,
+            faces=faces,
+            texture_uvs=texture_uvs,
+            texture_image=texture_image,
+        )
+
+        trimesh_obj = mesh.get_trimesh_mesh(process=False)
+        assert type(trimesh_obj.visual).__name__ == "TextureVisuals"
+        texture = trimesh_obj.visual.material.image
+        assert type(texture).__name__ == "_ArrayTextureImage"
+        assert np.asarray(texture.convert("RGBA")).shape == (2, 2, 4)
+
+        mesh_path = tmp_path / "textured_mesh.glb"
+        mesh.save_as_mesh(str(mesh_path))
+        glb = mesh_path.read_bytes()
+        json_len, _json_type = struct.unpack_from("<II", glb, 12)
+        gltf = json.loads(glb[20 : 20 + json_len].decode("utf-8"))
+        primitive_attrs = gltf["meshes"][0]["primitives"][0]["attributes"]
+        assert "TEXCOORD_0" in primitive_attrs
+        assert gltf.get("images") and "bufferView" in gltf["images"][0]
 
     def test_mesh_get_mesh_data(self):
         """Test getting mesh data."""

--- a/curobo/tests/_src/perception/mapper/test_block_checkpoint.py
+++ b/curobo/tests/_src/perception/mapper/test_block_checkpoint.py
@@ -62,6 +62,7 @@ def make_metadata(
     has_dynamic: bool = True,
     has_static: bool = False,
     feature_dim: int = 0,
+    color_grid_size: int = 1,
 ):
     return {
         "voxel_size": 0.01,
@@ -72,6 +73,7 @@ def make_metadata(
         "has_dynamic": has_dynamic,
         "has_static": has_static,
         "feature_dim": feature_dim,
+        "color_grid_size": color_grid_size,
     }
 
 
@@ -80,19 +82,21 @@ def make_dynamic_blocks(
     n_blocks: int = 2,
     block_size: int = 2,
     feature_dim: int = 0,
+    color_grid_size: int = 1,
 ):
     block_voxels = block_size**3
+    color_grid_voxels = color_grid_size**3
     coords = torch.arange(n_blocks * 3, dtype=torch.int32).reshape(n_blocks, 3)
     block_data = torch.zeros((n_blocks, block_voxels, 2), dtype=torch.float16)
     block_data[..., 0] = 0.5
     block_data[..., 1] = 1.0
-    block_rgb = torch.zeros((n_blocks, 4), dtype=torch.float16)
-    block_rgb[:, :3] = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float16)
-    block_rgb[:, 3] = 1.0
+    block_grid_rgb = torch.zeros((n_blocks, color_grid_voxels, 4), dtype=torch.float16)
+    block_grid_rgb[:, :, :3] = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float16)
+    block_grid_rgb[:, :, 3] = 1.0
     blocks = {
         "active_block_coords": coords,
         "block_data": block_data,
-        "block_rgb": block_rgb,
+        "block_grid_rgb": block_grid_rgb,
     }
     if feature_dim > 0:
         blocks["block_features"] = torch.ones(
@@ -153,7 +157,10 @@ def test_prepare_blocks_for_import_applies_constant_weight():
     blocks["block_data"].zero_()
     blocks["block_data"][0, 0, 0] = 1.0
     blocks["block_data"][0, 0, 1] = 2.0
-    blocks["block_rgb"][0] = torch.tensor([2.0, 4.0, 6.0, 2.0], dtype=torch.float16)
+    blocks["block_grid_rgb"][0, 0] = torch.tensor(
+        [2.0, 4.0, 6.0, 2.0],
+        dtype=torch.float16,
+    )
     blocks["block_features"][0] = torch.tensor([2.0, 6.0], dtype=torch.float16)
     blocks["block_feature_weight"][0] = 2.0
 
@@ -169,10 +176,10 @@ def test_prepare_blocks_for_import_applies_constant_weight():
     assert prepared["block_data"][0, 0, 1].item() == pytest.approx(4.0)
     assert prepared["block_data"][0, 1, 0].item() == pytest.approx(0.0)
     assert prepared["block_data"][0, 1, 1].item() == pytest.approx(0.0)
-    assert prepared["block_rgb"][0, 0].item() == pytest.approx(4.0)
-    assert prepared["block_rgb"][0, 1].item() == pytest.approx(8.0)
-    assert prepared["block_rgb"][0, 2].item() == pytest.approx(12.0)
-    assert prepared["block_rgb"][0, 3].item() == pytest.approx(4.0)
+    assert prepared["block_grid_rgb"][0, 0, 0].item() == pytest.approx(4.0)
+    assert prepared["block_grid_rgb"][0, 0, 1].item() == pytest.approx(8.0)
+    assert prepared["block_grid_rgb"][0, 0, 2].item() == pytest.approx(12.0)
+    assert prepared["block_grid_rgb"][0, 0, 3].item() == pytest.approx(4.0)
     assert prepared["block_features"][0, 0].item() == pytest.approx(4.0)
     assert prepared["block_features"][0, 1].item() == pytest.approx(12.0)
     assert prepared["block_feature_weight"][0].item() == pytest.approx(4.0)
@@ -280,8 +287,14 @@ def test_block_sparse_tsdf_export_import_compacts_active_blocks():
     )
     source.data.block_data[0, :, 1] = 1.0
     source.data.block_data[2, :, 1] = 3.0
-    source.data.block_rgb[0] = torch.tensor([1.0, 2.0, 3.0, 1.0], dtype=torch.float16)
-    source.data.block_rgb[2] = torch.tensor([3.0, 6.0, 9.0, 3.0], dtype=torch.float16)
+    source.data.block_grid_rgb[0, 0] = torch.tensor(
+        [1.0, 2.0, 3.0, 1.0],
+        dtype=torch.float16,
+    )
+    source.data.block_grid_rgb[2, 0] = torch.tensor(
+        [3.0, 6.0, 9.0, 3.0],
+        dtype=torch.float16,
+    )
 
     blocks = source.export_blocks()
     target = make_storage(max_blocks=6, hash_capacity=16)
@@ -291,7 +304,7 @@ def test_block_sparse_tsdf_export_import_compacts_active_blocks():
     assert int(target.data.free_count.item()) == 0
     assert target.data.block_coords[:6].tolist() == [-1, 0, 0, 0, 1, 0]
     assert target.data.block_sums[:2].tolist() == pytest.approx([8.0, 24.0])
-    assert target.data.block_rgb[:2, 3].tolist() == pytest.approx([1.0, 3.0])
+    assert target.data.block_grid_rgb[:2, 0, 3].tolist() == pytest.approx([1.0, 3.0])
     assert torch.all(target.data.block_to_hash_slot[:2] >= 0)
     assert torch.all(target.data.block_to_hash_slot[2:] == PY_HASH_EMPTY)
 
@@ -378,17 +391,17 @@ def test_cuda_checkpoint_roundtrip_preserves_block_data(tmp_path):
     )
     expected_block_data = source.data.block_data[active_pool_idx].detach().clone()
 
-    source.data.block_rgb[0] = torch.tensor(
+    source.data.block_grid_rgb[0, 0] = torch.tensor(
         [1.0, 2.0, 3.0, 2.0],
         dtype=torch.float16,
         device="cuda:0",
     )
-    source.data.block_rgb[2] = torch.tensor(
+    source.data.block_grid_rgb[2, 0] = torch.tensor(
         [3.0, 6.0, 9.0, 3.0],
         dtype=torch.float16,
         device="cuda:0",
     )
-    expected_rgb = source.data.block_rgb[active_pool_idx].detach().clone()
+    expected_rgb = source.data.block_grid_rgb[active_pool_idx].detach().clone()
 
     source.data.block_features[0] = torch.tensor(
         [2.0, 4.0, 6.0],
@@ -434,7 +447,7 @@ def test_cuda_checkpoint_roundtrip_preserves_block_data(tmp_path):
         expected_coords.cpu(),
     )
     assert torch.equal(target.data.block_data[:2].detach().cpu(), expected_block_data.cpu())
-    assert torch.equal(target.data.block_rgb[:2].detach().cpu(), expected_rgb.cpu())
+    assert torch.equal(target.data.block_grid_rgb[:2].detach().cpu(), expected_rgb.cpu())
     assert torch.equal(target.data.block_features[:2].detach().cpu(), expected_features.cpu())
     assert torch.equal(
         target.data.block_feature_weight[:2].detach().cpu(),
@@ -444,8 +457,9 @@ def test_cuda_checkpoint_roundtrip_preserves_block_data(tmp_path):
     assert target.data.block_sums[:2].detach().cpu().tolist() == pytest.approx([5.0, 9.0])
     assert target.data.static_block_sums[:2].detach().cpu().tolist() == [2, 1]
 
-    rgb_avg = target.data.block_rgb[:2, :3].float() / target.data.block_rgb[
+    rgb_avg = target.data.block_grid_rgb[:2, 0, :3].float() / target.data.block_grid_rgb[
         :2,
+        0,
         3:4,
     ].float()
     torch.testing.assert_close(

--- a/curobo/tests/_src/perception/mapper/test_block_checkpoint.py
+++ b/curobo/tests/_src/perception/mapper/test_block_checkpoint.py
@@ -63,6 +63,7 @@ def make_metadata(
     has_static: bool = False,
     feature_dim: int = 0,
     color_grid_size: int = 1,
+    feature_block_grid_size: int = 1,
 ):
     return {
         "voxel_size": 0.01,
@@ -74,6 +75,7 @@ def make_metadata(
         "has_static": has_static,
         "feature_dim": feature_dim,
         "color_grid_size": color_grid_size,
+        "feature_block_grid_size": feature_block_grid_size,
     }
 
 
@@ -83,9 +85,11 @@ def make_dynamic_blocks(
     block_size: int = 2,
     feature_dim: int = 0,
     color_grid_size: int = 1,
+    feature_block_grid_size: int = 1,
 ):
     block_voxels = block_size**3
     color_grid_voxels = color_grid_size**3
+    feature_grid_voxels = feature_block_grid_size**3
     coords = torch.arange(n_blocks * 3, dtype=torch.int32).reshape(n_blocks, 3)
     block_data = torch.zeros((n_blocks, block_voxels, 2), dtype=torch.float16)
     block_data[..., 0] = 0.5
@@ -100,10 +104,13 @@ def make_dynamic_blocks(
     }
     if feature_dim > 0:
         blocks["block_features"] = torch.ones(
-            (n_blocks, feature_dim),
+            (n_blocks, feature_grid_voxels, feature_dim),
             dtype=torch.float16,
         )
-        blocks["block_feature_weight"] = torch.ones(n_blocks, dtype=torch.float16)
+        blocks["block_feature_weight"] = torch.ones(
+            (n_blocks, feature_grid_voxels),
+            dtype=torch.float16,
+        )
     return blocks
 
 
@@ -134,6 +141,27 @@ def test_validate_block_payload_rejects_wrong_block_data_dtype():
         validate_block_payload(blocks, metadata)
 
 
+def test_validate_block_payload_uses_independent_feature_grid_size():
+    metadata = make_metadata(
+        block_size=4,
+        feature_dim=3,
+        color_grid_size=4,
+        feature_block_grid_size=2,
+    )
+    blocks = make_dynamic_blocks(
+        block_size=4,
+        feature_dim=3,
+        color_grid_size=4,
+        feature_block_grid_size=2,
+    )
+
+    validate_block_payload(blocks, metadata)
+
+    assert blocks["block_grid_rgb"].shape == (2, 64, 4)
+    assert blocks["block_features"].shape == (2, 8, 3)
+    assert blocks["block_feature_weight"].shape == (2, 8)
+
+
 def test_validate_block_metadata_rejects_extra_fields():
     metadata = make_metadata()
     metadata["unexpected"] = True
@@ -161,8 +189,8 @@ def test_prepare_blocks_for_import_applies_constant_weight():
         [2.0, 4.0, 6.0, 2.0],
         dtype=torch.float16,
     )
-    blocks["block_features"][0] = torch.tensor([2.0, 6.0], dtype=torch.float16)
-    blocks["block_feature_weight"][0] = 2.0
+    blocks["block_features"][0, 0] = torch.tensor([2.0, 6.0], dtype=torch.float16)
+    blocks["block_feature_weight"][0, 0] = 2.0
 
     prepared = prepare_blocks_for_import(
         blocks,
@@ -180,9 +208,9 @@ def test_prepare_blocks_for_import_applies_constant_weight():
     assert prepared["block_grid_rgb"][0, 0, 1].item() == pytest.approx(8.0)
     assert prepared["block_grid_rgb"][0, 0, 2].item() == pytest.approx(12.0)
     assert prepared["block_grid_rgb"][0, 0, 3].item() == pytest.approx(4.0)
-    assert prepared["block_features"][0, 0].item() == pytest.approx(4.0)
-    assert prepared["block_features"][0, 1].item() == pytest.approx(12.0)
-    assert prepared["block_feature_weight"][0].item() == pytest.approx(4.0)
+    assert prepared["block_features"][0, 0, 0].item() == pytest.approx(4.0)
+    assert prepared["block_features"][0, 0, 1].item() == pytest.approx(12.0)
+    assert prepared["block_feature_weight"][0, 0].item() == pytest.approx(4.0)
 
 
 def test_prepare_blocks_for_import_rejects_low_constant_weight():
@@ -240,6 +268,7 @@ def make_storage(
     hash_capacity: int = 8,
     device: str = "cpu",
     feature_dim: int = 0,
+    feature_block_grid_size: int = 1,
     enable_static: bool = False,
 ) -> BlockSparseTSDF:
     cfg = BlockSparseTSDFCfg(
@@ -252,6 +281,7 @@ def make_storage(
         grid_shape=(8, 8, 8),
         block_size=2,
         feature_dim=feature_dim,
+        feature_block_grid_size=feature_block_grid_size,
         feature_grid_height=1 if feature_dim > 0 else None,
         feature_grid_width=1 if feature_dim > 0 else None,
         enable_static=enable_static,
@@ -295,7 +325,6 @@ def test_block_sparse_tsdf_export_import_compacts_active_blocks():
         [3.0, 6.0, 9.0, 3.0],
         dtype=torch.float16,
     )
-
     blocks = source.export_blocks()
     target = make_storage(max_blocks=6, hash_capacity=16)
     target.import_blocks(blocks)
@@ -347,6 +376,7 @@ def test_cuda_checkpoint_roundtrip_preserves_block_data(tmp_path):
         hash_capacity=8,
         device="cuda:0",
         feature_dim=3,
+        feature_block_grid_size=2,
         enable_static=True,
     )
     source.data.num_allocated.fill_(3)
@@ -402,19 +432,18 @@ def test_cuda_checkpoint_roundtrip_preserves_block_data(tmp_path):
         device="cuda:0",
     )
     expected_rgb = source.data.block_grid_rgb[active_pool_idx].detach().clone()
-
-    source.data.block_features[0] = torch.tensor(
+    source.data.block_features[0, 0] = torch.tensor(
         [2.0, 4.0, 6.0],
         dtype=torch.float16,
         device="cuda:0",
     )
-    source.data.block_features[2] = torch.tensor(
+    source.data.block_features[2, 0] = torch.tensor(
         [3.0, 6.0, 9.0],
         dtype=torch.float16,
         device="cuda:0",
     )
-    source.data.block_feature_weight[0] = 2.0
-    source.data.block_feature_weight[2] = 3.0
+    source.data.block_feature_weight[0, 0] = 2.0
+    source.data.block_feature_weight[2, 0] = 3.0
     expected_features = source.data.block_features[active_pool_idx].detach().clone()
     expected_feature_weight = source.data.block_feature_weight[active_pool_idx].detach().clone()
 
@@ -436,6 +465,7 @@ def test_cuda_checkpoint_roundtrip_preserves_block_data(tmp_path):
         hash_capacity=16,
         device="cuda:0",
         feature_dim=3,
+        feature_block_grid_size=2,
         enable_static=True,
     )
     target.import_blocks(checkpoint["blocks"])
@@ -466,9 +496,10 @@ def test_cuda_checkpoint_roundtrip_preserves_block_data(tmp_path):
         rgb_avg.detach().cpu(),
         torch.tensor([[0.5, 1.0, 1.5], [1.0, 2.0, 3.0]]),
     )
-    feature_avg = target.data.block_features[:2].float() / target.data.block_feature_weight[
-        :2
-    ].float().unsqueeze(-1)
+    feature_avg = (
+        target.data.block_features[:2, 0].float()
+        / target.data.block_feature_weight[:2, 0].float().unsqueeze(-1)
+    )
     torch.testing.assert_close(
         feature_avg.detach().cpu(),
         torch.tensor([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]),

--- a/curobo/tests/_src/perception/mapper/test_block_hash.py
+++ b/curobo/tests/_src/perception/mapper/test_block_hash.py
@@ -47,6 +47,7 @@ spatial_hash = _kernels.spatial_hash
 hash_lookup = _kernels.hash_lookup
 find_or_insert_block = _kernels.find_or_insert_block
 clear_new_blocks_kernel = _kernels.clear_new_blocks_kernel
+clear_new_block_grid_rgb_kernel = _kernels.clear_new_block_grid_rgb_kernel
 linear_to_local_coords = _kernels.linear_to_local_coords
 local_to_linear_index = _kernels.local_to_linear_index
 world_to_block_coords = _coord_kernels.world_to_block_coords
@@ -803,9 +804,9 @@ class TestClearNewBlocks:
         # block_data is (max_blocks, 512, 2) - 3D layout
         tsdf.data.block_data[0, :, :].fill_(1.0)  # Block 0
         tsdf.data.block_data[5, :, :].fill_(2.0)  # Block 5
-        # block_rgb is (max_blocks, 4) - per-block weighted sums [R×w, G×w, B×w, W]
-        tsdf.data.block_rgb[0, :].fill_(100.0)
-        tsdf.data.block_rgb[5, :].fill_(128.0)
+        # block_grid_rgb is (max_blocks, color_grid_size**3, 4) RGBW sums.
+        tsdf.data.block_grid_rgb[0, :, :].fill_(100.0)
+        tsdf.data.block_grid_rgb[5, :, :].fill_(128.0)
 
         # Run clear kernel
         wp.launch(
@@ -813,7 +814,16 @@ class TestClearNewBlocks:
             dim=(config.max_blocks, config.block_size**3),
             inputs=[
                 wp.from_torch(tsdf.data.block_data, dtype=wp.float16),
-                wp.from_torch(tsdf.data.block_rgb, dtype=wp.float16),
+                wp.from_torch(tsdf.data.new_blocks, dtype=wp.int32),
+                wp.from_torch(tsdf.data.new_block_count, dtype=wp.int32),
+                config.max_blocks,
+            ],
+        )
+        wp.launch(
+            clear_new_block_grid_rgb_kernel,
+            dim=(config.max_blocks, config.color_grid_size**3 * 4),
+            inputs=[
+                wp.from_torch(tsdf.data.block_grid_rgb, dtype=wp.float16),
                 wp.from_torch(tsdf.data.new_blocks, dtype=wp.int32),
                 wp.from_torch(tsdf.data.new_block_count, dtype=wp.int32),
                 config.max_blocks,
@@ -822,11 +832,11 @@ class TestClearNewBlocks:
 
         # Block 0 should be cleared
         assert (tsdf.data.block_data[0, :, :] == 0).all()
-        assert (tsdf.data.block_rgb[0, :] == 0).all()
+        assert (tsdf.data.block_grid_rgb[0, :, :] == 0).all()
 
         # Block 5 should be cleared
         assert (tsdf.data.block_data[5, :, :] == 0).all()
-        assert (tsdf.data.block_rgb[5, :] == 0).all()
+        assert (tsdf.data.block_grid_rgb[5, :, :] == 0).all()
 
 
 if __name__ == "__main__":

--- a/curobo/tests/_src/perception/mapper/test_block_integrate.py
+++ b/curobo/tests/_src/perception/mapper/test_block_integrate.py
@@ -126,10 +126,10 @@ class TestIntegration:
         num_allocated = tsdf.data.num_allocated.item()
         assert num_allocated > 0, "Should have allocated blocks"
 
-    def test_block_rgb_matches_constant_input_color(
+    def test_block_grid_rgb_matches_constant_input_color(
         self, warp_init, device, simple_intrinsics, identity_pose
     ):
-        """Per-block RGB averages should preserve a uniform input color."""
+        """Single-node block RGB grid should preserve a uniform input color."""
         config = BlockSparseTSDFIntegratorCfg(
             max_blocks=1000,
             voxel_size=0.01,
@@ -156,11 +156,11 @@ class TestIntegration:
         n = tsdf.data.num_allocated.item()
         assert n > 0
 
-        block_rgb = tsdf.data.block_rgb[:n].float()
-        active = block_rgb[:, 3] > 0
+        block_grid_rgb = tsdf.data.block_grid_rgb[:n, 0].float()
+        active = block_grid_rgb[:, 3] > 0
         assert active.any(), "Expected at least one block with RGB observations"
 
-        normalized = block_rgb[active, :3] / block_rgb[active, 3:4]
+        normalized = block_grid_rgb[active, :3] / block_grid_rgb[active, 3:4]
         expected = torch.tensor(
             [64.0 / 255.0, 128.0 / 255.0, 192.0 / 255.0],
             dtype=torch.float32,

--- a/curobo/tests/_src/perception/mapper/test_block_marching_cubes.py
+++ b/curobo/tests/_src/perception/mapper/test_block_marching_cubes.py
@@ -12,6 +12,7 @@ from curobo._src.perception.mapper.integrator_tsdf import (
     BlockSparseTSDFIntegratorCfg,
 )
 from curobo._src.perception.mapper.mesh_extractor import (
+    extract_approximate_mesh_block_sparse,
     extract_mesh_block_sparse,
 )
 from curobo._src.util.warp import init_warp
@@ -79,6 +80,13 @@ class TestMarchingCubes:
         assert triangles.shape == (0, 3)
         assert colors.shape == (0, 3)
 
+        vertices, triangles, normals, colors = extract_approximate_mesh_block_sparse(tsdf)
+
+        assert vertices.shape == (0, 3)
+        assert triangles.shape == (0, 3)
+        assert normals.shape == (0, 3)
+        assert colors.shape == (0, 3)
+
     def test_flat_plane_creates_mesh(self, warp_init, device, simple_intrinsics, identity_pose):
         """Test that a flat depth plane creates a mesh."""
         # Use larger voxels and truncation to ensure dense sampling
@@ -118,6 +126,46 @@ class TestMarchingCubes:
         assert not torch.isnan(vertices).any(), "Vertices should not contain NaN"
 
         # Check triangles reference valid vertices
+        assert triangles.min() >= 0
+        assert triangles.max() < vertices.shape[0]
+
+    def test_approximate_mesh_triangle_soup(
+        self, warp_init, device, simple_intrinsics, identity_pose
+    ):
+        """Test that approximate extraction emits identity-indexed triangle soup."""
+        config = BlockSparseTSDFIntegratorCfg(
+            max_blocks=2000,
+            voxel_size=0.02,
+            origin=torch.tensor([-0.5, -0.5, 0.0]),
+            grid_shape=(512, 512, 512),
+            truncation_distance=0.1,
+            device=device,
+            image_height=200,
+            image_width=200,
+        )
+        integrator = BlockSparseTSDFIntegrator(config)
+        tsdf = integrator.tsdf
+
+        depth = torch.full((200, 200), 1.0, dtype=torch.float32, device=device)
+        rgb = torch.full((200, 200, 3), 200, dtype=torch.uint8, device=device)
+        position, quaternion = identity_pose
+        obs = make_observation(depth, rgb, position, quaternion, simple_intrinsics)
+        for _ in range(10):
+            integrator.integrate(obs)
+
+        vertices, triangles, normals, colors = extract_approximate_mesh_block_sparse(tsdf)
+
+        assert vertices.shape[0] > 0
+        assert triangles.shape[0] > 0
+        assert vertices.shape[0] == triangles.shape[0] * 3
+        assert normals.shape == vertices.shape
+        assert colors.shape == vertices.shape
+        assert triangles.dtype == torch.int32
+        assert torch.equal(
+            triangles.reshape(-1),
+            torch.arange(vertices.shape[0], dtype=torch.int32, device=device),
+        )
+        assert not torch.isnan(vertices).any()
         assert triangles.min() >= 0
         assert triangles.max() < vertices.shape[0]
 

--- a/curobo/tests/_src/perception/mapper/test_block_marching_cubes.py
+++ b/curobo/tests/_src/perception/mapper/test_block_marching_cubes.py
@@ -11,10 +11,7 @@ from curobo._src.perception.mapper.integrator_tsdf import (
     BlockSparseTSDFIntegrator,
     BlockSparseTSDFIntegratorCfg,
 )
-from curobo._src.perception.mapper.mesh_extractor import (
-    extract_approximate_mesh_block_sparse,
-    extract_mesh_block_sparse,
-)
+from curobo._src.perception.mapper.mesh_extractor import extract_mesh_block_sparse
 from curobo._src.util.warp import init_warp
 from curobo.tests._src.perception.mapper.conftest import make_observation
 
@@ -52,6 +49,12 @@ def identity_pose(device):
     return position, quaternion
 
 
+def _identity_triangles(vertices: torch.Tensor) -> torch.Tensor:
+    return torch.arange(vertices.shape[0], dtype=torch.int32, device=vertices.device).view(
+        -1, 3
+    )
+
+
 # =============================================================================
 # Tests
 # =============================================================================
@@ -74,16 +77,9 @@ class TestMarchingCubes:
         integrator = BlockSparseTSDFIntegrator(config)
         tsdf = integrator.tsdf
 
-        vertices, triangles, normals, colors = extract_mesh_block_sparse(tsdf)
+        vertices, normals, colors = extract_mesh_block_sparse(tsdf)
 
         assert vertices.shape == (0, 3)
-        assert triangles.shape == (0, 3)
-        assert colors.shape == (0, 3)
-
-        vertices, triangles, normals, colors = extract_approximate_mesh_block_sparse(tsdf)
-
-        assert vertices.shape == (0, 3)
-        assert triangles.shape == (0, 3)
         assert normals.shape == (0, 3)
         assert colors.shape == (0, 3)
 
@@ -115,7 +111,8 @@ class TestMarchingCubes:
             integrator.integrate(obs)
 
         # Extract mesh
-        vertices, triangles, normals, colors = extract_mesh_block_sparse(tsdf)
+        vertices, normals, colors = extract_mesh_block_sparse(tsdf)
+        triangles = _identity_triangles(vertices)
 
         # Should have some geometry
         assert vertices.shape[0] > 0, "Should have vertices"
@@ -129,10 +126,24 @@ class TestMarchingCubes:
         assert triangles.min() >= 0
         assert triangles.max() < vertices.shape[0]
 
-    def test_approximate_mesh_triangle_soup(
-        self, warp_init, device, simple_intrinsics, identity_pose
-    ):
-        """Test that approximate extraction emits identity-indexed triangle soup."""
+        # The integrated plane is observed from the camera at the origin and
+        # free space is in front of the surface, so outward normals point -Z.
+        assert normals[:, 2].mean() < -0.5
+
+        v0 = vertices[triangles[:, 0]]
+        v1 = vertices[triangles[:, 1]]
+        v2 = vertices[triangles[:, 2]]
+        face_normals = torch.nn.functional.normalize(
+            torch.cross(v1 - v0, v2 - v0, dim=1),
+            dim=1,
+        )
+        tri_normals = normals.view(-1, 3, 3).mean(dim=1)
+        winding_alignment = (face_normals * tri_normals).sum(dim=1)
+        assert winding_alignment.mean() > 0.5
+        assert face_normals[:, 2].mean() < -0.5
+
+    def test_mesh_triangle_soup(self, warp_init, device, simple_intrinsics, identity_pose):
+        """Test that mesh extraction emits triangle-soup vertices."""
         config = BlockSparseTSDFIntegratorCfg(
             max_blocks=2000,
             voxel_size=0.02,
@@ -153,7 +164,8 @@ class TestMarchingCubes:
         for _ in range(10):
             integrator.integrate(obs)
 
-        vertices, triangles, normals, colors = extract_approximate_mesh_block_sparse(tsdf)
+        vertices, normals, colors = extract_mesh_block_sparse(tsdf)
+        triangles = _identity_triangles(vertices)
 
         assert vertices.shape[0] > 0
         assert triangles.shape[0] > 0
@@ -168,6 +180,14 @@ class TestMarchingCubes:
         assert not torch.isnan(vertices).any()
         assert triangles.min() >= 0
         assert triangles.max() < vertices.shape[0]
+
+        refined_vertices, refined_normals, refined_colors = extract_mesh_block_sparse(
+            tsdf, refine_iterations=2
+        )
+        assert refined_vertices.shape == vertices.shape
+        assert refined_normals.shape == normals.shape
+        assert refined_colors.shape == colors.shape
+        assert not torch.isnan(refined_vertices).any()
 
     def test_mesh_vertices_near_surface(self, warp_init, device, simple_intrinsics, identity_pose):
         """Test that mesh vertices are near the depth surface."""
@@ -195,7 +215,7 @@ class TestMarchingCubes:
         for _ in range(5):
             integrator.integrate(obs)
 
-        vertices, triangles, normals, colors = extract_mesh_block_sparse(tsdf)
+        vertices, normals, colors = extract_mesh_block_sparse(tsdf)
 
         if vertices.shape[0] > 0:
             # Vertices should be near z=1.0
@@ -230,7 +250,7 @@ class TestMarchingCubes:
         for _ in range(3):
             integrator.integrate(obs)
 
-        vertices, triangles, normals, colors = extract_mesh_block_sparse(tsdf)
+        vertices, normals, colors = extract_mesh_block_sparse(tsdf)
 
         if vertices.shape[0] > 0:
             # Colors should be mostly red
@@ -276,7 +296,7 @@ class TestMarchingCubes:
             for _ in range(5):  # More passes per position
                 integrator.integrate(obs)
 
-        vertices, triangles, normals, colors = extract_mesh_block_sparse(tsdf)
+        vertices, normals, colors = extract_mesh_block_sparse(tsdf)
 
         assert vertices.shape[0] > 0, "Should have vertices from multiple views"
 
@@ -308,7 +328,8 @@ class TestMeshQuality:
         for _ in range(3):
             integrator.integrate(obs)
 
-        vertices, triangles, normals, colors = extract_mesh_block_sparse(tsdf)
+        vertices, normals, colors = extract_mesh_block_sparse(tsdf)
+        triangles = _identity_triangles(vertices)
 
         if triangles.shape[0] > 0:
             # Check for degenerate triangles

--- a/curobo/tests/_src/perception/mapper/test_builder.py
+++ b/curobo/tests/_src/perception/mapper/test_builder.py
@@ -71,6 +71,41 @@ class TestKernelBuilderConstruction:
         with pytest.raises(ValueError, match="block_size"):
             make_block_sparse_kernels(block_size=bad_value)
 
+    def test_color_grid_size_can_match_block_size(self, warp_init):
+        class Cfg:
+            block_size = 8
+            color_grid_size = 8
+            feature_dim = 0
+            num_cameras = 1
+            image_height = 8
+            image_width = 8
+            lidar_num_sensors = 0
+            grid_shape = (16, 16, 16)
+            origin = (0.0, 0.0, 0.0)
+            voxel_size = 0.01
+            truncation_distance = 0.04
+
+        kernels = make_block_sparse_kernels(Cfg)
+        assert kernels.color_grid_size == 8
+        assert kernels.color_grid_voxels == 8**3
+
+    def test_color_grid_size_cannot_exceed_block_size(self, warp_init):
+        class Cfg:
+            block_size = 4
+            color_grid_size = 5
+            feature_dim = 0
+            num_cameras = 1
+            image_height = 8
+            image_width = 8
+            lidar_num_sensors = 0
+            grid_shape = (16, 16, 16)
+            origin = (0.0, 0.0, 0.0)
+            voxel_size = 0.01
+            truncation_distance = 0.04
+
+        with pytest.raises(ValueError, match="color_grid_size.*block_size"):
+            make_block_sparse_kernels(Cfg)
+
     def test_feature_channel_grouping_specializes_feature_kernel(self, warp_init):
         k3 = make_block_sparse_kernels(block_size=8, feature_channels_per_thread=3)
         k4 = make_block_sparse_kernels(block_size=8, feature_channels_per_thread=4)

--- a/curobo/tests/_src/perception/mapper/test_builder.py
+++ b/curobo/tests/_src/perception/mapper/test_builder.py
@@ -89,6 +89,28 @@ class TestKernelBuilderConstruction:
         assert kernels.color_grid_size == 8
         assert kernels.color_grid_voxels == 8**3
 
+    def test_feature_grid_size_is_independent_from_color_grid_size(self, warp_init):
+        class Cfg:
+            block_size = 8
+            color_grid_size = 4
+            feature_block_grid_size = 2
+            feature_dim = 0
+            num_cameras = 1
+            image_height = 8
+            image_width = 8
+            lidar_num_sensors = 0
+            grid_shape = (16, 16, 16)
+            origin = (0.0, 0.0, 0.0)
+            voxel_size = 0.01
+            truncation_distance = 0.04
+
+        kernels = make_block_sparse_kernels(Cfg)
+
+        assert kernels.color_grid_size == 4
+        assert kernels.color_grid_voxels == 4**3
+        assert kernels.feature_block_grid_size == 2
+        assert kernels.feature_grid_voxels == 2**3
+
     def test_color_grid_size_cannot_exceed_block_size(self, warp_init):
         class Cfg:
             block_size = 4
@@ -104,6 +126,24 @@ class TestKernelBuilderConstruction:
             truncation_distance = 0.04
 
         with pytest.raises(ValueError, match="color_grid_size.*block_size"):
+            make_block_sparse_kernels(Cfg)
+
+    def test_feature_grid_size_cannot_exceed_block_size(self, warp_init):
+        class Cfg:
+            block_size = 4
+            color_grid_size = 1
+            feature_block_grid_size = 5
+            feature_dim = 0
+            num_cameras = 1
+            image_height = 8
+            image_width = 8
+            lidar_num_sensors = 0
+            grid_shape = (16, 16, 16)
+            origin = (0.0, 0.0, 0.0)
+            voxel_size = 0.01
+            truncation_distance = 0.04
+
+        with pytest.raises(ValueError, match="feature_block_grid_size.*block_size"):
             make_block_sparse_kernels(Cfg)
 
     def test_feature_channel_grouping_specializes_feature_kernel(self, warp_init):
@@ -298,6 +338,18 @@ class TestMapperCfgForwarding:
     the ESDF integrator's default block_size instead of the user's
     requested one.
     """
+
+    def test_mapper_cfg_default_block_size_is_eight(self) -> None:
+        """Keep the mapper default aligned with the documented release behavior."""
+        from curobo._src.perception.mapper.mapper_cfg import MapperCfg
+
+        config = MapperCfg(
+            extent_meters_xyz=(1.0, 1.0, 1.0),
+            image_height=8,
+            image_width=8,
+        )
+
+        assert config.block_size == 8
 
     def test_mapper_cfg_block_size_reaches_tsdf(self, warp_init):
         """Check that ``MapperCfg(block_size=4)`` reaches the TSDF.

--- a/curobo/tests/_src/perception/mapper/test_feature_grid.py
+++ b/curobo/tests/_src/perception/mapper/test_feature_grid.py
@@ -11,6 +11,7 @@ from curobo._src.perception.mapper.integrator_tsdf import (
     BlockSparseTSDFIntegrator,
     BlockSparseTSDFIntegratorCfg,
 )
+from curobo._src.perception.mapper.storage import BlockDataView
 from curobo._src.types.camera import CameraObservation
 from curobo._src.util.warp import init_warp
 from curobo.tests._src.perception.mapper.conftest import make_observation
@@ -31,6 +32,33 @@ def test_camera_observation_feature_grid_copy_clone_to_cpu():
     moved = obs.to(torch.device("cpu"))
     assert moved is obs
     assert obs.feature_grid.device.type == "cpu"
+
+
+def test_block_data_view_samples_independent_feature_grid():
+    features = torch.arange(8, dtype=torch.float16).view(1, 8, 1)
+    view = BlockDataView(
+        rgb_grid=torch.zeros((1, 1, 4), dtype=torch.float16),
+        coords=torch.zeros(3, dtype=torch.int32),
+        num_allocated=1,
+        origin=torch.zeros(3, dtype=torch.float32),
+        voxel_size=1.0,
+        block_size=2,
+        grid_shape=(2, 2, 2),
+        color_grid_size=1,
+        feature_block_grid_size=2,
+        features=features,
+        feature_weight=torch.ones((1, 8), dtype=torch.float16),
+        feature_dim=1,
+    )
+    centers = torch.tensor(
+        [[-0.5, -0.5, -0.5], [0.5, 0.5, 0.5]],
+        dtype=torch.float32,
+    )
+    block_indices = torch.zeros(2, dtype=torch.int32)
+
+    sampled = view.sample_features_at_centers(centers, block_indices)
+
+    torch.testing.assert_close(sampled, torch.tensor([[0.0], [7.0]]))
 
 
 @pytest.fixture
@@ -70,6 +98,9 @@ def _make_integrator(
     feature_dim: int,
     feature_channels_per_thread: int = 4,
     feature_grid_shape: tuple[int, int] | None = None,
+    feature_block_grid_size: int = 1,
+    color_grid_size: int = 1,
+    feature_integration_kernel: str = "auto",
 ) -> BlockSparseTSDFIntegrator:
     feature_grid_kwargs = {}
     if feature_dim > 0:
@@ -90,7 +121,10 @@ def _make_integrator(
             image_height=16,
             image_width=16,
             feature_dim=feature_dim,
+            feature_block_grid_size=feature_block_grid_size,
+            color_grid_size=color_grid_size,
             feature_channels_per_thread=feature_channels_per_thread,
+            feature_integration_kernel=feature_integration_kernel,
             max_support_pixels_per_block_camera=8,
             **feature_grid_kwargs,
         )
@@ -212,3 +246,32 @@ def test_feature_grid_grouping_keeps_trailing_channels(cuda_device):
     normalized = features[active] / weights[active].unsqueeze(-1)
     expected = channel_values.expand_as(normalized)
     torch.testing.assert_close(normalized, expected, atol=0.05, rtol=0.05)
+
+
+@pytest.mark.parametrize("feature_kernel", ["grouped", "tiled"])
+def test_feature_block_grid_is_independent_from_color_grid(
+    cuda_device,
+    feature_kernel: str,
+):
+    integrator = _make_integrator(
+        cuda_device,
+        feature_dim=3,
+        feature_grid_shape=(4, 4),
+        feature_block_grid_size=2,
+        color_grid_size=1,
+        feature_integration_kernel=feature_kernel,
+    )
+    feature_grid = torch.ones(
+        (1, 4, 4, 3),
+        dtype=torch.float16,
+        device=cuda_device,
+    )
+    obs = _make_feature_observation(cuda_device, feature_grid)
+
+    integrator.integrate(obs)
+
+    n_allocated = int(integrator.tsdf.data.num_allocated.item())
+    assert integrator.tsdf.data.block_grid_rgb.shape[1] == 1
+    assert integrator.tsdf.data.block_features.shape[1] == 8
+    weights = integrator.tsdf.data.block_feature_weight[:n_allocated].float()
+    assert int((weights > 0).sum(dim=1).max().item()) > 1

--- a/curobo/tests/_src/perception/mapper/test_feature_matching.py
+++ b/curobo/tests/_src/perception/mapper/test_feature_matching.py
@@ -107,8 +107,10 @@ def _stamp_orthogonal_features(
     gt_features = torch.zeros((num_alloc, feature_dim), dtype=torch.float32, device=device)
     for i in range(num_alloc):
         gt_features[i, i % feature_dim] = 1.0
-    integrator._tsdf.data.block_features[:num_alloc] = gt_features.to(torch.float16)
-    integrator._tsdf.data.block_feature_weight[:num_alloc] = 1.0
+    integrator._tsdf.data.block_features[:num_alloc].zero_()
+    integrator._tsdf.data.block_feature_weight[:num_alloc].zero_()
+    integrator._tsdf.data.block_features[:num_alloc, 0] = gt_features.to(torch.float16)
+    integrator._tsdf.data.block_feature_weight[:num_alloc, 0] = 1.0
     return gt_features
 
 
@@ -270,8 +272,8 @@ class TestMatchedVoxelsEdgeCases:
         inactive_pool_idx = 0
         integrator._tsdf.data.block_to_hash_slot[inactive_pool_idx] = -1
         integrator._tsdf.data.block_features[inactive_pool_idx].zero_()
-        integrator._tsdf.data.block_features[inactive_pool_idx, 0] = 100.0
-        integrator._tsdf.data.block_feature_weight[inactive_pool_idx] = 1.0
+        integrator._tsdf.data.block_features[inactive_pool_idx, 0, 0] = 100.0
+        integrator._tsdf.data.block_feature_weight[inactive_pool_idx, 0] = 1.0
 
         query = torch.zeros(feature_dim, device=device)
         query[0] = 1.0

--- a/curobo/tests/_src/perception/mapper/test_generated_observation_correctness.py
+++ b/curobo/tests/_src/perception/mapper/test_generated_observation_correctness.py
@@ -268,10 +268,11 @@ def _active_rgb(mapper: Mapper) -> tuple[torch.Tensor, torch.Tensor, torch.Tenso
 def _active_features(mapper: Mapper) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     data = mapper.tsdf.data
     n = int(data.num_allocated.item())
-    weights = data.block_feature_weight[:n].float()
+    weights = data.block_feature_weight[:n].float().sum(dim=1)
     active = weights > 0
     pool_idx = torch.arange(n, dtype=torch.int64, device=weights.device)[active]
-    normalized = data.block_features[:n].float()[active] / weights[active].view(-1, 1)
+    feature_sum = data.block_features[:n].float().sum(dim=1)
+    normalized = feature_sum[active] / weights[active].view(-1, 1)
     return pool_idx, normalized, weights[active]
 
 
@@ -283,17 +284,8 @@ def _sort_active_features_by_coord(mapper: Mapper) -> tuple[torch.Tensor, torch.
     return coords[order], normalized[order]
 
 
-def _expected_rgb_from_grid_node(
-    mapper: Mapper,
-    rgb: torch.Tensor,
-    pool_idx: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Expected normalized RGB for the single color-grid node per block."""
-    if rgb.ndim == 3:
-        rgb = rgb.unsqueeze(0)
-    assert rgb.shape[0] == 1
+def _grid_node_world(mapper: Mapper, pool_idx: torch.Tensor) -> torch.Tensor:
     data = mapper.tsdf.data
-    cfg = mapper.config
     coords = data.block_coords.view(data.max_blocks, 3)[pool_idx.long()].float()
     block_size = int(data.block_size)
     grid_d, grid_h, grid_w = (int(v) for v in data.grid_shape)
@@ -303,23 +295,125 @@ def _expected_rgb_from_grid_node(
     offsets = torch.tensor(
         [blocks_x // 2, blocks_y // 2, blocks_z // 2],
         dtype=torch.float32,
-        device=rgb.device,
+        device=pool_idx.device,
     )
     center_offset = torch.tensor(
         [grid_w, grid_h, grid_d],
         dtype=torch.float32,
-        device=rgb.device,
+        device=pool_idx.device,
     ) * 0.5
-    local = torch.full((3,), block_size * 0.5, dtype=torch.float32, device=rgb.device)
+    local = torch.full((3,), block_size * 0.5, dtype=torch.float32, device=pool_idx.device)
     voxel = (coords + offsets) * float(block_size) + local
-    origin = data.origin.to(device=rgb.device, dtype=torch.float32)
-    world = origin + (voxel - center_offset) * float(data.voxel_size)
+    origin = data.origin.to(device=pool_idx.device, dtype=torch.float32)
+    return origin + (voxel - center_offset) * float(data.voxel_size)
+
+
+def _pool_to_visible_slot(mapper: Mapper) -> torch.Tensor:
+    camera_integrator = mapper.integrator._tsdf_integrator._camera_integrator
+    n_visible = int(camera_integrator.visible_count.item())
+    max_pool = int(mapper.tsdf.data.num_allocated.item())
+    pool_to_vis = torch.full(
+        (max_pool,),
+        -1,
+        dtype=torch.int64,
+        device=camera_integrator.pool_indices.device,
+    )
+    for vis_idx in range(n_visible):
+        pool = int(camera_integrator.pool_indices[vis_idx].item())
+        if 0 <= pool < max_pool:
+            pool_to_vis[pool] = vis_idx
+    return pool_to_vis
+
+
+def _support_rgb_reference(
+    mapper: Mapper,
+    rgb: torch.Tensor,
+    pool_idx: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    camera_integrator = mapper.integrator._tsdf_integrator._camera_integrator
+    cfg = mapper.config
+    if rgb.ndim == 3:
+        rgb = rgb.unsqueeze(0)
+    support = torch.zeros((pool_idx.numel(), 3), dtype=torch.float32, device=rgb.device)
+    support_weight = torch.zeros(pool_idx.numel(), dtype=torch.float32, device=rgb.device)
+    pool_to_vis = _pool_to_visible_slot(mapper)
+    for out_idx, pool in enumerate(pool_idx.long().tolist()):
+        vis_idx = int(pool_to_vis[pool].item())
+        if vis_idx < 0:
+            continue
+        for cam_i in range(rgb.shape[0]):
+            count = int(camera_integrator.support_counts[vis_idx, cam_i].item())
+            if count <= 0:
+                continue
+            pixel_idx = int(camera_integrator.support_pixels[vis_idx, cam_i, 0].item())
+            py = pixel_idx // cfg.image_width
+            px = pixel_idx - py * cfg.image_width
+            if 0 <= py < cfg.image_height and 0 <= px < cfg.image_width:
+                support[out_idx] += rgb[cam_i, py, px].float() / 255.0
+                support_weight[out_idx] += 1.0
+    active = support_weight > 0
+    support[active] = support[active] / support_weight[active].unsqueeze(-1)
+    return support, active
+
+
+def _support_feature_reference(
+    mapper: Mapper,
+    feature_grid: torch.Tensor,
+    pool_idx: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    camera_integrator = mapper.integrator._tsdf_integrator._camera_integrator
+    cfg = mapper.config
+    feature_h = feature_grid.shape[1]
+    feature_w = feature_grid.shape[2]
+    support = torch.zeros(
+        (pool_idx.numel(), feature_grid.shape[-1]),
+        dtype=torch.float32,
+        device=feature_grid.device,
+    )
+    support_weight = torch.zeros(pool_idx.numel(), dtype=torch.float32, device=feature_grid.device)
+    pool_to_vis = _pool_to_visible_slot(mapper)
+    for out_idx, pool in enumerate(pool_idx.long().tolist()):
+        vis_idx = int(pool_to_vis[pool].item())
+        if vis_idx < 0:
+            continue
+        for cam_i in range(feature_grid.shape[0]):
+            count = int(camera_integrator.support_counts[vis_idx, cam_i].item())
+            if count <= 0:
+                continue
+            pixel_idx = int(camera_integrator.support_pixels[vis_idx, cam_i, 0].item())
+            py = pixel_idx // cfg.image_width
+            px = pixel_idx - py * cfg.image_width
+            if 0 <= py < cfg.image_height and 0 <= px < cfg.image_width:
+                gy = max(0, min(feature_h - 1, (py * feature_h) // cfg.image_height))
+                gx = max(0, min(feature_w - 1, (px * feature_w) // cfg.image_width))
+                support[out_idx] += feature_grid[cam_i, gy, gx].float()
+                support_weight[out_idx] += 1.0
+    active = support_weight > 0
+    support[active] = support[active] / support_weight[active].unsqueeze(-1)
+    return support, active
+
+
+def _expected_rgb_from_grid_node(
+    mapper: Mapper,
+    depth: torch.Tensor,
+    rgb: torch.Tensor,
+    pool_idx: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Expected RGB for the block color-grid node, with support fallback."""
+    if depth.ndim == 2:
+        depth = depth.unsqueeze(0)
+    if rgb.ndim == 3:
+        rgb = rgb.unsqueeze(0)
+    assert rgb.shape[0] == depth.shape[0]
+    data = mapper.tsdf.data
+    cfg = mapper.config
+    world = _grid_node_world(mapper, pool_idx).to(device=rgb.device)
 
     intrinsics = _intrinsics(str(rgb.device), cfg.image_height, cfg.image_width)
     z = world[:, 2]
     u = intrinsics[0, 0] * world[:, 0] / z + intrinsics[0, 2]
     v = intrinsics[1, 1] * world[:, 1] / z + intrinsics[1, 2]
-    valid = (
+    projected = (
         (z > cfg.depth_minimum_distance)
         & (z <= cfg.depth_maximum_distance)
         & (u >= 0.0)
@@ -338,17 +432,100 @@ def _expected_rgb_from_grid_node(
     ty = (v_clamped - py0.float()).unsqueeze(-1)
 
     image = rgb[0].float() / 255.0
-    c00 = image[py0, px0]
-    c10 = image[py0, px1]
-    c01 = image[py1, px0]
-    c11 = image[py1, px1]
-    expected = (
-        c00 * (1.0 - tx) * (1.0 - ty)
-        + c10 * tx * (1.0 - ty)
-        + c01 * (1.0 - tx) * ty
-        + c11 * tx * ty
+    depth0 = depth[0].float()
+    d00 = depth0[py0, px0]
+    d10 = depth0[py0, px1]
+    d01 = depth0[py1, px0]
+    d11 = depth0[py1, px1]
+    depths = (d00, d10, d01, d11)
+    pixels = (image[py0, px0], image[py0, px1], image[py1, px0], image[py1, px1])
+    bilinear = (
+        (1.0 - tx.squeeze(-1)) * (1.0 - ty.squeeze(-1)),
+        tx.squeeze(-1) * (1.0 - ty.squeeze(-1)),
+        (1.0 - tx.squeeze(-1)) * ty.squeeze(-1),
+        tx.squeeze(-1) * ty.squeeze(-1),
     )
-    return expected, valid
+    coverage = torch.maximum(
+        (intrinsics[0, 0] * float(data.voxel_size) / z)
+        * (intrinsics[1, 1] * float(data.voxel_size) / z),
+        torch.ones_like(z),
+    )
+    total_rgb = torch.zeros((pool_idx.numel(), 3), dtype=torch.float32, device=rgb.device)
+    total_w = torch.zeros(pool_idx.numel(), dtype=torch.float32, device=rgb.device)
+    for sample_depth, sample_rgb, weight in zip(depths, pixels, bilinear, strict=True):
+        sdf = sample_depth - z
+        sample_valid = (
+            projected
+            & (sample_depth >= cfg.depth_minimum_distance)
+            & (sample_depth <= cfg.depth_maximum_distance)
+            & (sdf >= -cfg.truncation_distance)
+            & (sdf <= cfg.truncation_distance)
+        )
+        sample_w = torch.where(sample_valid, weight * coverage, torch.zeros_like(weight))
+        total_rgb += sample_rgb * sample_w.unsqueeze(-1)
+        total_w += sample_w
+
+    direct = total_w > 0
+    expected = torch.zeros_like(total_rgb)
+    expected[direct] = total_rgb[direct] / total_w[direct].unsqueeze(-1)
+    support, support_active = _support_rgb_reference(mapper, rgb, pool_idx)
+    fallback = ~direct & support_active
+    expected[fallback] = support[fallback]
+    return expected, direct | fallback
+
+
+def _expected_features_from_grid_node(
+    mapper: Mapper,
+    depth: torch.Tensor,
+    feature_grid: torch.Tensor,
+    pool_idx: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Expected feature for the block feature-grid node, with support fallback."""
+    if depth.ndim == 2:
+        depth = depth.unsqueeze(0)
+    data = mapper.tsdf.data
+    cfg = mapper.config
+    world = _grid_node_world(mapper, pool_idx).to(device=feature_grid.device)
+    intrinsics = _intrinsics(str(feature_grid.device), cfg.image_height, cfg.image_width)
+    z = world[:, 2]
+    u = intrinsics[0, 0] * world[:, 0] / z + intrinsics[0, 2]
+    v = intrinsics[1, 1] * world[:, 1] / z + intrinsics[1, 2]
+    px = torch.floor(u + 0.5).long()
+    py = torch.floor(v + 0.5).long()
+    projected = (
+        (z > cfg.depth_minimum_distance)
+        & (z <= cfg.depth_maximum_distance)
+        & (px >= 0)
+        & (px < cfg.image_width)
+        & (py >= 0)
+        & (py < cfg.image_height)
+    )
+    px_clamped = px.clamp(0, cfg.image_width - 1)
+    py_clamped = py.clamp(0, cfg.image_height - 1)
+    depth0 = depth[0].float()
+    sample_depth = depth0[py_clamped, px_clamped]
+    sdf = sample_depth - z
+    direct = (
+        projected
+        & (sample_depth >= cfg.depth_minimum_distance)
+        & (sample_depth <= cfg.depth_maximum_distance)
+        & (sdf >= -cfg.truncation_distance)
+        & (sdf <= cfg.truncation_distance)
+    )
+    feature_h = feature_grid.shape[1]
+    feature_w = feature_grid.shape[2]
+    gy = ((py_clamped * feature_h) // cfg.image_height).clamp(0, feature_h - 1)
+    gx = ((px_clamped * feature_w) // cfg.image_width).clamp(0, feature_w - 1)
+    expected = torch.zeros(
+        (pool_idx.numel(), feature_grid.shape[-1]),
+        dtype=torch.float32,
+        device=feature_grid.device,
+    )
+    expected[direct] = feature_grid[0, gy[direct], gx[direct]].float()
+    support, support_active = _support_feature_reference(mapper, feature_grid, pool_idx)
+    fallback = ~direct & support_active
+    expected[fallback] = support[fallback]
+    return expected, direct | fallback
 
 
 def _expected_features_from_support(
@@ -502,7 +679,7 @@ def test_gradient_rgb_matches_color_grid_projection(warp_init, device):
 
     mapper.integrate(_observation(device=device, depth=depth, rgb=rgb))
     pool_idx, normalized, _ = _active_rgb(mapper)
-    expected_active, valid = _expected_rgb_from_grid_node(mapper, rgb, pool_idx)
+    expected_active, valid = _expected_rgb_from_grid_node(mapper, depth, rgb, pool_idx)
 
     assert valid.all()
     torch.testing.assert_close(normalized, expected_active, atol=0.03, rtol=0.0)
@@ -538,7 +715,7 @@ def test_constant_features_include_trailing_channels(warp_init, device, feature_
 
 
 @pytest.mark.parametrize("feature_kernel", ["grouped", "tiled"])
-def test_spatial_features_match_stored_support_pixel_reference(
+def test_spatial_features_match_grid_node_reference(
     warp_init,
     device,
     feature_kernel,
@@ -552,14 +729,21 @@ def test_spatial_features_match_stored_support_pixel_reference(
         support_capacity=8,
     )
 
-    mapper.integrate(
-        _constant_plane_observation(device, rgb_value=(0, 0, 0), feature_grid=feature_grid)
+    obs = _constant_plane_observation(
+        device,
+        rgb_value=(0, 0, 0),
+        feature_grid=feature_grid,
     )
-    expected_sum, expected_weight = _expected_features_from_support(mapper, feature_grid)
+    mapper.integrate(obs)
     pool_idx, normalized, _ = _active_features(mapper)
-    expected_active = expected_sum[pool_idx] / expected_weight[pool_idx].view(-1, 1)
+    expected_active, valid = _expected_features_from_grid_node(
+        mapper,
+        obs.depth_image,
+        feature_grid,
+        pool_idx,
+    )
 
-    assert (expected_weight[pool_idx] > 0).all()
+    assert valid.all()
     torch.testing.assert_close(normalized, expected_active, atol=0.04, rtol=0.0)
 
 

--- a/curobo/tests/_src/perception/mapper/test_generated_observation_correctness.py
+++ b/curobo/tests/_src/perception/mapper/test_generated_observation_correctness.py
@@ -256,11 +256,13 @@ def _spatial_feature_grid(
 def _active_rgb(mapper: Mapper) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     data = mapper.tsdf.data
     n = int(data.num_allocated.item())
-    block_rgb = data.block_rgb[:n].float()
-    active = block_rgb[:, 3] > 0
-    pool_idx = torch.arange(n, dtype=torch.int64, device=block_rgb.device)[active]
-    normalized = block_rgb[active, :3] / block_rgb[active, 3:4].clamp(min=1e-6)
-    return pool_idx, normalized, block_rgb[active, 3]
+    block_grid_rgb = data.block_grid_rgb[:n, 0].float()
+    active = block_grid_rgb[:, 3] > 0
+    pool_idx = torch.arange(n, dtype=torch.int64, device=block_grid_rgb.device)[active]
+    normalized = block_grid_rgb[active, :3] / block_grid_rgb[active, 3:4].clamp(
+        min=1e-6
+    )
+    return pool_idx, normalized, block_grid_rgb[active, 3]
 
 
 def _active_features(mapper: Mapper) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -281,38 +283,72 @@ def _sort_active_features_by_coord(mapper: Mapper) -> tuple[torch.Tensor, torch.
     return coords[order], normalized[order]
 
 
-def _expected_rgb_from_support(
+def _expected_rgb_from_grid_node(
     mapper: Mapper,
     rgb: torch.Tensor,
+    pool_idx: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    camera_integrator = mapper.integrator._tsdf_integrator._camera_integrator
-    n_visible = int(camera_integrator.visible_count.item())
-    max_pool = int(mapper.tsdf.data.num_allocated.item())
-    expected_sum = torch.zeros((max_pool, 3), dtype=torch.float32, device=rgb.device)
-    expected_weight = torch.zeros(max_pool, dtype=torch.float32, device=rgb.device)
-    for vis_idx in range(n_visible):
-        pool_idx = int(camera_integrator.pool_indices[vis_idx].item())
-        if pool_idx < 0:
-            continue
-        for cam_i in range(rgb.shape[0]):
-            count = int(camera_integrator.support_counts[vis_idx, cam_i].item())
-            count = min(count, mapper.config.max_support_pixels_per_block_camera)
-            if count <= 0:
-                continue
-            pixels = camera_integrator.support_pixels[vis_idx, cam_i, :count].long()
-            py = pixels // mapper.config.image_width
-            px = pixels - py * mapper.config.image_width
-            valid = (
-                (py >= 0)
-                & (py < mapper.config.image_height)
-                & (px >= 0)
-                & (px < mapper.config.image_width)
-            )
-            if valid.any():
-                values = rgb[cam_i, py[valid], px[valid]].float() / 255.0
-                expected_sum[pool_idx] += values.sum(dim=0)
-                expected_weight[pool_idx] += float(values.shape[0])
-    return expected_sum, expected_weight
+    """Expected normalized RGB for the single color-grid node per block."""
+    if rgb.ndim == 3:
+        rgb = rgb.unsqueeze(0)
+    assert rgb.shape[0] == 1
+    data = mapper.tsdf.data
+    cfg = mapper.config
+    coords = data.block_coords.view(data.max_blocks, 3)[pool_idx.long()].float()
+    block_size = int(data.block_size)
+    grid_d, grid_h, grid_w = (int(v) for v in data.grid_shape)
+    blocks_x = (grid_w + block_size - 1) // block_size
+    blocks_y = (grid_h + block_size - 1) // block_size
+    blocks_z = (grid_d + block_size - 1) // block_size
+    offsets = torch.tensor(
+        [blocks_x // 2, blocks_y // 2, blocks_z // 2],
+        dtype=torch.float32,
+        device=rgb.device,
+    )
+    center_offset = torch.tensor(
+        [grid_w, grid_h, grid_d],
+        dtype=torch.float32,
+        device=rgb.device,
+    ) * 0.5
+    local = torch.full((3,), block_size * 0.5, dtype=torch.float32, device=rgb.device)
+    voxel = (coords + offsets) * float(block_size) + local
+    origin = data.origin.to(device=rgb.device, dtype=torch.float32)
+    world = origin + (voxel - center_offset) * float(data.voxel_size)
+
+    intrinsics = _intrinsics(str(rgb.device), cfg.image_height, cfg.image_width)
+    z = world[:, 2]
+    u = intrinsics[0, 0] * world[:, 0] / z + intrinsics[0, 2]
+    v = intrinsics[1, 1] * world[:, 1] / z + intrinsics[1, 2]
+    valid = (
+        (z > cfg.depth_minimum_distance)
+        & (z <= cfg.depth_maximum_distance)
+        & (u >= 0.0)
+        & (u <= cfg.image_width - 1)
+        & (v >= 0.0)
+        & (v <= cfg.image_height - 1)
+    )
+
+    u_clamped = u.clamp(0.0, cfg.image_width - 1)
+    v_clamped = v.clamp(0.0, cfg.image_height - 1)
+    px0 = torch.floor(u_clamped).long()
+    py0 = torch.floor(v_clamped).long()
+    px1 = (px0 + 1).clamp(max=cfg.image_width - 1)
+    py1 = (py0 + 1).clamp(max=cfg.image_height - 1)
+    tx = (u_clamped - px0.float()).unsqueeze(-1)
+    ty = (v_clamped - py0.float()).unsqueeze(-1)
+
+    image = rgb[0].float() / 255.0
+    c00 = image[py0, px0]
+    c10 = image[py0, px1]
+    c01 = image[py1, px0]
+    c11 = image[py1, px1]
+    expected = (
+        c00 * (1.0 - tx) * (1.0 - ty)
+        + c10 * tx * (1.0 - ty)
+        + c01 * (1.0 - tx) * ty
+        + c11 * tx * ty
+    )
+    return expected, valid
 
 
 def _expected_features_from_support(
@@ -450,7 +486,7 @@ def test_constant_rgb_accumulates_across_frames(warp_init, device):
     assert weights_second.sum() > weights_first.sum()
 
 
-def test_gradient_rgb_matches_stored_support_pixel_reference(warp_init, device):
+def test_gradient_rgb_matches_color_grid_projection(warp_init, device):
     mapper = _make_mapper(device, support_capacity=8)
     x = torch.arange(IMAGE_W, dtype=torch.float32, device=device).view(1, IMAGE_W)
     y = torch.arange(IMAGE_H, dtype=torch.float32, device=device).view(IMAGE_H, 1)
@@ -465,11 +501,10 @@ def test_gradient_rgb_matches_stored_support_pixel_reference(warp_init, device):
     depth = torch.full((IMAGE_H, IMAGE_W), PLANE_Z, dtype=torch.float32, device=device)
 
     mapper.integrate(_observation(device=device, depth=depth, rgb=rgb))
-    expected_sum, expected_weight = _expected_rgb_from_support(mapper, rgb.unsqueeze(0))
     pool_idx, normalized, _ = _active_rgb(mapper)
-    expected_active = expected_sum[pool_idx] / expected_weight[pool_idx].view(-1, 1)
+    expected_active, valid = _expected_rgb_from_grid_node(mapper, rgb, pool_idx)
 
-    assert (expected_weight[pool_idx] > 0).all()
+    assert valid.all()
     torch.testing.assert_close(normalized, expected_active, atol=0.03, rtol=0.0)
 
 
@@ -570,7 +605,7 @@ def test_time_decay_reduces_tsdf_rgb_and_feature_weights(warp_init, device):
     )
     n = int(mapper.tsdf.data.num_allocated.item())
     before_tsdf = mapper.tsdf.data.block_data[:n, :, 1].float().sum()
-    before_rgb = mapper.tsdf.data.block_rgb[:n, 3].float().sum()
+    before_rgb = mapper.tsdf.data.block_grid_rgb[:n, :, 3].float().sum()
     before_feature = mapper.tsdf.data.block_feature_weight[:n].float().sum()
 
     empty_depth = torch.zeros((IMAGE_H, IMAGE_W), dtype=torch.float32, device=device)
@@ -584,7 +619,7 @@ def test_time_decay_reduces_tsdf_rgb_and_feature_weights(warp_init, device):
         )
     )
     after_tsdf = mapper.tsdf.data.block_data[:n, :, 1].float().sum()
-    after_rgb = mapper.tsdf.data.block_rgb[:n, 3].float().sum()
+    after_rgb = mapper.tsdf.data.block_grid_rgb[:n, :, 3].float().sum()
     after_feature = mapper.tsdf.data.block_feature_weight[:n].float().sum()
 
     assert before_tsdf > 0
@@ -627,7 +662,7 @@ def test_clear_region_removes_stale_rgb_and_features(warp_init, device):
     )
     assert n_cleared > 0
     n = int(mapper.tsdf.data.num_allocated.item())
-    assert mapper.tsdf.data.block_rgb[:n, 3].float().sum() == 0
+    assert mapper.tsdf.data.block_grid_rgb[:n, :, 3].float().sum() == 0
     assert mapper.tsdf.data.block_feature_weight[:n].float().sum() == 0
 
     mapper.integrate(
@@ -675,7 +710,7 @@ def test_stats_report_last_integration_and_kernel_timings(warp_init, device):
     assert stats["last_integration"]["num_visible_blocks"] == 0
 
 
-def test_support_capacity_overflow_matches_stored_support_reference(warp_init, device):
+def test_support_capacity_overflow_keeps_rgb_grid_and_support_features(warp_init, device):
     feature_vector = torch.tensor([0.25, 0.5, 0.75], dtype=torch.float32, device=device)
     feature_grid = _constant_feature_grid(device, feature_vector)
     mapper = _make_mapper(
@@ -694,11 +729,15 @@ def test_support_capacity_overflow_matches_stored_support_reference(warp_init, d
     stats = mapper.get_stats(scan_pool=False)
     assert stats["last_integration"]["support_overflow_count"] > 0
 
-    expected_rgb_sum, expected_rgb_weight = _expected_rgb_from_support(mapper, obs.rgb_image)
     rgb_pool_idx, rgb_normalized, _ = _active_rgb(mapper)
+    expected_rgb = torch.tensor(
+        [32.0 / 255.0, 160.0 / 255.0, 224.0 / 255.0],
+        dtype=torch.float32,
+        device=device,
+    )
     torch.testing.assert_close(
         rgb_normalized,
-        expected_rgb_sum[rgb_pool_idx] / expected_rgb_weight[rgb_pool_idx].view(-1, 1),
+        expected_rgb.view(1, 3).expand_as(rgb_normalized),
         atol=0.03,
         rtol=0.0,
     )

--- a/curobo/tests/_src/perception/mapper/test_integrator.py
+++ b/curobo/tests/_src/perception/mapper/test_integrator.py
@@ -118,7 +118,7 @@ class TestBlockSparseTSDFIntegrator:
         )
         integrator = BlockSparseTSDFIntegrator(config)
         integrator.tsdf.data.block_data.fill_(7.0)
-        integrator.tsdf.data.block_rgb.fill_(5.0)
+        integrator.tsdf.data.block_grid_rgb.fill_(5.0)
         integrator.tsdf.data.block_features.fill_(3.0)
         integrator.tsdf.data.block_feature_weight.fill_(2.0)
 
@@ -147,7 +147,7 @@ class TestBlockSparseTSDFIntegrator:
         n_allocated = int(integrator.tsdf.data.num_allocated.item())
         assert n_allocated > 0
         assert torch.count_nonzero(integrator.tsdf.data.block_data[:n_allocated]).item() == 0
-        assert torch.count_nonzero(integrator.tsdf.data.block_rgb[:n_allocated]).item() == 0
+        assert torch.count_nonzero(integrator.tsdf.data.block_grid_rgb[:n_allocated]).item() == 0
         assert (
             torch.count_nonzero(integrator.tsdf.data.block_features[:n_allocated]).item()
             == 0

--- a/curobo/tests/_src/perception/mapper/test_integrator.py
+++ b/curobo/tests/_src/perception/mapper/test_integrator.py
@@ -4,6 +4,10 @@
 
 """Unit tests for BlockSparseTSDFIntegrator."""
 
+import json
+import struct
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -11,6 +15,13 @@ from curobo._src.perception.mapper.integrator_tsdf import (
     BlockSparseTSDFIntegrator,
     BlockSparseTSDFIntegratorCfg,
 )
+from curobo._src.perception.mapper.projector_texture import (
+    ProjectiveTextureProjector,
+    ProjectiveTextureProjectorCfg,
+    _projective_texture_atlas_columns,
+)
+from curobo._src.types.camera import CameraObservation
+from curobo._src.types.pose import Pose
 from curobo._src.util.warp import init_warp
 from curobo.tests._src.perception.mapper.conftest import make_observation
 
@@ -38,6 +49,95 @@ def device():
 
 class TestBlockSparseTSDFIntegrator:
     """Tests for the high-level integrator interface."""
+
+    def test_projective_texture_atlas_wraps_wide_camera_sets(self):
+        """Large texture frame sets pack into rows instead of one oversized strip."""
+        atlas_columns = _projective_texture_atlas_columns(
+            total_cameras=64,
+            image_width=500,
+        )
+        assert atlas_columns == 32
+
+        projector = ProjectiveTextureProjector(
+            tsdf=SimpleNamespace(device="cpu"),
+            renderer=SimpleNamespace(),
+            config=ProjectiveTextureProjectorCfg(
+                texture_num_cameras=1,
+                image_height=2,
+                image_width=3,
+                depth_minimum_distance=0.1,
+                depth_maximum_distance=5.0,
+                voxel_size=0.01,
+            ),
+        )
+
+        batches = []
+        for camera_idx in range(5):
+            rgb = torch.full((1, 2, 3, 3), camera_idx, dtype=torch.uint8)
+            batches.append((rgb, None, None, None, None))
+
+        atlas = projector._build_projective_texture_atlas(
+            batches,
+            atlas_columns=3,
+        )
+
+        assert atlas.shape == (4, 9, 3)
+        assert atlas[0, 0, 0] == 0
+        assert atlas[0, 3, 0] == 1
+        assert atlas[0, 6, 0] == 2
+        assert atlas[2, 0, 0] == 3
+        assert atlas[2, 3, 0] == 4
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+    def test_projective_texture_mixed_cpu_depth_moves_to_cuda(self, warp_init, device):
+        """Combine supplied CPU depth with CUDA-rendered visibility depth."""
+        image_height = 8
+        image_width = 8
+        integrator = BlockSparseTSDFIntegrator(
+            BlockSparseTSDFIntegratorCfg(
+                voxel_size=0.02,
+                origin=torch.zeros(3, dtype=torch.float32),
+                grid_shape=(32, 32, 32),
+                max_blocks=32,
+                device=device,
+                image_height=image_height,
+                image_width=image_width,
+                texture_num_cameras=2,
+            )
+        )
+        intrinsics = torch.tensor(
+            [[4.0, 0.0, 3.5], [0.0, 4.0, 3.5], [0.0, 0.0, 1.0]],
+            dtype=torch.float32,
+        )
+        pose = Pose(
+            position=torch.zeros(3, dtype=torch.float32),
+            quaternion=torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float32),
+        )
+        rgb = torch.zeros((image_height, image_width, 3), dtype=torch.uint8)
+        supplied_depth = torch.ones((image_height, image_width), dtype=torch.float32)
+        observations = [
+            CameraObservation(
+                rgb_image=rgb,
+                depth_image=supplied_depth,
+                pose=pose,
+                intrinsics=intrinsics,
+            ),
+            CameraObservation(
+                rgb_image=rgb,
+                pose=pose,
+                intrinsics=intrinsics,
+            ),
+        ]
+
+        batches = integrator._texture_projector._normalize_projective_texture_observations(
+            observations
+        )
+
+        assert len(batches) == 1
+        visibility_depth = batches[0][1]
+        assert visibility_depth.device.type == "cuda"
+        torch.testing.assert_close(visibility_depth[0], supplied_depth.to(device=device))
+        assert torch.count_nonzero(visibility_depth[1]) == 0
 
     def test_initialization(self, warp_init, device):
         """Test integrator initialization."""
@@ -260,19 +360,165 @@ class TestBlockSparseTSDFIntegrator:
         assert triangles.dtype == torch.int32
         assert normals.dtype == torch.float32
         assert colors.dtype == torch.uint8
-
-        vertices, triangles, normals, colors = integrator.extract_mesh_tensors(approximate=True)
-
-        assert vertices.dtype == torch.float32
-        assert triangles.dtype == torch.int32
-        assert normals.dtype == torch.float32
-        assert colors.dtype == torch.uint8
         if triangles.shape[0] > 0:
             assert vertices.shape[0] == triangles.shape[0] * 3
             assert torch.equal(
                 triangles.reshape(-1),
                 torch.arange(vertices.shape[0], dtype=torch.int32, device=device),
             )
+
+    def test_extract_textured_mesh_rgb_only(self, warp_init, device, tmp_path):
+        """Render visibility depth and project mesh UVs from RGB and camera data."""
+        config = BlockSparseTSDFIntegratorCfg(
+            voxel_size=0.01,
+            origin=torch.tensor([0.0, 0.0, 0.0]),
+            grid_shape=(512, 512, 512),
+            max_blocks=500,
+            device=device,
+            image_height=64,
+            image_width=64,
+            texture_camera_image_height=32,
+            texture_camera_image_width=32,
+        )
+        integrator = BlockSparseTSDFIntegrator(config)
+
+        img_H, img_W = 64, 64
+        tex_H, tex_W = 32, 32
+        depth = torch.full((img_H, img_W), 1.0, dtype=torch.float32, device=device)
+        rgb = torch.full((img_H, img_W, 3), 10, dtype=torch.uint8, device=device)
+        texture_rgb = torch.zeros((tex_H, tex_W, 3), dtype=torch.uint8, device=device)
+        texture_rgb[..., 0] = torch.arange(tex_W, dtype=torch.uint8, device=device).view(
+            1, tex_W
+        )
+        texture_rgb[..., 1] = torch.arange(tex_H, dtype=torch.uint8, device=device).view(
+            tex_H, 1
+        )
+        texture_rgb[..., 2] = 200
+        position = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32, device=device)
+        quaternion = torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float32, device=device)
+        intrinsics = torch.tensor(
+            [[500.0, 0.0, 32.0], [0.0, 500.0, 32.0], [0.0, 0.0, 1.0]],
+            dtype=torch.float32,
+            device=device,
+        )
+
+        obs = make_observation(depth, rgb, position, quaternion, intrinsics)
+        for _ in range(3):
+            integrator.integrate(obs)
+
+        texture_intrinsics = torch.tensor(
+            [[250.0, 0.0, 16.0], [0.0, 250.0, 16.0], [0.0, 0.0, 1.0]],
+            dtype=torch.float32,
+            device=device,
+        )
+        texture_obs = make_observation(
+            depth[:tex_H, :tex_W],
+            texture_rgb,
+            position,
+            quaternion,
+            texture_intrinsics,
+        )
+        texture_obs.depth_image = None
+        textured_mesh = integrator.extract_textured_mesh(texture_obs)
+
+        assert textured_mesh.vertices is not None
+        assert textured_mesh.faces is not None
+        assert textured_mesh.texture_uvs is not None
+        assert textured_mesh.texture_image is not None
+        assert textured_mesh.vertex_colors is not None
+        assert textured_mesh.texture_uvs.shape == (textured_mesh.vertices.shape[0], 2)
+        assert textured_mesh.texture_image.shape[0] >= tex_H
+        assert textured_mesh.texture_image.shape[1:] == (tex_W, 3)
+        assert torch.equal(textured_mesh.texture_image[:tex_H], texture_rgb)
+        if textured_mesh.vertices.shape[0] > 0:
+            assert torch.all(textured_mesh.texture_uvs >= 0.0)
+            assert torch.all(textured_mesh.texture_uvs <= 1.0)
+            assert torch.any(textured_mesh.texture_uvs > 0.0)
+            assert torch.any(textured_mesh.vertex_colors[..., 2] > 0.5)
+            projected = textured_mesh.vertex_colors[..., 2] > 0.5
+            projected_v = textured_mesh.texture_uvs[projected, 1]
+            if textured_mesh.texture_image.shape[0] > tex_H:
+                projected_v = (
+                    projected_v
+                    * float(textured_mesh.texture_image.shape[0])
+                    / float(tex_H)
+                )
+            expected_green = torch.round(projected_v * (tex_H - 1)) / 255.0
+            assert torch.mean(
+                torch.abs(textured_mesh.vertex_colors[projected, 1] - expected_green)
+            ) < 0.02
+            trimesh_mesh = textured_mesh.get_trimesh_mesh(process=False)
+            assert type(trimesh_mesh.visual).__name__ == "TextureVisuals"
+            mesh_path = tmp_path / "textured_mesh.glb"
+            textured_mesh.save_as_mesh(str(mesh_path))
+            glb = mesh_path.read_bytes()
+            json_len, _json_type = struct.unpack_from("<II", glb, 12)
+            gltf = json.loads(glb[20 : 20 + json_len].decode("utf-8"))
+            primitive_attrs = gltf["meshes"][0]["primitives"][0]["attributes"]
+            assert "TEXCOORD_0" in primitive_attrs
+            assert gltf.get("images") and "bufferView" in gltf["images"][0]
+
+    def test_textured_mesh_falls_back_to_voxel_color_patches(self, warp_init, device):
+        """Unprojected triangles get valid UVs into appended voxel-color texture patches."""
+        config = BlockSparseTSDFIntegratorCfg(
+            voxel_size=0.01,
+            origin=torch.tensor([0.0, 0.0, 0.0]),
+            grid_shape=(512, 512, 512),
+            max_blocks=500,
+            device=device,
+            image_height=64,
+            image_width=64,
+        )
+        integrator = BlockSparseTSDFIntegrator(config)
+
+        img_H, img_W = 64, 64
+        depth = torch.full((img_H, img_W), 1.0, dtype=torch.float32, device=device)
+        rgb = torch.full((img_H, img_W, 3), 10, dtype=torch.uint8, device=device)
+        texture_rgb = torch.zeros((img_H, img_W, 3), dtype=torch.uint8, device=device)
+        texture_rgb[..., 2] = 200
+        position = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32, device=device)
+        quaternion = torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float32, device=device)
+        intrinsics = torch.tensor(
+            [[500.0, 0.0, 32.0], [0.0, 500.0, 32.0], [0.0, 0.0, 1.0]],
+            dtype=torch.float32,
+            device=device,
+        )
+
+        obs = make_observation(depth, rgb, position, quaternion, intrinsics)
+        for _ in range(3):
+            integrator.integrate(obs)
+
+        texture_obs = make_observation(depth, texture_rgb, position, quaternion, intrinsics)
+        textured_mesh = integrator.extract_textured_mesh(
+            texture_obs,
+            camera_max_distance=0.2,
+        )
+
+        assert textured_mesh.vertices is not None
+        assert textured_mesh.texture_uvs is not None
+        assert textured_mesh.texture_image is not None
+        assert textured_mesh.vertex_colors is not None
+        assert textured_mesh.vertices.shape[0] > 0
+        assert textured_mesh.texture_uvs.shape == (textured_mesh.vertices.shape[0], 2)
+        assert textured_mesh.texture_image.shape[0] > img_H
+        assert textured_mesh.texture_image.shape[1:] == (img_W, 3)
+        assert torch.equal(textured_mesh.texture_image[:img_H], texture_rgb)
+        assert torch.all(textured_mesh.texture_uvs >= 0.0)
+        assert torch.all(textured_mesh.texture_uvs <= 1.0)
+        fallback_v0 = float(img_H) / textured_mesh.texture_image.shape[0]
+        assert torch.all(textured_mesh.texture_uvs[:, 1] >= fallback_v0)
+        assert torch.all(textured_mesh.vertex_colors[..., 2] < 0.1)
+
+        px = torch.floor(
+            textured_mesh.texture_uvs[:, 0] * textured_mesh.texture_image.shape[1]
+        ).to(torch.long)
+        py = torch.floor(
+            textured_mesh.texture_uvs[:, 1] * textured_mesh.texture_image.shape[0]
+        ).to(torch.long)
+        px = px.clamp(0, textured_mesh.texture_image.shape[1] - 1)
+        py = py.clamp(0, textured_mesh.texture_image.shape[0] - 1)
+        sampled_colors = textured_mesh.texture_image[py, px].float() / 255.0
+        assert torch.max(torch.abs(sampled_colors - textured_mesh.vertex_colors)) < 1.0e-4
 
     def test_reset(self, warp_init, device):
         """Test integrator reset."""

--- a/curobo/tests/_src/perception/mapper/test_integrator.py
+++ b/curobo/tests/_src/perception/mapper/test_integrator.py
@@ -261,6 +261,19 @@ class TestBlockSparseTSDFIntegrator:
         assert normals.dtype == torch.float32
         assert colors.dtype == torch.uint8
 
+        vertices, triangles, normals, colors = integrator.extract_mesh_tensors(approximate=True)
+
+        assert vertices.dtype == torch.float32
+        assert triangles.dtype == torch.int32
+        assert normals.dtype == torch.float32
+        assert colors.dtype == torch.uint8
+        if triangles.shape[0] > 0:
+            assert vertices.shape[0] == triangles.shape[0] * 3
+            assert torch.equal(
+                triangles.reshape(-1),
+                torch.arange(vertices.shape[0], dtype=torch.int32, device=device),
+            )
+
     def test_reset(self, warp_init, device):
         """Test integrator reset."""
         config = BlockSparseTSDFIntegratorCfg(

--- a/curobo/tests/_src/perception/mapper/test_lidar_projection.py
+++ b/curobo/tests/_src/perception/mapper/test_lidar_projection.py
@@ -11,6 +11,7 @@ import math
 import pytest
 import torch
 
+from curobo.examples.reference.lidar_volumetric_mapping import tsdf_surface_voxels_with_blocks
 from curobo._src.perception.mapper.integrator_tsdf import (
     BlockSparseTSDFIntegrator,
     BlockSparseTSDFIntegratorCfg,
@@ -18,6 +19,41 @@ from curobo._src.perception.mapper.integrator_tsdf import (
 from curobo._src.types.lidar import LidarObservation
 from curobo._src.types.pose import Pose
 from curobo._src.util.warp import init_warp
+
+
+class _FakeConfig:
+    block_size = 8
+    voxel_size = 0.05
+    grid_shape = (8, 8, 8)
+    grid_center = torch.zeros(3, dtype=torch.float32)
+    minimum_tsdf_weight = 0.0
+    color_grid_size = 4
+
+
+class _FakeTsdf:
+    def export_blocks(self) -> dict[str, torch.Tensor]:
+        block_data = torch.zeros((1, 512, 2), dtype=torch.float32)
+        block_data[..., 1] = 1.0
+        block_grid_rgb = torch.zeros((1, 64, 4), dtype=torch.float16)
+        for idx in range(64):
+            x = idx % 4
+            y = (idx // 4) % 4
+            z = idx // 16
+            block_grid_rgb[0, idx, :3] = torch.tensor(
+                [float(x) / 3.0, float(y) / 3.0, float(z) / 3.0],
+                dtype=torch.float16,
+            )
+            block_grid_rgb[0, idx, 3] = 1.0
+        return {
+            "active_block_coords": torch.zeros((1, 3), dtype=torch.int32),
+            "block_data": block_data,
+            "block_grid_rgb": block_grid_rgb,
+        }
+
+
+class _FakeMapper:
+    config = _FakeConfig()
+    tsdf = _FakeTsdf()
 
 
 def _as_angle_range(elevation_range_rad: tuple[float, float]) -> tuple[float, float]:
@@ -234,6 +270,19 @@ def test_lidar_planar_2d_rejects_non_fixed_elevation_range():
         )
 
 
+def test_lidar_example_surface_preview_samples_color_grid_nodes():
+    """The Viser preview should color voxels from their local RGB-grid node."""
+    centers, colors, block_idx, _ = tsdf_surface_voxels_with_blocks(_FakeMapper())
+
+    assert centers.shape == (512, 3)
+    assert colors.shape == (512, 3)
+    assert block_idx.shape == (512,)
+    assert len({tuple(color.tolist()) for color in colors}) > 1
+    assert tuple(colors[0].tolist()) == (0, 0, 0)
+    assert colors[6, 0] == 255
+    assert tuple(colors[-1].tolist()) == (255, 255, 255)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_lidar_integrator_allocates_blocks_from_planar_scan():
     """Smoke-test the end-to-end LiDAR integration path on CUDA."""
@@ -281,6 +330,14 @@ def test_lidar_integrator_allocates_blocks_from_planar_scan():
     assert stats["num_allocated"] > 0
     assert stats["last_lidar_integration"]["num_visible_blocks"] > 0
 
+    n_blocks = stats["num_allocated"]
+    rgbw = integrator.tsdf.data.block_grid_rgb[:n_blocks, 0].float()
+    active = rgbw[:, 3] > 0
+    assert active.any()
+    normalized = rgbw[active, :3] / rgbw[active, 3:4].clamp(min=1e-6)
+    assert normalized[:, 0].mean() > 0.95
+    assert normalized[:, 1:].max() < 0.05
+
     with pytest.raises(ValueError, match="fixed elevation"):
         _lidar_point_to_pixel(
             torch.tensor([[1.0, 0.0, 0.0]], dtype=torch.float32),
@@ -288,3 +345,165 @@ def test_lidar_integrator_allocates_blocks_from_planar_scan():
             image_width=8,
             elevation_range_rad=(-0.1, 0.1),
         )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_lidar_color_grid_projects_individual_nodes():
+    """LiDAR RGB integration should not broadcast one block color to every grid node."""
+    init_warp()
+    device = "cuda:0"
+    image_height = 9
+    image_width = 64
+    cfg = BlockSparseTSDFIntegratorCfg(
+        voxel_size=0.05,
+        origin=torch.zeros(3, dtype=torch.float32),
+        truncation_distance=0.12,
+        grid_shape=(64, 64, 64),
+        max_blocks=4096,
+        block_size=4,
+        color_grid_size=4,
+        image_height=4,
+        image_width=4,
+        num_cameras=1,
+        lidar_num_sensors=1,
+        lidar_image_height=image_height,
+        lidar_image_width=image_width,
+        device=device,
+    )
+    integrator = BlockSparseTSDFIntegrator(cfg)
+
+    ranges = torch.full((1, image_height, image_width), 1.0, dtype=torch.float32, device=device)
+    azimuth_color = torch.linspace(0, 255, image_width, dtype=torch.float32, device=device).round()
+    elevation_color = torch.linspace(0, 255, image_height, dtype=torch.float32, device=device).round()
+    rgb = torch.zeros((1, image_height, image_width, 3), dtype=torch.uint8, device=device)
+    rgb[0, :, :, 0] = azimuth_color.to(dtype=torch.uint8).view(1, image_width)
+    rgb[0, :, :, 1] = (255.0 - azimuth_color).to(dtype=torch.uint8).view(1, image_width)
+    rgb[0, :, :, 2] = elevation_color.to(dtype=torch.uint8).view(image_height, 1)
+    observation = LidarObservation(
+        range_image=ranges,
+        rgb_image=rgb,
+        pose=Pose(
+            position=torch.zeros((1, 3), dtype=torch.float32, device=device),
+            quaternion=torch.tensor(
+                [[1.0, 0.0, 0.0, 0.0]],
+                dtype=torch.float32,
+                device=device,
+            ),
+        ),
+        valid_range_m=torch.tensor([[0.1, 3.0]], dtype=torch.float32, device=device),
+        elevation_range_rad=torch.tensor([[-0.4, 0.4]], dtype=torch.float32, device=device),
+    )
+
+    integrator.integrate(lidar_observation=observation)
+    stats = integrator.get_stats(scan_pool=True)
+    n_blocks = stats["num_allocated"]
+    assert n_blocks > 0
+
+    rgbw = integrator.tsdf.data.block_grid_rgb[:n_blocks].float()
+    active = rgbw[..., 3] > 0
+    normalized = torch.zeros_like(rgbw[..., :3])
+    normalized[active] = rgbw[..., :3][active] / rgbw[..., 3:4][active].clamp(min=1e-6)
+
+    found_varying_block = False
+    for grid_rgb, block_active in zip(normalized.detach().cpu(), active.detach().cpu()):
+        if int(block_active.sum()) < 2:
+            continue
+        colors = grid_rgb[block_active]
+        variation = (colors.max(dim=0).values - colors.min(dim=0).values).abs().max()
+        if float(variation) > 0.05:
+            found_varying_block = True
+            break
+
+    assert found_varying_block
+
+
+@pytest.mark.parametrize("feature_kernel", ["grouped", "tiled"])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_lidar_feature_grid_projects_individual_nodes(feature_kernel: str):
+    """LiDAR feature integration should not broadcast one block feature to every grid node."""
+    init_warp()
+    device = "cuda:0"
+    image_height = 9
+    image_width = 64
+    feature_dim = 3
+    cfg = BlockSparseTSDFIntegratorCfg(
+        voxel_size=0.05,
+        origin=torch.zeros(3, dtype=torch.float32),
+        truncation_distance=0.12,
+        grid_shape=(64, 64, 64),
+        max_blocks=4096,
+        block_size=4,
+        color_grid_size=2,
+        feature_block_grid_size=4,
+        image_height=4,
+        image_width=4,
+        num_cameras=1,
+        lidar_num_sensors=1,
+        lidar_image_height=image_height,
+        lidar_image_width=image_width,
+        feature_dim=feature_dim,
+        feature_grid_height=1,
+        feature_grid_width=1,
+        lidar_feature_grid_height=image_height,
+        lidar_feature_grid_width=image_width,
+        feature_integration_kernel=feature_kernel,
+        device=device,
+    )
+    integrator = BlockSparseTSDFIntegrator(cfg)
+
+    ranges = torch.full((1, image_height, image_width), 1.0, dtype=torch.float32, device=device)
+    rgb = torch.zeros((1, image_height, image_width, 3), dtype=torch.uint8, device=device)
+    azimuth_feature = torch.linspace(0.0, 1.0, image_width, dtype=torch.float32, device=device)
+    elevation_feature = torch.linspace(0.0, 1.0, image_height, dtype=torch.float32, device=device)
+    feature_grid = torch.zeros(
+        (1, image_height, image_width, feature_dim),
+        dtype=torch.float16,
+        device=device,
+    )
+    feature_grid[0, :, :, 0] = azimuth_feature.view(1, image_width)
+    feature_grid[0, :, :, 1] = elevation_feature.view(image_height, 1)
+    feature_grid[0, :, :, 2] = (
+        0.5
+        * (
+            azimuth_feature.view(1, image_width)
+            + elevation_feature.view(image_height, 1)
+        )
+    )
+    observation = LidarObservation(
+        range_image=ranges,
+        rgb_image=rgb,
+        feature_grid=feature_grid.contiguous(),
+        pose=Pose(
+            position=torch.zeros((1, 3), dtype=torch.float32, device=device),
+            quaternion=torch.tensor(
+                [[1.0, 0.0, 0.0, 0.0]],
+                dtype=torch.float32,
+                device=device,
+            ),
+        ),
+        valid_range_m=torch.tensor([[0.1, 3.0]], dtype=torch.float32, device=device),
+        elevation_range_rad=torch.tensor([[-0.4, 0.4]], dtype=torch.float32, device=device),
+    )
+
+    integrator.integrate(lidar_observation=observation)
+    stats = integrator.get_stats(scan_pool=True)
+    n_blocks = stats["num_allocated"]
+    assert n_blocks > 0
+
+    features = integrator.tsdf.data.block_features[:n_blocks].float()
+    weights = integrator.tsdf.data.block_feature_weight[:n_blocks].float()
+    active = weights > 0
+    normalized = torch.zeros_like(features)
+    normalized[active] = features[active] / weights[active].unsqueeze(-1)
+
+    found_varying_block = False
+    for block_features, block_active in zip(normalized.detach().cpu(), active.detach().cpu()):
+        if int(block_active.sum()) < 2:
+            continue
+        values = block_features[block_active]
+        variation = (values.max(dim=0).values - values.min(dim=0).values).abs().max()
+        if float(variation) > 0.05:
+            found_varying_block = True
+            break
+
+    assert found_varying_block

--- a/curobo/tests/_src/perception/mapper/test_multi_camera.py
+++ b/curobo/tests/_src/perception/mapper/test_multi_camera.py
@@ -111,13 +111,13 @@ def _snapshot_tsdf(integrator):
         return {
             "num_allocated": 0,
             "block_data": data.block_data[:0].clone(),
-            "block_rgb": data.block_rgb[:0].clone(),
+            "block_grid_rgb": data.block_grid_rgb[:0].clone(),
             "block_coords": data.block_coords[:0].clone(),
         }
 
     coords = data.block_coords[: n * 3].clone().view(n, 3)
     bd = data.block_data[:n].clone()
-    br = data.block_rgb[:n].clone()
+    br = data.block_grid_rgb[:n].clone()
 
     # Lexicographic sort by (bx, by, bz) for deterministic ordering.
     sort_key = coords[:, 0].long() * (2**20) + coords[:, 1].long() * (2**10) + coords[:, 2].long()
@@ -126,7 +126,7 @@ def _snapshot_tsdf(integrator):
     return {
         "num_allocated": n,
         "block_data": bd[order],
-        "block_rgb": br[order],
+        "block_grid_rgb": br[order],
         "block_coords": coords[order],
     }
 
@@ -278,11 +278,13 @@ class TestMultiCameraForLoop:
         integ.integrate(_stack_observations(obs_red, obs_blue))
 
         snap = _snapshot_tsdf(integ)
-        active = snap["block_rgb"][:, 3].float() > 0
+        active = snap["block_grid_rgb"][:, 0, 3].float() > 0
         assert active.any()
 
-        normalized = snap["block_rgb"][active, :3].float() / snap["block_rgb"][
-            active, 3:4
+        normalized = snap["block_grid_rgb"][active, 0, :3].float() / snap[
+            "block_grid_rgb"
+        ][
+            active, 0, 3:4
         ].float().clamp(min=1e-6)
         expected = torch.tensor([0.5, 0.0, 0.5], dtype=torch.float32, device=device).view(1, 3)
         torch.testing.assert_close(
@@ -340,8 +342,8 @@ class TestMultiCameraBatchEquivalence:
             rtol=1e-2,
         )
         torch.testing.assert_close(
-            snap_bat["block_rgb"].float(),
-            snap_ref["block_rgb"].float(),
+            snap_bat["block_grid_rgb"].float(),
+            snap_ref["block_grid_rgb"].float(),
             atol=1e-2,
             rtol=1e-2,
         )

--- a/curobo/tests/_src/perception/mapper/test_occupied_voxel_texture.py
+++ b/curobo/tests/_src/perception/mapper/test_occupied_voxel_texture.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Focused tests for occupied voxel subvoxel and texture output."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from curobo._src.perception.mapper.integrator_tsdf import BlockSparseTSDFIntegrator
+from curobo._src.perception.mapper.mapper import Mapper
+from curobo._src.perception.mapper.projector_texture import (
+    ProjectiveTextureProjector,
+    ProjectiveTextureProjectorCfg,
+)
+from curobo._src.perception.mapper.storage import OccupiedVoxels
+from curobo._src.types.camera import CameraObservation
+from curobo._src.types.pose import Pose
+
+
+class _FakeBlockData:
+    """Minimal block-data view for color accessor tests."""
+
+    def __init__(self, rgbw_by_block: torch.Tensor) -> None:
+        self.rgbw_by_block = rgbw_by_block
+
+    def sample_rgbw_at_centers(
+        self,
+        centers: torch.Tensor,
+        block_idx_per_voxel: torch.Tensor,
+    ) -> torch.Tensor:
+        del centers
+        return self.rgbw_by_block[block_idx_per_voxel.long()].to(torch.float32)
+
+
+class _FakeVoxelIntegrator:
+    """Capture Mapper occupied-voxel extraction calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.result = object()
+
+    def extract_occupied_voxels(self, **kwargs: Any) -> object:
+        self.calls.append(kwargs)
+        return self.result
+
+
+def _make_pose(num_cameras: int = 1) -> Pose:
+    position = torch.zeros((num_cameras, 3), dtype=torch.float32)
+    quaternion = torch.zeros((num_cameras, 4), dtype=torch.float32)
+    quaternion[:, 0] = 1.0
+    return Pose(position=position, quaternion=quaternion)
+
+
+def _make_intrinsics(num_cameras: int = 1) -> torch.Tensor:
+    intrinsics = torch.eye(3, dtype=torch.float32).repeat(num_cameras, 1, 1)
+    intrinsics[:, 0, 0] = 1.0
+    intrinsics[:, 1, 1] = 1.0
+    intrinsics[:, 0, 2] = 1.0
+    intrinsics[:, 1, 2] = 1.0
+    if num_cameras == 1:
+        return intrinsics[0]
+    return intrinsics
+
+
+def _make_mapper(
+    *,
+    texture_num_cameras: int = 1,
+    image_shape: tuple[int, int] = (3, 3),
+) -> tuple[Mapper, _FakeVoxelIntegrator, list[dict[str, Any]]]:
+    mapper = Mapper.__new__(Mapper)
+    fake_integrator = _FakeVoxelIntegrator()
+    render_calls: list[dict[str, Any]] = []
+    mapper.config = SimpleNamespace(
+        texture_num_cameras=texture_num_cameras,
+        texture_camera_image_height=image_shape[0],
+        texture_camera_image_width=image_shape[1],
+    )
+    mapper._device = torch.device("cpu")
+    mapper._integrator = fake_integrator
+
+    def render_depth(
+        intrinsics: torch.Tensor,
+        pose: Pose,
+        image_shape_arg: tuple[int, int],
+    ) -> torch.Tensor:
+        render_calls.append(
+            {
+                "intrinsics": intrinsics,
+                "pose": pose,
+                "image_shape": image_shape_arg,
+            }
+        )
+        return torch.ones((int(intrinsics.shape[0]), *image_shape_arg), dtype=torch.float32)
+
+    mapper.render_depth = render_depth
+    return mapper, fake_integrator, render_calls
+
+
+def _make_integrator() -> BlockSparseTSDFIntegrator:
+    integrator = BlockSparseTSDFIntegrator.__new__(BlockSparseTSDFIntegrator)
+    integrator.config = SimpleNamespace(
+        voxel_size=0.4,
+        texture_num_cameras=1,
+        texture_camera_image_height=3,
+        texture_camera_image_width=3,
+        depth_minimum_distance=0.1,
+        depth_maximum_distance=5.0,
+    )
+    integrator._tsdf = SimpleNamespace(device="cpu")
+    return integrator
+
+
+def _make_texture_projector() -> ProjectiveTextureProjector:
+    return ProjectiveTextureProjector(
+        tsdf=SimpleNamespace(device="cpu"),
+        renderer=SimpleNamespace(),
+        config=ProjectiveTextureProjectorCfg(
+            texture_num_cameras=1,
+            image_height=3,
+            image_width=3,
+            depth_minimum_distance=0.1,
+            depth_maximum_distance=5.0,
+            voxel_size=0.4,
+        ),
+    )
+
+
+def test_mapper_extract_occupied_voxels_defaults_to_surface_only() -> None:
+    mapper, fake_integrator, _render_calls = _make_mapper()
+
+    result = mapper.extract_occupied_voxels()
+
+    assert result is fake_integrator.result
+    assert fake_integrator.calls[0]["surface_only"] is True
+    assert fake_integrator.calls[0]["sdf_threshold"] is None
+    assert fake_integrator.calls[0]["subvoxel_factor"] == 1
+    assert fake_integrator.calls[0]["texture_observations"] is None
+
+
+def test_mapper_extract_occupied_voxels_preserves_explicit_full_occupied_path() -> None:
+    mapper, fake_integrator, _render_calls = _make_mapper()
+
+    mapper.extract_occupied_voxels(surface_only=False, sdf_threshold=0.2)
+
+    assert fake_integrator.calls[0]["surface_only"] is False
+    assert fake_integrator.calls[0]["sdf_threshold"] == 0.2
+
+
+def test_subvoxel_factor_one_preserves_base_voxel_output() -> None:
+    integrator = _make_integrator()
+    centers = torch.tensor([[1.0, 2.0, 3.0]], dtype=torch.float32)
+    blocks = torch.tensor([7], dtype=torch.int32)
+    voxels = OccupiedVoxels(centers, blocks, _FakeBlockData(torch.ones((8, 4))))
+
+    expanded = integrator._expand_subvoxels(voxels, subvoxel_factor=1)
+
+    torch.testing.assert_close(expanded.centers, centers)
+    assert torch.equal(expanded.block_idx_per_voxel, blocks)
+    assert expanded.texture_colors is None
+    assert expanded.texture_valid is None
+    assert expanded.subvoxel_factor == 1
+
+
+def test_subvoxel_factor_two_count_geometry_and_repeated_block_indices() -> None:
+    integrator = _make_integrator()
+    centers = torch.tensor([[1.0, 2.0, 3.0]], dtype=torch.float32)
+    blocks = torch.tensor([7], dtype=torch.int32)
+    voxels = OccupiedVoxels(centers, blocks, _FakeBlockData(torch.ones((8, 4))))
+
+    expanded = integrator._expand_subvoxels(voxels, subvoxel_factor=2)
+
+    assert expanded.centers.shape == (8, 3)
+    assert torch.equal(expanded.block_idx_per_voxel, blocks.repeat_interleave(8))
+    torch.testing.assert_close(expanded.centers.mean(dim=0), centers[0])
+    expected_offsets = torch.tensor([-0.1, 0.1], dtype=torch.float32)
+    for axis in range(3):
+        actual_offsets = torch.unique(expanded.centers[:, axis] - centers[0, axis])
+        torch.testing.assert_close(actual_offsets, expected_offsets)
+
+
+def test_max_points_caps_after_subvoxel_expansion_by_downsampling_source_voxels() -> None:
+    integrator = _make_integrator()
+    centers = torch.arange(15, dtype=torch.float32).view(5, 3)
+    blocks = torch.arange(5, dtype=torch.int32)
+    voxels = OccupiedVoxels(centers, blocks, _FakeBlockData(torch.ones((8, 4))))
+
+    limited = integrator._limit_voxels_for_point_cap(
+        voxels,
+        subvoxel_factor=2,
+        max_points=16,
+    )
+    expanded = integrator._expand_subvoxels(limited, subvoxel_factor=2)
+
+    assert expanded.centers.shape == (16, 3)
+    assert torch.equal(expanded.block_idx_per_voxel, torch.tensor([0, 4]).repeat_interleave(8))
+
+
+def test_invalid_subvoxel_factor_raises() -> None:
+    with pytest.raises(ValueError, match="subvoxel_factor"):
+        BlockSparseTSDFIntegrator._validate_subvoxel_factor(0)
+
+
+def test_colors_uint8_prefers_texture_only_when_requested_and_valid() -> None:
+    rgbw = torch.tensor(
+        [
+            [1.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0, 1.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    voxels = OccupiedVoxels(
+        centers=torch.zeros((3, 3), dtype=torch.float32),
+        block_idx_per_voxel=torch.tensor([0, 1, 2], dtype=torch.int32),
+        block_data=_FakeBlockData(rgbw),
+        texture_colors=torch.tensor(
+            [[0, 255, 0], [255, 255, 0], [255, 0, 255]],
+            dtype=torch.uint8,
+        ),
+        texture_valid=torch.tensor([True, False, False]),
+    )
+
+    torch.testing.assert_close(
+        voxels.colors_uint8(),
+        torch.tensor([[0, 255, 0], [0, 0, 255], [128, 128, 128]], dtype=torch.uint8),
+    )
+    torch.testing.assert_close(
+        voxels.colors_uint8(prefer_texture=False),
+        torch.tensor([[255, 0, 0], [0, 0, 255], [128, 128, 128]], dtype=torch.uint8),
+    )
+
+
+def test_occupied_voxel_texture_uses_visibility_and_falls_back_to_persistent_color() -> None:
+    projector = _make_texture_projector()
+    rgbw = torch.tensor(
+        [
+            [1.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0, 1.0],
+        ],
+        dtype=torch.float32,
+    )
+    voxels = OccupiedVoxels(
+        centers=torch.tensor([[0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], dtype=torch.float32),
+        block_idx_per_voxel=torch.tensor([0, 1], dtype=torch.int32),
+        block_data=_FakeBlockData(rgbw),
+    )
+    rgb = torch.zeros((1, 3, 3, 3), dtype=torch.uint8)
+    rgb[0, 1, 1] = torch.tensor([0, 255, 0], dtype=torch.uint8)
+    depth = torch.ones((1, 3, 3), dtype=torch.float32)
+    observation = CameraObservation(
+        rgb_image=rgb,
+        depth_image=depth,
+        pose=_make_pose(),
+        intrinsics=_make_intrinsics().unsqueeze(0),
+    )
+
+    textured = projector.texture_occupied_voxels(
+        voxels,
+        [observation],
+        camera_min_distance=None,
+        camera_max_distance=None,
+        texture_depth_tolerance_m=None,
+    )
+
+    assert textured.texture_valid is not None
+    assert textured.texture_valid.tolist() == [True, False]
+    torch.testing.assert_close(
+        textured.colors_uint8(),
+        torch.tensor([[0, 255, 0], [0, 0, 255]], dtype=torch.uint8),
+    )
+    torch.testing.assert_close(
+        textured.colors_uint8(prefer_texture=False),
+        torch.tensor([[255, 0, 0], [0, 0, 255]], dtype=torch.uint8),
+    )
+
+
+def test_mapper_delegates_rgbd_voxel_texture_without_rendering() -> None:
+    mapper, fake_integrator, render_calls = _make_mapper()
+    rgb = torch.zeros((3, 3, 3), dtype=torch.uint8)
+    depth = torch.ones((3, 3), dtype=torch.float32)
+    observation = CameraObservation(
+        rgb_image=rgb,
+        depth_image=depth,
+        pose=_make_pose(),
+        intrinsics=_make_intrinsics(),
+    )
+
+    mapper.extract_occupied_voxels(texture_observations=observation)
+
+    assert render_calls == []
+    assert fake_integrator.calls[0]["texture_observations"] is observation
+
+
+def test_mapper_delegates_rgb_only_voxel_texture_without_rendering() -> None:
+    mapper, fake_integrator, render_calls = _make_mapper(texture_num_cameras=2)
+    observation = CameraObservation(
+        rgb_image=torch.zeros((3, 3, 3), dtype=torch.uint8),
+        pose=_make_pose(),
+        intrinsics=_make_intrinsics(),
+    )
+
+    mapper.extract_occupied_voxels(texture_observations=observation)
+
+    assert render_calls == []
+    assert fake_integrator.calls[0]["texture_observations"] is observation
+    assert observation.depth_image is None

--- a/curobo/tests/_src/perception/mapper/test_renderer.py
+++ b/curobo/tests/_src/perception/mapper/test_renderer.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Focused tests for block-sparse TSDF renderer batching."""
+
+import pytest
+import torch
+
+from curobo._src.perception.mapper.integrator_tsdf import (
+    BlockSparseTSDFIntegrator,
+    BlockSparseTSDFIntegratorCfg,
+)
+from curobo._src.perception.mapper.kernel.builder.builder_block_sparse_kernel import (
+    make_block_sparse_kernels,
+)
+from curobo._src.perception.mapper.renderer import (
+    BlockSparseTSDFRenderer,
+    BlockSparseTSDFRendererCfg,
+)
+from curobo._src.types.pose import Pose
+from curobo._src.util.warp import init_warp
+from curobo.tests._src.perception.mapper.conftest import make_observation
+
+
+def _make_pose(num_cameras: int = 1, device: str = "cpu") -> Pose:
+    position = torch.zeros((num_cameras, 3), dtype=torch.float32, device=device)
+    quaternion = torch.zeros((num_cameras, 4), dtype=torch.float32, device=device)
+    quaternion[:, 0] = 1.0
+    rotation = torch.eye(3, dtype=torch.float32, device=device).repeat(num_cameras, 1, 1)
+    return Pose(position=position, quaternion=quaternion, rotation=rotation)
+
+
+def _make_intrinsics(device: str = "cpu") -> torch.Tensor:
+    return torch.tensor(
+        [[40.0, 0.0, 4.0], [0.0, 40.0, 3.0], [0.0, 0.0, 1.0]],
+        dtype=torch.float32,
+        device=device,
+    )
+
+
+class _ShapeRenderer(BlockSparseTSDFRenderer):
+    """Renderer test double that reuses normalization and helper methods."""
+
+    def __init__(self, device: str = "cpu") -> None:
+        self.device = device
+        self.config = BlockSparseTSDFRendererCfg()
+
+    def render(
+        self,
+        intrinsics: torch.Tensor,
+        pose: Pose,
+        image_shape: tuple[int, int],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        render_inputs = self._normalize_render_inputs(intrinsics, pose)
+        image_height, image_width = image_shape
+        if render_inputs.single_camera:
+            depth = torch.ones((image_height, image_width), dtype=torch.float32)
+            normals = torch.zeros((image_height, image_width, 3), dtype=torch.float32)
+            valid = torch.ones((image_height, image_width), dtype=torch.bool)
+        else:
+            depth = torch.ones(
+                (render_inputs.camera_count, image_height, image_width), dtype=torch.float32
+            )
+            normals = torch.zeros(
+                (render_inputs.camera_count, image_height, image_width, 3),
+                dtype=torch.float32,
+            )
+            valid = torch.ones(
+                (render_inputs.camera_count, image_height, image_width), dtype=torch.bool
+            )
+        normals[..., 2] = 1.0
+        return depth, normals, valid
+
+    def render_color(
+        self,
+        intrinsics: torch.Tensor,
+        pose: Pose,
+        image_shape: tuple[int, int],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        depth, normals, valid = self.render(intrinsics, pose, image_shape)
+        color = torch.full((*normals.shape[:-1], 3), 127, dtype=torch.uint8)
+        return depth, normals, color, valid
+
+
+class TestRendererInputNormalization:
+    """Renderer inputs must be exact-batched without singleton broadcasting."""
+
+    def test_accepts_unbatched_single_camera(self) -> None:
+        renderer = _ShapeRenderer()
+        render_inputs = renderer._normalize_render_inputs(_make_intrinsics(), _make_pose())
+
+        assert render_inputs.camera_count == 1
+        assert render_inputs.single_camera
+        assert render_inputs.intrinsics.shape == (1, 3, 3)
+        assert render_inputs.positions.shape == (1, 3)
+        assert render_inputs.quaternions.shape == (1, 4)
+
+    def test_accepts_exact_batched_intrinsics_and_pose(self) -> None:
+        renderer = _ShapeRenderer()
+        intrinsics = torch.stack((_make_intrinsics(), _make_intrinsics()))
+        render_inputs = renderer._normalize_render_inputs(intrinsics, _make_pose(2))
+
+        assert render_inputs.camera_count == 2
+        assert not render_inputs.single_camera
+        assert render_inputs.intrinsics.shape == (2, 3, 3)
+
+    def test_accepts_exact_batched_vector_intrinsics(self) -> None:
+        renderer = _ShapeRenderer()
+        intrinsics = torch.tensor(
+            [[40.0, 40.0, 4.0, 3.0], [35.0, 35.0, 4.0, 3.0]],
+            dtype=torch.float32,
+        )
+        render_inputs = renderer._normalize_render_inputs(intrinsics, _make_pose(2))
+
+        assert render_inputs.camera_count == 2
+        assert render_inputs.intrinsics.shape == (2, 3, 3)
+        torch.testing.assert_close(render_inputs.intrinsics[:, 2, 2], torch.ones(2))
+
+    def test_rejects_batched_intrinsics_with_singleton_pose(self) -> None:
+        renderer = _ShapeRenderer()
+        intrinsics = torch.stack((_make_intrinsics(), _make_intrinsics()))
+
+        with pytest.raises(ValueError, match="same camera count"):
+            renderer._normalize_render_inputs(intrinsics, _make_pose())
+
+    def test_rejects_unbatched_intrinsics_with_batched_pose(self) -> None:
+        renderer = _ShapeRenderer()
+
+        with pytest.raises(ValueError, match="same camera count"):
+            renderer._normalize_render_inputs(_make_intrinsics(), _make_pose(2))
+
+
+class TestRendererHelperShapes:
+    """Convenience helpers should preserve the render shape convention."""
+
+    def test_unbatched_single_camera_helper_shapes(self) -> None:
+        renderer = _ShapeRenderer()
+        intrinsics = _make_intrinsics()
+        pose = _make_pose()
+        image_shape = (3, 4)
+
+        assert renderer.render_depth(intrinsics, pose, image_shape).shape == (3, 4)
+        assert renderer.render_normals(intrinsics, pose, image_shape).shape == (3, 4, 3)
+        assert renderer.render_color_only(intrinsics, pose, image_shape).shape == (3, 4, 3)
+        assert renderer.render_shaded(intrinsics, pose, image_shape).shape == (3, 4, 3)
+        assert renderer.render_depth_colormap(intrinsics, pose, image_shape).shape == (3, 4, 3)
+        assert renderer.render_normal_colormap(intrinsics, pose, image_shape).shape == (
+            3,
+            4,
+            3,
+        )
+
+    def test_batched_helper_shapes(self) -> None:
+        renderer = _ShapeRenderer()
+        intrinsics = torch.stack((_make_intrinsics(), _make_intrinsics()))
+        pose = _make_pose(2)
+        image_shape = (3, 4)
+
+        assert renderer.render_depth(intrinsics, pose, image_shape).shape == (2, 3, 4)
+        assert renderer.render_normals(intrinsics, pose, image_shape).shape == (2, 3, 4, 3)
+        assert renderer.render_color_only(intrinsics, pose, image_shape).shape == (
+            2,
+            3,
+            4,
+            3,
+        )
+        assert renderer.render_shaded(intrinsics, pose, image_shape).shape == (2, 3, 4, 3)
+        assert renderer.render_depth_colormap(intrinsics, pose, image_shape).shape == (
+            2,
+            3,
+            4,
+            3,
+        )
+        assert renderer.render_normal_colormap(intrinsics, pose, image_shape).shape == (
+            2,
+            3,
+            4,
+            3,
+        )
+
+    def test_explicit_batched_singleton_intrinsics_keep_leading_dimension(self) -> None:
+        renderer = _ShapeRenderer()
+        intrinsics = _make_intrinsics().unsqueeze(0)
+        pose = _make_pose()
+
+        assert renderer.render_depth(intrinsics, pose, (3, 4)).shape == (1, 3, 4)
+
+
+def test_depth_only_buffer_allocation_does_not_create_color_buffer() -> None:
+    renderer = BlockSparseTSDFRenderer.__new__(BlockSparseTSDFRenderer)
+    renderer.device = "cpu"
+    renderer._buffer_size = 0
+    renderer._hit_points = None
+    renderer._hit_normals = None
+    renderer._hit_colors = None
+    renderer._hit_depths = None
+    renderer._hit_mask = None
+
+    renderer._ensure_buffers(12)
+    assert renderer._hit_colors is None
+
+    renderer._ensure_buffers(12, include_color=True)
+    assert renderer._hit_colors is not None
+    assert renderer._hit_colors.shape == (12, 3)
+
+
+def test_kernel_bundle_has_no_accelerated_raycast_exports() -> None:
+    init_warp()
+    kernels = make_block_sparse_kernels(block_size=8)
+
+    assert hasattr(kernels, "raycast_block_sparse_kernel")
+    assert hasattr(kernels, "raycast_block_sparse_color_kernel")
+    assert not hasattr(kernels, "raycast_block_sparse_accelerated_kernel")
+    assert not hasattr(kernels, "raycast_block_sparse_accelerated_color_kernel")
+    assert "accelerated" not in kernels.raycast_block_sparse_kernel.key
+    assert "accelerated" not in kernels.raycast_block_sparse_color_kernel.key
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for renderer kernels")
+def test_batched_render_matches_stacked_single_camera_renders() -> None:
+    init_warp()
+    device = "cuda:0"
+    image_shape = (8, 8)
+    intrinsics = _make_intrinsics(device)
+    pose = _make_pose(device=device)
+
+    integrator = BlockSparseTSDFIntegrator(
+        BlockSparseTSDFIntegratorCfg(
+            max_blocks=512,
+            voxel_size=0.04,
+            origin=torch.tensor([-0.8, -0.8, 0.0], dtype=torch.float32),
+            grid_shape=(64, 64, 64),
+            truncation_distance=0.12,
+            device=device,
+            image_height=image_shape[0],
+            image_width=image_shape[1],
+        )
+    )
+    depth = torch.full(image_shape, 0.8, dtype=torch.float32, device=device)
+    rgb = torch.full((*image_shape, 3), 128, dtype=torch.uint8, device=device)
+    integrator.integrate(
+        make_observation(
+            depth,
+            rgb,
+            pose.position[0],
+            pose.quaternion[0],
+            intrinsics,
+        )
+    )
+
+    renderer = BlockSparseTSDFRenderer(integrator)
+    batched_intrinsics = torch.stack((intrinsics, intrinsics))
+    batched_pose = _make_pose(2, device=device)
+
+    depth_b, normals_b, valid_b = renderer.render(
+        batched_intrinsics, batched_pose, image_shape
+    )
+    depth_s, normals_s, valid_s = renderer.render(intrinsics, pose, image_shape)
+    color_depth_b, color_normals_b, colors_b, color_valid_b = renderer.render_color(
+        batched_intrinsics, batched_pose, image_shape
+    )
+    color_depth_s, color_normals_s, colors_s, color_valid_s = renderer.render_color(
+        intrinsics, pose, image_shape
+    )
+
+    assert depth_b.shape == (2, *image_shape)
+    assert normals_b.shape == (2, *image_shape, 3)
+    assert valid_b.shape == (2, *image_shape)
+    torch.testing.assert_close(depth_b, torch.stack((depth_s, depth_s)))
+    torch.testing.assert_close(normals_b, torch.stack((normals_s, normals_s)))
+    torch.testing.assert_close(valid_b, torch.stack((valid_s, valid_s)))
+    torch.testing.assert_close(color_depth_b, torch.stack((color_depth_s, color_depth_s)))
+    torch.testing.assert_close(color_normals_b, torch.stack((color_normals_s, color_normals_s)))
+    torch.testing.assert_close(colors_b, torch.stack((colors_s, colors_s)))
+    torch.testing.assert_close(color_valid_b, torch.stack((color_valid_s, color_valid_s)))

--- a/curobo/tests/_src/perception/mapper/test_texture_visibility.py
+++ b/curobo/tests/_src/perception/mapper/test_texture_visibility.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Focused tests for texture visibility preparation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from curobo._src.perception.mapper.mapper import Mapper
+from curobo._src.perception.mapper.projector_texture import (
+    ProjectiveTextureProjector,
+    ProjectiveTextureProjectorCfg,
+    _texture_depth_visible,
+)
+from curobo._src.types.camera import CameraObservation
+from curobo._src.types.pose import Pose
+
+
+class _FakeTextureIntegrator:
+    """Capture texture mesh extraction calls from :class:`Mapper`."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def extract_textured_mesh(self, **kwargs: Any) -> "_FakeTextureIntegrator":
+        self.calls.append(kwargs)
+        return self
+
+
+class _FakeTextureRenderer:
+    """Capture visibility-depth renders from the TSDF integrator."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def render_depth(
+        self,
+        intrinsics: torch.Tensor,
+        pose: Pose,
+        image_shape: tuple[int, int],
+    ) -> torch.Tensor:
+        self.calls.append(
+            {
+                "intrinsics": intrinsics,
+                "pose": pose,
+                "image_shape": image_shape,
+            }
+        )
+        return torch.full(
+            (intrinsics.shape[0], *image_shape),
+            1.25,
+            dtype=torch.float32,
+            device=intrinsics.device,
+        )
+
+
+def _make_pose(num_cameras: int = 1) -> Pose:
+    position = torch.zeros((num_cameras, 3), dtype=torch.float32)
+    quaternion = torch.zeros((num_cameras, 4), dtype=torch.float32)
+    quaternion[:, 0] = 1.0
+    return Pose(position=position, quaternion=quaternion)
+
+
+def _make_intrinsics(num_cameras: int = 1) -> torch.Tensor:
+    intrinsics = torch.eye(3, dtype=torch.float32).repeat(num_cameras, 1, 1)
+    intrinsics[:, 0, 0] = 40.0
+    intrinsics[:, 1, 1] = 40.0
+    intrinsics[:, 0, 2] = 2.0
+    intrinsics[:, 1, 2] = 1.5
+    if num_cameras == 1:
+        return intrinsics[0]
+    return intrinsics
+
+
+def _make_mapper(
+    *,
+    texture_num_cameras: int = 1,
+    image_shape: tuple[int, int] = (3, 4),
+) -> tuple[Mapper, _FakeTextureIntegrator, list[dict[str, Any]]]:
+    mapper = Mapper.__new__(Mapper)
+    fake_integrator = _FakeTextureIntegrator()
+    render_calls: list[dict[str, Any]] = []
+    mapper.config = SimpleNamespace(
+        texture_num_cameras=texture_num_cameras,
+        texture_camera_image_height=image_shape[0],
+        texture_camera_image_width=image_shape[1],
+    )
+    mapper._device = torch.device("cpu")
+    mapper._integrator = fake_integrator
+
+    def render_depth(
+        intrinsics: torch.Tensor,
+        pose: Pose,
+        image_shape_arg: tuple[int, int],
+    ) -> torch.Tensor:
+        render_calls.append(
+            {
+                "intrinsics": intrinsics,
+                "pose": pose,
+                "image_shape": image_shape_arg,
+            }
+        )
+        camera_count = int(intrinsics.shape[0])
+        return torch.full((camera_count, *image_shape_arg), 1.25, dtype=torch.float32)
+
+    mapper.render_depth = render_depth
+    return mapper, fake_integrator, render_calls
+
+
+def _make_texture_projector(
+    *,
+    texture_num_cameras: int = 1,
+    image_shape: tuple[int, int] = (3, 4),
+) -> tuple[ProjectiveTextureProjector, _FakeTextureRenderer]:
+    renderer = _FakeTextureRenderer()
+    projector = ProjectiveTextureProjector(
+        tsdf=SimpleNamespace(device="cpu"),
+        renderer=renderer,
+        config=ProjectiveTextureProjectorCfg(
+            texture_num_cameras=texture_num_cameras,
+            image_height=image_shape[0],
+            image_width=image_shape[1],
+            depth_minimum_distance=0.1,
+            depth_maximum_distance=5.0,
+            voxel_size=0.01,
+        ),
+    )
+    return projector, renderer
+
+
+def _make_observation(
+    *,
+    rgb: torch.Tensor,
+    depth: torch.Tensor | None = None,
+    num_cameras: int = 1,
+) -> CameraObservation:
+    return CameraObservation(
+        rgb_image=rgb,
+        depth_image=depth,
+        pose=_make_pose(num_cameras),
+        intrinsics=_make_intrinsics(num_cameras),
+    )
+
+
+def test_mapper_delegates_rgbd_texture_without_rendering() -> None:
+    mapper, fake_integrator, render_calls = _make_mapper()
+    rgb = torch.zeros((3, 4, 3), dtype=torch.uint8)
+    depth = torch.full((3, 4), 1.5, dtype=torch.float32)
+    observation = _make_observation(rgb=rgb, depth=depth)
+
+    result = mapper.extract_textured_mesh(
+        observation,
+        refine_iterations=2,
+        surface_only=False,
+        camera_min_distance=0.2,
+        camera_max_distance=3.0,
+        texture_depth_tolerance_m=0.03,
+    )
+
+    assert result is fake_integrator
+    assert render_calls == []
+    assert len(fake_integrator.calls) == 1
+    call = fake_integrator.calls[0]
+    assert call["refine_iterations"] == 2
+    assert not call["surface_only"]
+    assert call["camera_min_distance"] == 0.2
+    assert call["camera_max_distance"] == 3.0
+    assert call["texture_depth_tolerance_m"] == 0.03
+    assert call["texture_observations"] is observation
+
+
+def test_mapper_delegates_rgb_only_texture_without_rendering() -> None:
+    mapper, fake_integrator, render_calls = _make_mapper(image_shape=(5, 6))
+    rgb = torch.zeros((5, 6, 3), dtype=torch.uint8)
+    observation = _make_observation(rgb=rgb)
+
+    mapper.extract_textured_mesh(observation)
+
+    assert render_calls == []
+    assert fake_integrator.calls[0]["texture_observations"] is observation
+    assert observation.depth_image is None
+
+
+def test_projector_renders_missing_depth_for_batched_texture() -> None:
+    projector, renderer = _make_texture_projector(
+        texture_num_cameras=2,
+        image_shape=(5, 6),
+    )
+    rgb = torch.zeros((2, 5, 6, 3), dtype=torch.uint8)
+    observation = _make_observation(rgb=rgb, num_cameras=2)
+
+    batches = projector._normalize_projective_texture_observations(observation)
+
+    assert len(renderer.calls) == 1
+    assert renderer.calls[0]["intrinsics"].shape == (2, 3, 3)
+    assert renderer.calls[0]["pose"].position.shape == (2, 3)
+    assert renderer.calls[0]["image_shape"] == (5, 6)
+    assert len(batches) == 1
+    torch.testing.assert_close(
+        batches[0][1],
+        torch.full((2, 5, 6), 1.25, dtype=torch.float32),
+    )
+
+
+def test_projector_renders_one_batch_for_unbatched_texture_group() -> None:
+    projector, renderer = _make_texture_projector(
+        texture_num_cameras=2,
+        image_shape=(5, 6),
+    )
+    observations = [
+        _make_observation(rgb=torch.zeros((5, 6, 3), dtype=torch.uint8)),
+        _make_observation(rgb=torch.zeros((5, 6, 3), dtype=torch.uint8)),
+    ]
+
+    batches = projector._normalize_projective_texture_observations(observations)
+
+    assert len(renderer.calls) == 1
+    assert renderer.calls[0]["intrinsics"].shape == (2, 3, 3)
+    assert len(batches) == 1
+    assert batches[0][1].shape == (2, 5, 6)
+
+
+def test_projector_preserves_provided_depth_in_partially_missing_batch() -> None:
+    projector, renderer = _make_texture_projector(texture_num_cameras=2)
+    provided_depth = torch.full((3, 4), 2.0, dtype=torch.float32)
+    observations = [
+        _make_observation(
+            rgb=torch.zeros((3, 4, 3), dtype=torch.uint8),
+            depth=provided_depth,
+        ),
+        _make_observation(rgb=torch.zeros((3, 4, 3), dtype=torch.uint8)),
+    ]
+
+    batches = projector._normalize_projective_texture_observations(observations)
+
+    assert len(renderer.calls) == 1
+    torch.testing.assert_close(batches[0][1][0], provided_depth)
+    torch.testing.assert_close(
+        batches[0][1][1],
+        torch.full((3, 4), 1.25, dtype=torch.float32),
+    )
+
+
+@pytest.mark.parametrize(
+    "depth",
+    [
+        torch.ones((3, 4, 1), dtype=torch.float32),
+        torch.ones((3, 4), dtype=torch.int32),
+    ],
+)
+def test_invalid_texture_depth_shape_or_dtype_raises(depth: torch.Tensor) -> None:
+    projector, _renderer = _make_texture_projector()
+    rgb = torch.zeros((3, 4, 3), dtype=torch.uint8)
+    observation = _make_observation(rgb=rgb, depth=depth)
+
+    with pytest.raises(ValueError, match="depth_image"):
+        projector._normalize_projective_texture_observations(observation)
+
+
+def test_incomplete_unbatched_texture_camera_group_raises() -> None:
+    projector, _renderer = _make_texture_projector(texture_num_cameras=2)
+    rgb = torch.zeros((3, 4, 3), dtype=torch.uint8)
+    depth = torch.ones((3, 4), dtype=torch.float32)
+    observation = _make_observation(rgb=rgb, depth=depth)
+
+    with pytest.raises(ValueError, match="complete camera batches"):
+        projector._normalize_projective_texture_observations(observation)
+
+
+def test_texture_visibility_depth_policy_rejects_occluded_and_invalid_depth() -> None:
+    projected_z = torch.tensor([1.0, 1.0, 1.0, 2.0, 1.0], dtype=torch.float32)
+    visibility_depth = torch.tensor([1.015, 1.03, 0.0, 2.03, float("nan")])
+
+    default_visible = _texture_depth_visible(
+        projected_z,
+        visibility_depth,
+        voxel_size=0.01,
+        texture_depth_tolerance_m=None,
+    )
+    explicit_visible = _texture_depth_visible(
+        projected_z,
+        visibility_depth,
+        voxel_size=0.01,
+        texture_depth_tolerance_m=0.05,
+    )
+
+    assert default_visible.tolist() == [True, False, False, False, False]
+    assert explicit_visible.tolist() == [True, True, False, True, False]


### PR DESCRIPTION
- Move feature and color from block level to patch level in tsdf grid. Each block can now store up to block size resolution of color and features. Makes it computationally faster compared to setting block_size=1 to get per voxel color/feature.
- Simplify mesh extraction, extraction is 10x faster from tsdf. Add projective texturing from color images when available.
- Fix bug in lidar tsdf example, fisheye projection is now done correctly to get points from unregistered pointcloud
- Minor: optimization kernels take int32 instead of int16