### PR TITLE
Preserve feasible queries in mixed-validity PRM batches

### DIFF
--- a/curobo/_src/graph_planner/graph_planner_prm.py
+++ b/curobo/_src/graph_planner/graph_planner_prm.py
@@ -334,12 +334,34 @@ class PRMGraphPlanner:
         b, _, _ = node_set.shape
         node_set = node_set.view(b * 2, self.action_dim)
         # check if start and goal are in freespace:
-        mask = self.check_samples_feasibility(node_set)
-        if mask.all() != True:
+        endpoint_feasible = self.check_samples_feasibility(node_set).reshape(num_problems, 2)
+        problem_feasible = endpoint_feasible.all(dim=1)
+        if not problem_feasible.any():
             log_warn("Start or End state in collision")
             result.plan_waypoints = [None for _ in range(num_problems)]
             result.valid_query = False
             result.debug_info = "Start or End state in collision"
+            return result
+        if not problem_feasible.all():
+            invalid_indices = torch.where(~problem_feasible)[0].cpu().tolist()
+            log_warn(f"Start or End state in collision for batch indices {invalid_indices}")
+
+            feasible_indices = torch.where(problem_feasible)[0]
+            feasible_result = self._find_path_impl(
+                x_start[feasible_indices], x_goal[feasible_indices]
+            )
+
+            result.success[feasible_indices] = feasible_result.success
+            result.path_length[feasible_indices] = feasible_result.path_length
+            feasible_indices_list = feasible_indices.cpu().tolist()
+            for feasible_result_idx, original_idx in enumerate(feasible_indices_list):
+                result.plan_waypoints[original_idx] = feasible_result.plan_waypoints[
+                    feasible_result_idx
+                ]
+            result.valid_query = False
+            result.debug_info = (
+                f"Start or End state in collision for batch indices {invalid_indices}"
+            )
             return result
 
         # if start and goal are same, return True:

--- a/curobo/tests/_src/graph_planner/test_graph_planner_batch_seed.py
+++ b/curobo/tests/_src/graph_planner/test_graph_planner_batch_seed.py
@@ -100,6 +100,28 @@ class TestGraphPlannerBatchSeedShape:
         assert result.interpolated_waypoints is None
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_infeasible_query_does_not_reject_feasible_batch_query(self, planner):
+        """An infeasible endpoint only rejects its own batch query."""
+        horizon = 16
+        feasible_state = planner.sampling_strategy.generate_feasible_action_samples(1)
+        x_start = feasible_state.repeat(2, 1)
+        x_goal = torch.cat((feasible_state, torch.full_like(feasible_state, 999.0)))
+
+        result = planner.find_path(
+            x_start,
+            x_goal,
+            interpolate_waypoints=True,
+            interpolation_steps=horizon,
+            interpolation_type=TrajInterpolationType.LINEAR,
+            validate_interpolated_trajectory=False,
+        )
+
+        assert result.success.tolist() == [True, False]
+        assert result.interpolated_waypoints.shape == (2, horizon, planner.action_dim)
+        assert not (result.interpolated_waypoints[0] == 0).all()
+        assert (result.interpolated_waypoints[1] == 0).all()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
     def test_successful_queries_have_full_shape(self, planner):
         """When some queries succeed, waypoints shape is (N, H, D), not filtered."""
         N = 4


### PR DESCRIPTION
## Summary

- evaluate PRM endpoint feasibility per start/goal pair instead of collapsing it across the entire batch
- continue planning feasible queries while leaving only invalid batch entries unsuccessful
- preserve original batch positions and interpolated output shape when results are scattered back
- add regression coverage for a batch containing one feasible and one infeasible query

## Problem

`PRMGraphPlanner._find_path_impl` flattened all start and goal endpoints and then reduced feasibility with `mask.all()`. As a result, a collision in any single endpoint caused an early return for the whole batch. Valid queries in the same batch were incorrectly reported as failures and never reached graph planning.

## Fix

Endpoint feasibility is reshaped into `(num_problems, 2)` and reduced per start/goal pair. If a batch contains both valid and invalid queries, the planner:

1. selects the feasible query indices,
2. plans only that subset, and
3. scatters success, path length, and waypoints back to their original batch positions.

Invalid entries remain unsuccessful and retain their placeholder trajectories, so downstream tensors keep the expected batch shape. Debug information now identifies the invalid batch indices.

## Scope

This PR is intentionally limited to mixed-validity PRM batches. The separate failed-IK-seed indexing issue is already covered by #713.

## Testing

- `conda run -n isaac6 python -m pytest -o addopts= curobo/tests/_src/graph_planner/test_graph_planner_batch_seed.py -q`
- 6 passed
